### PR TITLE
locks the object and image step in analysis area workflows

### DIFF
--- a/afs/media/js/views/components/plugins/analysis-areas-workflow.js
+++ b/afs/media/js/views/components/plugins/analysis-areas-workflow.js
@@ -13,6 +13,7 @@ define([
             var self = this;
 
             this.resourceId = ko.observable();
+            
 
             params.steps = [
                 {
@@ -42,7 +43,7 @@ define([
                                         graphids: [
                                             '9519cb4f-b25b-11e9-8c7b-a4d18cec433a',  /* physical thing */
                                         ],
-                                        renderContext: 'workflow',
+                                        renderContext: 'workflow'
                                     },
                                 },
                             ], 
@@ -62,6 +63,7 @@ define([
                     component: 'views/components/workflows/component-based-step',
                     componentname: 'component-based-step',
                     required: true,
+                    lockableExternalSteps: ['object-step'],
                     externalstepdata: {
                         objectstep: 'object-step'
                     },
@@ -87,6 +89,7 @@ define([
                     component: 'views/components/workflows/component-based-step',
                     componentname: 'component-based-step',
                     required: true,
+                    lockableExternalSteps: ['image-step'],
                     externalstepdata: {
                         objectstep: 'object-step',
                         imagestep: 'image-step'

--- a/afs/media/js/views/components/workflows/analysis-areas-annotation-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-annotation-step.js
@@ -291,6 +291,7 @@ define([
         this.saveWorkflowStep = function() {
             params.form.complete(false);
             params.form.saving(true);
+            params.form.lockExternalStep('image-step', true);
             let mappedInstances = self.analysisAreaInstances().map((instance) => { return { "data": instance.data }});
             params.form.savedData(mappedInstances);
             params.form.complete(true);

--- a/afs/media/js/views/components/workflows/analysis-areas-annotation-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-annotation-step.js
@@ -166,6 +166,7 @@ define([
         };
 
         this.saveAnalysisAreaTile = function() {
+            params.form.lockExternalStep('image-step', true);
             var savePhysicalThingNameTile = function(physicalThingNameTile) {
                 return new Promise(function(resolve, _reject) {
                     var partIdentifierAssignmentLabelNodeId = '3e541cc6-859b-11ea-97eb-acde48001122';
@@ -291,7 +292,6 @@ define([
         this.saveWorkflowStep = function() {
             params.form.complete(false);
             params.form.saving(true);
-            params.form.lockExternalStep('image-step', true);
             let mappedInstances = self.analysisAreaInstances().map((instance) => { return { "data": instance.data }});
             params.form.savedData(mappedInstances);
             params.form.complete(true);

--- a/afs/media/js/views/components/workflows/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-image-step.js
@@ -42,7 +42,7 @@ define([
             return topCard.nodegroupid === digitalResourceNameNodegroupId;
         });
         this.digitalResourceNameTile = digitalResourceNameCard.getNewTile();
-
+        this.locked = params.form.locked;
         
         var digitalResourceStatementNodegroupId = 'da1fac57-ca7a-11e9-86a3-a4d18cec433a';
         var digitalResourceStatementCard = params.form.topCards.find(function(topCard) {
@@ -123,6 +123,7 @@ define([
             params.form.complete(false);
             params.form.saving(true);
 
+            params.form.lockExternalStep("object-step", true);
             if (self.manifestData() && self.manifestData()['label'] === self.selectedPhysicalThingImageServiceName()) {
                 self.digitalResourceNameTile.save().then(function(data) {
                     self.digitalResourceStatementTile.resourceinstance_id = data.resourceinstance_id;
@@ -174,7 +175,6 @@ define([
     
                     params.form.savedData.push(matchingTile);
                 }
-
                 params.form.complete(true);
                 params.form.saving(false);        
             }

--- a/afs/templates/views/components/workflows/analysis-areas-image-step.htm
+++ b/afs/templates/views/components/workflows/analysis-areas-image-step.htm
@@ -23,7 +23,6 @@
                     disable: $parent.locked
                 }"
             />
-            <span data-bind="text: console.log($parent.locked())"></span>
             <label 
                 style="cursor: pointer;"
                 data-bind="
@@ -37,7 +36,7 @@
 
 <button
     class="btn btn-success"
-    data-bind="click: openManifestManager"
+    data-bind="click: openManifestManager, disable: $parent.locked"
 >
     <i class="ion-android-cloud-done"></i>
     <span>

--- a/afs/templates/views/components/workflows/analysis-areas-image-step.htm
+++ b/afs/templates/views/components/workflows/analysis-areas-image-step.htm
@@ -20,8 +20,10 @@
                 data-bind="{
                     value: $data.displayname,
                     checked: $parent.selectedPhysicalThingImageServiceName,
+                    disable: $parent.locked
                 }"
             />
+            <span data-bind="text: console.log($parent.locked())"></span>
             <label 
                 style="cursor: pointer;"
                 data-bind="


### PR DESCRIPTION
locks the object and image step in the analysis area workflow.  Needs PR [7620](https://github.com/archesproject/arches/issues/7620) for core.  Also needs a fix for dirty tiles to validate image step locking, pending discussion.  

closes #432 

