### PR TITLE
bugfix for the sample location step

### DIFF
--- a/afs/media/js/views/components/plugins/upload-dataset-workflow.js
+++ b/afs/media/js/views/components/plugins/upload-dataset-workflow.js
@@ -69,7 +69,7 @@ define([
                             componentConfigs: [
                                 { 
                                     componentName: 'instrument-info-step',
-                                    uniqueInstanceName: 'instrument-type', /* unique to step */
+                                    uniqueInstanceName: 'instrument-info', /* unique to step */
                                     parameters: {
                                         renderContext: 'workflow',
                                     },


### PR DESCRIPTION
Changes unique instance name back to instrument-info, where the sample location step is looking.