### PR TITLE
Manifest manager plugin visible on package load

### DIFF
--- a/afs/pkg/preliminary_sql/configure_manifest_manager.sql
+++ b/afs/pkg/preliminary_sql/configure_manifest_manager.sql
@@ -1,0 +1,1 @@
+UPDATE plugins SET config = '{"show": true}' WHERE pluginid = '6f707d86-d49c-4ece-9883-8cbb2ecda1b5';


### PR DESCRIPTION
Makes manifest manager plugin visible on package load, re archesproject/arches#6979