### PR TITLE
Update the value with the savedData in analysis area annotation step, #681

### DIFF
--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -473,6 +473,7 @@ define([
 
                                             let mappedInstances = self.analysisAreaInstances().map((instance) => { return { "data": instance.data }});
                                             params.form.savedData(koMapping.toJS(mappedInstances));
+                                            params.form.value(params.form.savedData());
                                             params.form.complete(true);
                                         });
                                     });


### PR DESCRIPTION
Fix the issue of the step's hanging, when _`saved and completed workflow`_ at the analysis area annotation step, #681 
by updating the self.value with savedData.