### PR TITLE
workflow transaction rollback POC

### DIFF
--- a/afs/media/js/views/components/workflows/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-image-step.js
@@ -151,6 +151,7 @@ define([
                                 var digitalReferenceTypeNodeId = 'f11e4d60-8d59-11eb-a9c4-faffc265b501'; // Digital Reference Type (E55) (physical thing)
                                 digitalReferenceTile.data[digitalReferenceTypeNodeId] = '1497d15a-1c3b-4ee9-a259-846bbab012ed'; // Preferred Manifest concept value
 
+                                digitalReferenceTile.transactionId = params.form.workflowId;
                                 digitalReferenceTile.save().then(function(data) {
                                     params.form.complete(true);
                                     params.form.saving(false);

--- a/afs/media/js/views/components/workflows/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-image-step.js
@@ -124,32 +124,33 @@ define([
             params.form.saving(true);
 
             if (self.manifestData() && self.manifestData()['label'] === self.selectedPhysicalThingImageServiceName()) {
+                self.digitalResourceNameTile.transactionId = params.form.workflowId;
                 self.digitalResourceNameTile.save().then(function(data) {
                     self.digitalResourceStatementTile.resourceinstance_id = data.resourceinstance_id;
-    
+                    self.digitalResourceStatementTile.transactionId = params.form.workflowId;
                     self.digitalResourceStatementTile.save().then(function(data) {
                         self.digitalResourceServiceTile.resourceinstance_id = data.resourceinstance_id;
-    
+                        self.digitalResourceServiceTile.transactionId = params.form.workflowId;
                         self.digitalResourceServiceTile.save().then(function(data) {
                             self.digitalResourceServiceIdentifierTile.resourceinstance_id = data.resourceinstance_id;
                             self.digitalResourceServiceIdentifierTile.parenttile_id = data.tileid;
-    
+                            self.digitalResourceServiceIdentifierTile.transactionId = params.form.workflowId;
                             self.digitalResourceServiceIdentifierTile.save().then(function(data) {
                                 params.form.savedData.push(data);
-    
+
                                 var digitalReferenceTile = self.physicalThingDigitalReferenceTile();
-    
+
                                 var digitalSourceNodeId = 'a298ee52-8d59-11eb-a9c4-faffc265b501'; // Digital Source (E73) (physical thing)
-    
+
                                 digitalReferenceTile.data[digitalSourceNodeId] = [{
                                     "resourceId": data.resourceinstance_id,
                                     "ontologyProperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
                                     "inverseOntologyProperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to"
                                 }];
-                                
+
                                 var digitalReferenceTypeNodeId = 'f11e4d60-8d59-11eb-a9c4-faffc265b501'; // Digital Reference Type (E55) (physical thing)
                                 digitalReferenceTile.data[digitalReferenceTypeNodeId] = '1497d15a-1c3b-4ee9-a259-846bbab012ed'; // Preferred Manifest concept value
-                    
+
                                 digitalReferenceTile.save().then(function(data) {
                                     params.form.complete(true);
                                     params.form.saving(false);


### PR DESCRIPTION
adds proof of concept code for adding the workflow ID as a transaction ID for new tiles created in the analysis areas image step.

Related to/Requires Arches Core [#7599](https://github.com/archesproject/arches/pull/7599)

resolves #419 