### PR TITLE
Add loading spinner while manifest is loading, #585

### DIFF
--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
@@ -268,7 +268,7 @@ define([
 
             const hasDataset = tiles.some(function(tile) {
                 var digitalReferenceTypeValue = ko.unwrap(tile.data[digitalReferenceTypeNodeId]);
-                return (digitalReferenceTypeValue === ( preferredManifestConceptValueId || alternateManifestConceptValueId ))
+                return (digitalReferenceTypeValue === ( preferredManifestConceptValueId || alternateManifestConceptValueId ));
             });
 
             if (!hasDataset){

--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
@@ -10,6 +10,8 @@ define([
 ], function(_, $, arches, ko, koMapping, GraphModel, CardViewModel) {
     function viewModel(params) {
         var self = this;
+        params.pageVm.loading(true);
+
         this.isManifestManagerHidden = ko.observable(true);
         this.shouldShowEditService = ko.observable(false);
 
@@ -264,12 +266,21 @@ define([
             
             var tiles = card.tiles() || [];
 
+            const hasDataset = tiles.some(function(tile) {
+                var digitalReferenceTypeValue = ko.unwrap(tile.data[digitalReferenceTypeNodeId]);
+                return (digitalReferenceTypeValue === ( preferredManifestConceptValueId || alternateManifestConceptValueId ))
+            });
+
+            if (!hasDataset){
+                params.pageVm.loading(false);
+            }
+
             tiles.forEach(function(tile) {
                 var digitalReferenceTypeValue = ko.unwrap(tile.data[digitalReferenceTypeNodeId]);
 
                 if (digitalReferenceTypeValue === ( preferredManifestConceptValueId || alternateManifestConceptValueId ))  {
                     var physicalThingManifestResourceId = tile.data[digitalSourceNodeId]()[0].resourceId();
-                    params.pageVm.loading(true);
+
                     $.getJSON( arches.urls.api_card + physicalThingManifestResourceId )
                         .then(function(data) {
                             if (digitalReferenceTypeValue === preferredManifestConceptValueId) {

--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
@@ -266,12 +266,12 @@ define([
             
             var tiles = card.tiles() || [];
 
-            const hasDataset = tiles.some(function(tile) {
+            const hasManifest = tiles.some(function(tile) {
                 var digitalReferenceTypeValue = ko.unwrap(tile.data[digitalReferenceTypeNodeId]);
                 return (digitalReferenceTypeValue === ( preferredManifestConceptValueId || alternateManifestConceptValueId ));
             });
 
-            if (!hasDataset){
+            if (!hasManifest){
                 params.pageVm.loading(false);
             }
 

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
@@ -270,12 +270,12 @@ define([
             
             var tiles = card.tiles() || [];
 
-            const hasDataset = tiles.some(function(tile) {
+            const hasManifest = tiles.some(function(tile) {
                 var digitalReferenceTypeValue = ko.unwrap(tile.data[digitalReferenceTypeNodeId]);
                 return (digitalReferenceTypeValue === ( preferredManifestConceptValueId || alternateManifestConceptValueId ));
             });
 
-            if (!hasDataset){
+            if (!hasManifest){
                 params.pageVm.loading(false);
             }
 

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
@@ -272,7 +272,7 @@ define([
 
             const hasDataset = tiles.some(function(tile) {
                 var digitalReferenceTypeValue = ko.unwrap(tile.data[digitalReferenceTypeNodeId]);
-                return (digitalReferenceTypeValue === ( preferredManifestConceptValueId || alternateManifestConceptValueId ))
+                return (digitalReferenceTypeValue === ( preferredManifestConceptValueId || alternateManifestConceptValueId ));
             });
 
             if (!hasDataset){


### PR DESCRIPTION
Add loading spinner to image-step in the sample taking and analysis area workflows, #585 
Improved to start the spinner while page is loading before create button is clickable (vs. after finish loading the page)