### PR TITLE
Temporarily removes tween.js

### DIFF
--- a/afs/media/js/views/components/cards/file-renderers/textreader.js
+++ b/afs/media/js/views/components/cards/file-renderers/textreader.js
@@ -74,7 +74,6 @@ define(['jquery',
             };
 
             if (this.displayContent) {
-                console.log('subscribing')
                 this.url = this.displayContent.url;
                 this.type = this.displayContent.type;
                 var self = this;

--- a/afs/settings.py
+++ b/afs/settings.py
@@ -169,13 +169,13 @@ RENDERERS = [
     },
     {"name": "pdbreader", "component": "views/components/cards/file-renderers/pdbreader", "ext": "pdb", "type": "", "hastab": True,},
     {"name": "pcdreader", "component": "views/components/cards/file-renderers/pcdreader", "ext": "pcd", "type": "", "hastab": True,},
-    {
-        "name": "colladareader",
-        "component": "views/components/cards/file-renderers/colladareader",
-        "ext": "dae",
-        "type": "",
-        "hastab": True,
-    },
+    # {
+    #     "name": "colladareader",
+    #     "component": "views/components/cards/file-renderers/colladareader",
+    #     "ext": "dae",
+    #     "type": "",
+    #     "hastab": True,
+    # },
 ]
 
 

--- a/afs/templates/javascript.htm
+++ b/afs/templates/javascript.htm
@@ -10,7 +10,6 @@
     'TrackballControls': '{{ STATIC_URL }}packages/three/examples/js/controls/TrackballControls',
     'PDBLoader': '{{ STATIC_URL }}packages/three/examples/js/loaders/PDBLoader',
     'PCDLoader': '{{ STATIC_URL }}packages/three/examples/js/loaders/PCDLoader',
-    'TWEEN': '{{ STATIC_URL }}packages/@tweenjs/tween.js/src/Tween',
     'ColladaLoader': '{{ STATIC_URL }}packages/three/examples/js/loaders/ColladaLoader',
     'Plotly': '{{ STATIC_URL }}packages/plotly.js-dist/plotly'
 {% endblock paths %}


### PR DESCRIPTION
Removes tween until collada reader is working properly. re #6