### PR TITLE
Prevent dataset save for parts with no files or name, re #804

### DIFF
--- a/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
@@ -366,6 +366,7 @@ define([
                 params.form.lockExternalStep("select-instrument-and-files", true);
                 const parts = self.parts();
                 for (const part of parts) {
+                    if (!part.datasetName() && part.datasetFiles().length === 0) { continue; }
                     try {
                         // For each part of parent phys thing, create a digital resource with a Name tile
                         const dataset = (await self.saveDatasetName(part));


### PR DESCRIPTION
In the upload dataset workflow, prevents the creation of a dataset for parts that do not have files or a name. re #804 