### PR TITLE
Support multi-canvas editing in sample taking workflow

### DIFF
--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -730,15 +730,6 @@ define([
                 }
             }]);
 
-            this.map.subscribe(function(map){
-                map.on('click', function(e){
-                    const clickedFeatureLayer = $(e.originalEvent.path[0]).hasClass('leaflet-interactive')
-                    if (!clickedFeatureLayer) {
-                        self.resetAnalysisAreasTile()
-                    }
-                })
-            });
-
             /* overwrites iiif-annotation methods */ 
             self.updateTiles = function() {
                 _.each(self.featureLookup, function(value) {

--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -699,8 +699,8 @@ define([
                                         feature.properties.graphName = "Physical Thing";
                                         if (self.sampleLocationTileIds.includes(feature.properties.tileId)) {
                                             feature.properties.type = 'sample_location';
-                                            feature.properties.color = '#AC53F5';
-                                            feature.properties.fillColor = '#AC53F5';
+                                            feature.properties.color = '#999999';
+                                            feature.properties.fillColor = '#999999';
                                             sampleAnnotations.push(feature);
                                         } else {
                                             feature.properties.type = 'analysis_area';

--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -677,6 +677,14 @@ define([
                     })
                 },
                 buildAnnotationNodes: function(json) {
+                    const editNodeActiveState = ko.observable(true);
+                    const nonEditNodeActiveState = ko.observable(true);
+                    editNodeActiveState.subscribe(function(active){
+                        if (!active) {
+                            self.resetAnalysisAreasTile();
+                            updateAnnotations();
+                        }
+                    });
                     var updateAnnotations = function() {
                         let sampleAnnotations = ko.observableArray();
                         let analysisAreaAnnotations = ko.observableArray();
@@ -699,12 +707,6 @@ define([
                                             analysisAreaAnnotations.push(feature);
                                         }
                                     });
-                                    const editNodeActiveState = ko.observable(true);
-                                    editNodeActiveState.subscribe(function(active){
-                                        if (!active) {
-                                            self.resetAnalysisAreasTile();
-                                        }
-                                    });
                                     self.annotationNodes([
                                         {
                                             name: "Analysis Areas",
@@ -716,7 +718,7 @@ define([
                                         {
                                             name: "Sample Locations",
                                             icon: "fa fa-eyedropper",
-                                            active: ko.observable(false),
+                                            active: nonEditNodeActiveState,
                                             opacity: ko.observable(100),
                                             annotations: sampleAnnotations
                                         }

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -55,8 +55,6 @@ define([
             self.highlightAnnotation();
 
             if (selectedSampleLocationInstance) {
-                /* TODO: switchCanvas logic */ 
-                
                 self.tile = selectedSampleLocationInstance;
                 params.tile = selectedSampleLocationInstance;
                 self.physicalThingPartIdentifierAssignmentTile(selectedSampleLocationInstance);

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -1046,8 +1046,8 @@ define([
                                         feature.properties.graphName = "Physical Thing";
                                         if (self.analysisAreaTileIds.includes(feature.properties.tileId)) {
                                             feature.properties.type = 'analysis_area';
-                                            feature.properties.color = '#AC53F5';
-                                            feature.properties.fillColor = '#AC53F5';
+                                            feature.properties.color = '#999999';
+                                            feature.properties.fillColor = '#999999';
                                             analysisAreaAnnotations.push(feature);
                                         } else {
                                             feature.properties.type = 'sample_location';

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -1080,15 +1080,6 @@ define([
                 }
             }]);
 
-            this.map.subscribe(function(map){
-                map.on('click', function(e){
-                    const clickedFeatureLayer = $(e.originalEvent.path[0]).hasClass('leaflet-interactive')
-                    if (!clickedFeatureLayer) {
-                        self.resetSampleLocationTile()
-                    }
-                })
-            });
-
             /* overwrites iiif-annotation method */ 
             self.updateTiles = function() {
                 _.each(self.featureLookup, function(value) {


### PR DESCRIPTION
Allow user to switch between canvases to edit sample locations in each. Also sets all overlays to visible by default in sample taking and analysis areas workflows and makes the color of the layer which the user is not editing to be consistent with the color for that layer in the final step.