### PR TITLE
crud operations in upload workflow

### DIFF
--- a/afs/media/js/views/components/plugins/upload-dataset-workflow.js
+++ b/afs/media/js/views/components/plugins/upload-dataset-workflow.js
@@ -23,7 +23,6 @@ define([
                 required: true,
                 workflowstepclass: 'upload-dataset-step-workflow-component-based-step',
                 lockableExternalSteps: ['select-instrument-and-files'],
-                hiddenWorkflowButtons: ['undo', 'save'],
                 layoutSections: [
                     {
                         componentConfigs: [
@@ -164,7 +163,6 @@ define([
                     name: 'file-interpretation',
                     workflowstepclass: 'upload-dataset-step-workflow-component-based-step',
                     required: false,
-                    hiddenWorkflowButtons: ['undo', 'save'],
                     informationboxdata: {
                         heading: 'Select the instrument used for the analysis',
                         text: 'Select the instrument, add any special parameters/configuration for the instrument, and upload the dataset files',

--- a/afs/media/js/views/components/workflows/upload-dataset/file-interpretation-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/file-interpretation-step.js
@@ -54,6 +54,11 @@ define([
             }
             return false;
         });
+
+        this.dirty.subscribe((newval) => {
+            params.form.dirty(self.dirty());
+        })
+
         this.save = function(){
             for (var value of Object.values(params.value())) {
                 if(value.fileStatementParameter.dirty()){
@@ -63,9 +68,10 @@ define([
                     value.fileStatementInterpretation.save();
                 }
             }
+            params.form.savedData(params.value());
             params.form.complete(true);
         };
-
+        params.form.save = this.save;
         params.form.reset = function(){
             for (var value of Object.values(params.value())) {
                 value.fileStatementParameter.reset();
@@ -195,7 +201,8 @@ define([
         };
         datasetIds.forEach(function(datasetId){
             self.getDigitalResource(datasetId);
-        })
+        });
+        params.form.savedData(params.form.value());
 
         this.digitalResourceFilter = ko.observable('');
         this.selectedDigitalResource = ko.observable();

--- a/afs/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
@@ -136,7 +136,6 @@ define([
             self.instrumentValue(snapshot.instrumentValue);
             self.procedureValue(snapshot.procedureValue);
             self.parameterValue(snapshot.parameterValue);
-            params.form.hasUnsavedData(false);
         };
 
         self.instrumentValue.subscribe(function(val){

--- a/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
@@ -125,6 +125,7 @@ define([
                     self.selectedPart().datasetFiles.push(file);
                     self.parts.valueHasMutated();
                     self.files.remove(file);
+                    self.updateValue();
                 }
             }
 
@@ -361,6 +362,24 @@ define([
                 self.parts.valueHasMutated();
             }
 
+            this.getStepValue = () => {
+                return { 
+                    observationReferenceTileId: self.observationReferenceTileId(),
+                    parts: self.parts().map(x => 
+                        {
+                            return {
+                                datasetFiles: x.datasetFiles().map(x => { return {...x, tileId: x.tileId()} }),
+                                datasetId: x.datasetId(),
+                                nameTileId: x.nameTileId(),
+                                datasetName: x.datasetName() || '',
+                                resourceReferenceId: x.resourceReferenceId(),
+                                tileid: x.tileid
+                            };
+                        }
+                    )
+                };
+            }
+
             this.save = async() => {
                 
                 params.form.lockExternalStep("select-instrument-and-files", true);
@@ -393,25 +412,20 @@ define([
                     console.log('Couldn\'t create observation cross references.');
                 }
 
-                params.form.savedData({ 
-                    observationReferenceTileId: self.observationReferenceTileId(),
-                    parts: self.parts().map(x => 
-                        {
-                            return {
-                                datasetFiles: x.datasetFiles().map(x => { return {...x, tileId: x.tileId()} }),
-                                datasetId: x.datasetId(),
-                                nameTileId: x.nameTileId(),
-                                datasetName: x.datasetName() || '',
-                                resourceReferenceId: x.resourceReferenceId(),
-                                tileid: x.tileid
-                            };
-                        }
-                    )
-                });
+                params.form.savedData(this.getStepValue());
+                params.form.value(params.form.savedData())
 
                 self.snapshot = params.form.savedData();
+
                 params.form.complete(true);
             };
+
+            params.form.save = self.save;
+            params.form.reset = self.cancel;
+            
+            this.updateValue = () => {
+                params.form.value(self.getStepValue());
+            }
 
             this.dropzoneOptions = {
                 url: "arches.urls.root",
@@ -533,6 +547,7 @@ define([
                             } else {
                                 part.nameDirty(false);
                             }
+                            self.updateValue()
                         });
                     }
                 };


### PR DESCRIPTION
Modifies the upload workflow to delegate save/undo/cancel operations to the workflow buttons (previously hidden).  I did not remove the save/cancel buttons - as I could see a use case where a user might want to save/cancel and not advance the workflow.  But that should be easy enough to do if desired.  This is done for the select files step and the file interpretation step, both of which needed the change.  Also fixes state issues (savedData/value) that were causing this not to work beforehand.