### PR TITLE
Allow for a single feature to be added with iiif annotations

### DIFF
--- a/afs/pkg/post_sql/update_iiif_widget_configuration.sql
+++ b/afs/pkg/post_sql/update_iiif_widget_configuration.sql
@@ -1,0 +1,2 @@
+update cards_x_nodes_x_widgets set config = jsonb_set(defaultconfig, '{multiFeature}', 'false') where widgetid = 'aae743b8-4c48-11ea-988b-2bc775672c81';
+update widgets set defaultconfig = jsonb_set(defaultconfig, '{multiFeature}', 'false') where widgetid = 'aae743b8-4c48-11ea-988b-2bc775672c81';

--- a/afs/pkg/post_sql/update_iiif_widget_configuration.sql
+++ b/afs/pkg/post_sql/update_iiif_widget_configuration.sql
@@ -1,2 +1,2 @@
-update cards_x_nodes_x_widgets set config = jsonb_set(defaultconfig, '{multiFeature}', 'false') where widgetid = 'aae743b8-4c48-11ea-988b-2bc775672c81';
+update cards_x_nodes_x_widgets set config = jsonb_set(config, '{multiFeature}', 'false') where widgetid = 'aae743b8-4c48-11ea-988b-2bc775672c81';
 update widgets set defaultconfig = jsonb_set(defaultconfig, '{multiFeature}', 'false') where widgetid = 'aae743b8-4c48-11ea-988b-2bc775672c81';

--- a/afs/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.htm
+++ b/afs/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.htm
@@ -200,10 +200,15 @@
                                         </div>
                                     </div>
                                     <div class="map-card-feature-list">
+                                        <span data-bind="text: console.log(widget)"></span>
                                         <div 
                                             class="add-new-feature" 
                                             data-bind="{
-                                                visible: !self.disableDrawing(),
+                                                visible: !self.disableDrawing() && 
+                                                    (widget.config.multiFeature() || 
+                                                    (!widget.config.multiFeature() && 
+                                                        (self.selectedAnalysisAreaInstanceFeatures() === undefined || 
+                                                        self.selectedAnalysisAreaInstanceFeatures().length < 1))),
                                                 click: self.clearEditedGeometries,
                                             }"
                                         >

--- a/afs/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.htm
+++ b/afs/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.htm
@@ -200,7 +200,6 @@
                                         </div>
                                     </div>
                                     <div class="map-card-feature-list">
-                                        <span data-bind="text: console.log(widget)"></span>
                                         <div 
                                             class="add-new-feature" 
                                             data-bind="{

--- a/afs/templates/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.htm
+++ b/afs/templates/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.htm
@@ -201,7 +201,11 @@
                                     <div 
                                         class="add-new-feature" 
                                         data-bind="
-                                            visible: !self.disableDrawing(),
+                                            visible: !self.disableDrawing() && 
+                                                    (widget.config.multiFeature() || 
+                                                    (!widget.config.multiFeature() && 
+                                                        (self.selectedSampleLocationInstanceFeatures() === undefined || 
+                                                         self.selectedSampleLocationInstanceFeatures().length < 1))),
                                             click: self.clearEditedGeometries,
                                         "
                                     >


### PR DESCRIPTION
Modifies the analysis-areas-annotation-step component and the sample-taking-sample-location-step component to only allow for a single feature to be added.  Checks widget config in cards_x_nodes_x_widgets.  Updates that table and default widget template table on package load to turn of multi-feature support.  Multifeature is enabled by default.  

There will need to be an additional feature added to core arches to support this in the base component, if desired.