### PR TITLE
If physical thing validation is turned off, don't check for a manifest

### DIFF
--- a/afs/media/js/views/components/workflows/select-phys-thing-step.js
+++ b/afs/media/js/views/components/workflows/select-phys-thing-step.js
@@ -105,7 +105,7 @@ define([
                 x.nodegroup_id == self.partNodeGroupId &&
                 x.data?.[self.partManifestNodeId]?.features?.[0]?.properties?.manifest)
 
-            if(digitalReferencesWithManifest.length && partsWithManifests.length) {
+            if(!self.validateThing || (digitalReferencesWithManifest.length && partsWithManifests.length)) {
                 params.value({
                     physThingName: physThing.displayname,
                     physicalThing: val,


### PR DESCRIPTION
Avoids manifest check if physical thing validation is turned off. 
resolves #500 