### PR TITLE
Fix the create project's final step, #563

### DIFF
--- a/afs/media/js/views/components/plugins/create-project-workflow.js
+++ b/afs/media/js/views/components/plugins/create-project-workflow.js
@@ -22,6 +22,7 @@ define([
                     component: 'views/components/workflows/component-based-step',
                     componentname: 'component-based-step',
                     required: true,
+                    shouldtrackresource: true,
                     layoutSections: [
                         {
                             componentConfigs: [

--- a/afs/media/js/views/components/plugins/create-project-workflow.js
+++ b/afs/media/js/views/components/plugins/create-project-workflow.js
@@ -156,7 +156,8 @@ define([
                     description: 'Summary',
                     component: 'views/components/workflows/component-based-step',
                     componentname: 'component-based-step',
-                    externalstepdata: { 
+                    externalstepdata: {
+                        projectnamestep: 'set-project-name',
                         addphysthingstep: 'object-search-step',
                     },
                     layoutSections: [

--- a/afs/media/js/views/components/workflows/create-project-workflow/create-project-final-step.js
+++ b/afs/media/js/views/components/workflows/create-project-workflow/create-project-final-step.js
@@ -5,6 +5,7 @@ define([
 
     function viewModel(params) {
         var self = this;
+        params.form.resourceId(params.form.externalStepData.projectnamestep.data["project-name"][0]["resourceInstanceId"]);
         SummaryStep.apply(this, [params]);
 
         this.resourceLoading = ko.observable(true);


### PR DESCRIPTION
Fix the issue of missing resourceid in the final step of create-project workflow, #563 
By adding `externalStepData` and reintroducing the `shouldtrackresource`.