### PR TITLE
Allow modal content in RDM to appear above background

### DIFF
--- a/afs/media/css/project.css
+++ b/afs/media/css/project.css
@@ -8,7 +8,7 @@
     position:relative;
 }
 
-#content-container {
+#content-container .workbench-card-wrapper {
     z-index: 0;
 }
 


### PR DESCRIPTION
Allow modal content in RDM to appear above background without reversing fix for #611, re #652