### PR TITLE
Exit the iiif function for unsupported files, #310

### DIFF
--- a/afs/functions/file_to_iiif.py
+++ b/afs/functions/file_to_iiif.py
@@ -94,6 +94,8 @@ class FileToIIIF(BaseFunction):
                 )
             else:
                 logger.warn("filetype unacceptable: " + f.path.name)
+                return
+
         pres_dict = {
             "@context": "http://iiif.io/api/presentation/2/context.json",
             "@type": "sc:Manifest",


### PR DESCRIPTION
Stop and exit the function when the file formats are unsupported. #310 
To avoid the function failing when it expects the image in the iiif server. 