### PR TITLE
Set tab container x-axis scroll to auto for windows, re #785

### DIFF
--- a/afs/media/css/report_templates.css
+++ b/afs/media/css/report_templates.css
@@ -74,7 +74,7 @@
 }
 
 .afs-report-anchor-container {
-    overflow-x: scroll;
+    overflow-x: auto;
     white-space: nowrap;
     position: fixed;
     width: 100%;
@@ -93,9 +93,8 @@
     background: #fcfcfc;
     border-bottom: 1px solid #ddd;
     width: 100%;
-    overflow-x: scroll;
+    overflow-x: auto;
     position: relative;
-    padding-right: 550px;
 }
 
 .afs-report-a {
@@ -146,7 +145,7 @@ li, .afs-report-a.active:hover {
 }
 
 .afs-tab-container {
-    overflow-x: scroll;
+    overflow-x: auto;
     min-height: 45px;
 }
 


### PR DESCRIPTION
Removes unnecessary horizontal scrollbars beneath report tabs when viewed on Windows Chrome