### PR TITLE
check for which tab is active to show colorpicker, re #43

### DIFF
--- a/afs/templates/views/components/cards/file-renderers/afs-reader.htm
+++ b/afs/templates/views/components/cards/file-renderers/afs-reader.htm
@@ -117,7 +117,7 @@
     </div>
     <!--/ko-->
     <div>
-        <!-- ko if: seriesData().length >= 1 && selectedSeriesTile -->
+        <!-- ko if: seriesData().length >= 1 && selectedSeriesTile && fileViewer.activeTab() === 'other-tab' -->
         <div class="chart-style-panel">
             <h2>{% trans "Style" %}</h2>
             <div class="row widget-container">


### PR DESCRIPTION
hides color picker if any tab other than 'other-tab'