### PR TITLE
Fixes a regression with the analysis area annotation step

### DIFF
--- a/afs/media/js/views/components/workflows/analysis-areas-annotation-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-annotation-step.js
@@ -281,6 +281,7 @@ define([
                     handleSaveChain(physicalThingNameTile);
                 });
             }
+            params.dirty(true);
         };
 
         this.loadNewAnalysisAreaTile = function() {


### PR DESCRIPTION
There's a regression here; I dropped a line when fixing some auto-formatting code.  This PR adds that line (marking the step dirty) back whenever there's a save action.

fixes #444 