### PR TITLE
Lock first two steps of upload dataset workflow

### DIFF
--- a/afs/media/js/views/components/plugins/upload-dataset-workflow.js
+++ b/afs/media/js/views/components/plugins/upload-dataset-workflow.js
@@ -58,6 +58,7 @@ define([
                         text: 'Select the instrument, add any special parameters/configuration for the instrument, and upload the dataset files',
                     },
                     required: true,
+                    lockableExternalSteps: ['project-info'],
                     externalstepdata: {
                         projectinfo: 'project-info',
                     },
@@ -86,6 +87,7 @@ define([
                     required: true,
                     workflowstepclass: 'upload-dataset-step-workflow-component-based-step',
                     autoAdvance: false,
+                    lockableExternalSteps: ['select-instrument-and-files'],
                     externalstepdata: {
                         projectinfo: 'project-info',
                         observationinfo: 'select-instrument-and-files',

--- a/afs/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
@@ -43,6 +43,7 @@ define([
         this.nameValue = ko.observable(getProp('name', 'value'));
         this.observationInstanceId = ko.observable(getProp('observationInstanceId'));
         this.showName = ko.observable(false);
+        this.locked = params.form.locked;
 
         this.createRelatedInstance = function(val){
             return [{
@@ -118,6 +119,7 @@ define([
         params.form.save = function() {
             let observedThingData = {};
             observedThingData[observedThingNodeId] = self.createRelatedInstance(observedThingInstanceId);
+            params.form.lockExternalStep("project-info", true);
             return self.saveTile(observedThingData, observedThingNodeId, self.observationInstanceId(), observedThingTileid)
                 .then(function(data) {
                     let partOfProjectData = {};

--- a/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
@@ -238,6 +238,7 @@ define([
 
             this.save = function() {
                 if (self.requiredInputsComplete()) {
+                    params.form.lockExternalStep("select-instrument-and-files", true);
                     self.parts().forEach(function(part){
                         // For each part of parent phys thing, create a digital resource with a Name tile
                         self.saveDatasetName(part)

--- a/afs/templates/views/components/workflows/upload-dataset/instrument-info-step.htm
+++ b/afs/templates/views/components/workflows/upload-dataset/instrument-info-step.htm
@@ -10,6 +10,7 @@
                 ],
                 renderContext: 'workflow', 
                 value: instrumentValue,
+                disabled: locked
             }
         }"></div>
     </div>
@@ -23,6 +24,7 @@
                 ],
                 renderContext: 'workflow', 
                 value: procedureValue,
+                disabled: locked
             }
         }"></div>
     </div>
@@ -33,6 +35,7 @@
             params: {
                 renderContext: 'workflow', 
                 value: parameterValue,
+                disabled: locked
             }
         }"></div>
     </div>
@@ -45,6 +48,7 @@
                 params: {
                     renderContext: 'workflow', 
                     value: nameValue,
+                    disabled: locked
                 }
             }"></div>
         </div>


### PR DESCRIPTION
Lock the each of the first two steps after their subsequent steps are saved. Depends on #409, re #423