### PR TITLE
Remove default manifest

### DIFF
--- a/afs/pkg/graphs/resource_models/Physical Thing.json
+++ b/afs/pkg/graphs/resource_models/Physical Thing.json
@@ -1535,7 +1535,7 @@
                     "cardid": "fec5c840-8593-11ea-97eb-acde48001122",
                     "component_id": "10ae2f00-cbda-4a0d-8ca2-5af3b46b37ad",
                     "config": {
-                        "defaultManifest": "https://media.getty.edu/iiif/manifest/028b269e-054f-4d39-83b9-6b207707731d"
+                        "defaultManifest": ""
                     },
                     "constraints": [
                         {


### PR DESCRIPTION
Removes the default manifest assigned to the annotation node in the Physical Thing parts branch., re #800 