### PR TITLE
Updates renderer configs to exclude psd and tif 

### DIFF
--- a/afs/settings.py
+++ b/afs/settings.py
@@ -162,6 +162,7 @@ RENDERERS = [
         "component": "views/components/cards/file-renderers/imagereader",
         "ext": "",
         "type": "image/*",
+        "exclude": "tif,tiff,psd"
     },
     {
         "name": "xrf-reader",
@@ -172,6 +173,7 @@ RENDERERS = [
         "component": "views/components/cards/file-renderers/xrf-reader",
         "ext": "txt",
         "type": "text/plain",
+        "exclude": "",
     },
     {
         "name": "raman-reader",
@@ -181,7 +183,8 @@ RENDERERS = [
         "iconclass": "fa fa-bolt",
         "component": "views/components/cards/file-renderers/raman-reader",
         "ext": "txt",
-        "type": "text/plain",
+        "type": "text/plain",   
+        "exclude": "",
     },
     {
         "name": "pdbreader",
@@ -192,6 +195,7 @@ RENDERERS = [
         "component": "views/components/cards/file-renderers/pdbreader",
         "ext": "pdb",
         "type": "",
+        "exclude": "",
     },
     {
         "name": "pcdreader",
@@ -202,6 +206,7 @@ RENDERERS = [
         "component": "views/components/cards/file-renderers/pcdreader",
         "ext": "pcd",
         "type": "",
+        "exclude": "",
     },
     # {
     #     "name": "colladareader",
@@ -210,6 +215,7 @@ RENDERERS = [
     #     "component": "views/components/cards/file-renderers/colladareader",
     #     "ext": "dae",
     #     "type": "",
+    #    "exclude": [],
     # },
 ]
 


### PR DESCRIPTION
Update renderer configs to exclude file types that have an image mime type but are not browser supported. re #88