### PR TITLE
dataset ids should be saved

### DIFF
--- a/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
@@ -32,7 +32,7 @@ define([
             this.partFilter = ko.observable("");
             this.alert = params.alert;
             this.annotations = ko.observableArray([]);
-            this.parts = ko.observableArray(params.value()?.parts || []);
+            this.parts = ko.observableArray([]);
             this.uniqueId = uuid.generate();
             this.formData = new window.FormData();
             this.physicalThing = projectInfo.physicalThing;

--- a/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
@@ -236,15 +236,15 @@ define([
                 );
             };
 
-            this.save = async () => {
+            this.save = async() => {
                 if (!self.requiredInputsComplete()) { return; }
                 params.form.lockExternalStep("select-instrument-and-files", true);
                 const parts = self.parts();
-                const datasets = []
+                const datasets = [];
                 for (const part of parts) {
                     try {
                         // For each part of parent phys thing, create a digital resource with a Name tile
-                        const dataset = await self.saveDatasetName(part)
+                        const dataset = await self.saveDatasetName(part);
                         datasets.push(dataset);
                         // Then save a file tile to the digital resource for each associated file
                         self.saveDatasetFiles(part, dataset);
@@ -256,7 +256,7 @@ define([
                         console.log('Tile update failed', err);
                         params.form.loading(false);
                     }
-                };
+                }
                 self.datasets(datasets);
                 params.value({ datasets: self.datasets() });
                 params.form.savedData(params.form.addedData());


### PR DESCRIPTION
This saves newly generated dataset ids in the select dataset files step.  Also reduces some nesting.

@chiatt even though I validated that this does indeed save the ids, it looks insufficient on its own.  The ids will need to be used in the subsequent step, and it looks like this (dataset files) step doesn't load its state from local storage properly, so clears out every time it's saved.  These seem like separate tickets, though.  