### PR TITLE
Reset descriptions when canceled, #623

### DIFF
--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -350,9 +350,19 @@ define([
             }
         };
 
+        this.resetDescriptions = function(){
+            const previouslySavedSampleDescriptionWidgetValue = ko.unwrap(self.previouslySavedSampleDescriptionWidgetValue);
+            const previouslySavedMotivationForSamplingWidgetValue = ko.unwrap(self.previouslySavedMotivationForSamplingWidgetValue);
+            
+            self.sampleDescriptionWidgetValue(previouslySavedSampleDescriptionWidgetValue);
+            self.motivationForSamplingWidgetValue(previouslySavedMotivationForSamplingWidgetValue);
+
+        }
+
         this.resetSampleLocationTile = function() {
             self.tile.reset();
             self.resetCanvasFeatures();
+            self.resetDescriptions();
             self.drawFeatures([]);
             self.highlightAnnotation();
             self.selectedFeature(null);


### PR DESCRIPTION
The values of sampling descriptions and motivations will be reset, when the cancel button is clicked, #623 