### PR TITLE
Adds transaction IDs to steps in sample taking workflow

### DIFF
--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
@@ -124,16 +124,21 @@ define([
             params.form.saving(true);
 
             if (self.manifestData() && self.manifestData()['label'] === self.selectedPhysicalThingImageServiceName()) {
+                self.digitalResourceNameTile.transactionId = params.form.workflowId;
+
                 self.digitalResourceNameTile.save().then(function(data) {
                     self.digitalResourceStatementTile.resourceinstance_id = data.resourceinstance_id;
-    
+                    self.digitalResourceStatementTile.transactionId = params.form.workflowId;
+
                     self.digitalResourceStatementTile.save().then(function(data) {
                         self.digitalResourceServiceTile.resourceinstance_id = data.resourceinstance_id;
-    
+                        self.digitalResourceServiceTile.transactionId = params.form.workflowId;
+
                         self.digitalResourceServiceTile.save().then(function(data) {
                             self.digitalResourceServiceIdentifierTile.resourceinstance_id = data.resourceinstance_id;
                             self.digitalResourceServiceIdentifierTile.parenttile_id = data.tileid;
-    
+                            self.digitalResourceServiceIdentifierTile.transactionId = params.form.workflowId;
+
                             self.digitalResourceServiceIdentifierTile.save().then(function(data) {
                                 params.form.savedData.push(data);
     
@@ -149,7 +154,8 @@ define([
                                 
                                 var digitalReferenceTypeNodeId = 'f11e4d60-8d59-11eb-a9c4-faffc265b501'; // Digital Reference Type (E55) (physical thing)
                                 digitalReferenceTile.data[digitalReferenceTypeNodeId] = '1497d15a-1c3b-4ee9-a259-846bbab012ed'; // Preferred Manifest concept value
-                    
+                                digitalReferenceTile.transactionId = params.form.workflowId;
+
                                 digitalReferenceTile.save().then(function(data) {
                                     params.form.complete(true);
                                     params.form.saving(false);

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -266,7 +266,8 @@ define([
                     
                     var physicalThingNameContentNodeId = 'b9c1d8a6-b497-11e9-876b-a4d18cec433a'; // Name_content (xsd:string)
                     physicalThingNameTile.data[physicalThingNameContentNodeId] = selectedSampleLocationInstanceLabel;
-    
+                    physicalThingNameTile.transactionId = params.form.workflowId;
+
                     physicalThingNameTile.save().then(function(physicalThingNameData) {
                         resolve(physicalThingNameData);
                     });
@@ -282,6 +283,7 @@ define([
                         "ontologyProperty": "",
                         "inverseOntologyProperty": ""
                     }];
+                    physicalThingPartOfTile.transactionId = params.form.workflowId;
 
                     physicalThingPartOfTile.save().then(function(physicalThingPartOfData) {
                         resolve(physicalThingPartOfData);
@@ -305,6 +307,7 @@ define([
                         "ontologyProperty": "",
                         "inverseOntologyProperty": ""
                     }]);
+                    selectedSampleLocationInstance.transactionId = params.form.workflowId
     
                     selectedSampleLocationInstance.save().then(function(data) {
                         resolve(data);
@@ -361,6 +364,7 @@ define([
             var saveSamplingActivitySamplingUnitTile = function(samplingActivitySamplingUnitTile, regionPhysicalThingNameData, samplePhysicalThingNameData) {
                 return new Promise(function(resolve, _reject) {
                     var samplingAreaNodeId = 'b3e171ac-1d9d-11eb-a29f-024e0d439fdb';  // Sampling Area (E22)
+                    
                     samplingActivitySamplingUnitTile.data[samplingAreaNodeId] = [{
                         "resourceId": regionPhysicalThingNameData.resourceinstance_id,
                         "ontologyProperty": "",
@@ -387,6 +391,7 @@ define([
                     samplingActivitySamplingUnitTile.data[samplingAreaVisualizationNodeId] = ko.toJS(
                         self.physicalThingPartIdentifierAssignmentTile().data[partIdentifierAssignmentPolygonIdentifierNodeId]
                     );
+                    samplingActivitySamplingUnitTile.transactionId = params.form.workflowId;
 
                     samplingActivitySamplingUnitTile.save().then(function(data) {
                         resolve(data);
@@ -480,7 +485,8 @@ define([
                         }
     
                         physicalThingStatementTile.data[physicalThingStatementTypeNodeId] = physicalThingStatementTypeData;
-    
+                        physicalThingStatementTile.transactionId = params.form.workflowId;
+
                         physicalThingStatementTile.save().then(function(data) {
                             resolve(data);
                         });
@@ -514,7 +520,8 @@ define([
                         physicalThingStatementTile.data[physicalThingStatementTypeNodeId] = physicalThingStatementTypeData.filter(function(data) {
                             return data !== fooNodeId;
                         });
-    
+                        physicalThingStatementTile.transactionId = params.form.workflowId;
+
                         physicalThingStatementTile.save().then(function(data) {
                             resolve(data);
                         });

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sampling-info-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sampling-info-step.js
@@ -111,6 +111,7 @@ define([
                     'data': data,
                     'resourceinstanceid': resourceinstanceid,
                     'tileid': tileid,
+                    'transaction_id': params.form.workflowId
                 }
             });
         };
@@ -118,6 +119,7 @@ define([
         this.saveTile = function(tileid, tile){
             let formData = new window.FormData();
             formData.append('data', JSON.stringify(tile));
+            formData.append('transaction_id', params.form.workflowId);
             return $.ajax({
                 url: arches.urls.api_tiles(tileid),
                 type: 'POST',
@@ -181,7 +183,8 @@ define([
                     "033578ae-1d9d-11eb-a29f-024e0d439fdb": null,  //label
                     "033578af-1d9d-11eb-a29f-024e0d439fdb": null,  //type
                     "033578c2-1d9d-11eb-a29f-024e0d439fdb": self.samplingDate()  //end of the end
-                }
+                },
+                'transaction_id': params.form.workflowId
             };
             var samplingDateTileid = ko.unwrap(self.samplingDateTile) || uuid.generate();
             return self.saveTile(samplingDateTileid, samplingDateTileData);
@@ -201,7 +204,8 @@ define([
                     '033578b6-1d9d-11eb-a29f-024e0d439fdb': null,
                     '033578b7-1d9d-11eb-a29f-024e0d439fdb': ['df8e4cf6-9b0b-472f-8986-83d5b2ca28a0','72202a9f-1551-4cbc-9c7a-73c02321f3ea'],
                     '033578c1-1d9d-11eb-a29f-024e0d439fdb': self.samplingTechnique()
-                }        
+                },
+                'transaction_id': params.form.workflowId        
             };
             var samplingTechniqueTileid = ko.unwrap(self.samplingTechniqueTile) || uuid.generate();
             return self.saveTile(samplingTechniqueTileid, samplingTechniqueTileData);


### PR DESCRIPTION
Adds transaction IDs to steps in sample taking workflow

Depends on PR [#7664](https://github.com/archesproject/arches/pull/7664) for core, as the nodevalue endpoint currently doesn't accept transaction IDs and is used in the second (sample info) step.

resolves #486 