### PR TITLE
removes wastebin configuration for project name step; no longer needed.

### DIFF
--- a/afs/media/js/views/components/plugins/create-project-workflow.js
+++ b/afs/media/js/views/components/plugins/create-project-workflow.js
@@ -38,8 +38,7 @@ define([
                                 },
                             ], 
                         },
-                    ],
-                    wastebin: {resourceid: null, description: 'a project instance'}
+                    ]
                 },
                 {
                     title: 'Project Statement',


### PR DESCRIPTION
removes wastebin configuration for the project name step; will no longer be needed.  

Do not merge until [7624](https://github.com/archesproject/arches/pull/7624) in core is merged.

PR may be updated as blockers to #448 are resolved.  