### PR TITLE
Fixes manifest creation when running AfS from Docker

### DIFF
--- a/afs/settings.py
+++ b/afs/settings.py
@@ -36,7 +36,7 @@ SECRET_KEY = "(hdj_k6s^6*+ve_y9i(&$jo4cj4&jb=ryedo$2jh56bi82ye%*"
 DEBUG = True
 
 ROOT_URLCONF = "afs.urls"
-
+FILE_UPLOAD_PERMISSIONS = 0o644
 # a prefix to append to all elasticsearch indexes, note: must be lower case
 ELASTICSEARCH_PREFIX = "afs"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       volumes:
         - ../arches/:/web_root/arches
         - ./:/web_root/afs
-        - cantaloupe-data:/web_root/afs/afs/cantaloupe
+        - cantaloupe-data:/web_root/afs/afs/uploadedfiles
       env_file:
         - ./docker/env_file.env
       ports:


### PR DESCRIPTION
Fixes path to image directory and allows files larger than 3MB to be uploaded. re #393 