### PR TITLE
edit link visibility fix

### DIFF
--- a/afs/templates/views/components/search/search-results.htm
+++ b/afs/templates/views/components/search/search-results.htm
@@ -24,7 +24,7 @@
             <a class="search-candidate-link" href="" data-bind="click: showDetails"><i class="fa fa-info-circle"></i> {% trans "Details" %} </a>
             <!-- /ko -->
 
-            {% if user_can_edit %}
+            {% if user|can_edit_resource_instance %}
             <!--ko if: canEdit -->
             <a class="search-candidate-link" href="" data-bind="click: $parent.editResource.bind($parent)"><i class="ion-ios-refresh-empty"></i> {% trans "Edit" %} </a>
             <!--/ko-->


### PR DESCRIPTION
uses a filter on the user object to toggle the visibility of the edit link depending on permissions
fixes #495 