### PR TITLE
Remove default manifest from phys thing part and hide visual work widget, #800, #831

### DIFF
--- a/afs/pkg/graphs/resource_models/Physical Thing.json
+++ b/afs/pkg/graphs/resource_models/Physical Thing.json
@@ -2307,7 +2307,7 @@
                     "label": "Object Part - Visual Work Shown",
                     "node_id": "5d440fea-8651-11ea-97eb-acde48001122",
                     "sortorder": 3,
-                    "visible": true,
+                    "visible": false,
                     "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
                 },
                 {

--- a/afs/pkg/graphs/resource_models/Physical Thing.json
+++ b/afs/pkg/graphs/resource_models/Physical Thing.json
@@ -1535,7 +1535,7 @@
                     "cardid": "fec5c840-8593-11ea-97eb-acde48001122",
                     "component_id": "10ae2f00-cbda-4a0d-8ca2-5af3b46b37ad",
                     "config": {
-                        "defaultManifest": "https://media.getty.edu/iiif/manifest/028b269e-054f-4d39-83b9-6b207707731d"
+                        "defaultManifest": ""
                     },
                     "constraints": [
                         {


### PR DESCRIPTION
Removes  the default manifest from physical thing part annotation node and hides the visual work widget, #800, #831