### PR TITLE
A new component -related resources filtered by other node values

### DIFF
--- a/afs/media/js/views/components/plugins/analysis-areas-workflow.js
+++ b/afs/media/js/views/components/plugins/analysis-areas-workflow.js
@@ -89,6 +89,7 @@ define([
                                     parameters: {
                                         graphid: '9519cb4f-b25b-11e9-8c7b-a4d18cec433a',  /* physical thing */
                                         physicalThingResourceId: "['select-project']['select-phys-thing']['physicalThing']",
+                                        projectResourceId: "['select-project']['select-phys-thing']['project']",
                                         imageStepData: "['image-step']['image-service-instance'][0]['data']",
                                         projectSet: "['select-project']['select-phys-thing']['projectSet']"
                                     },

--- a/afs/media/js/views/components/resource-instance-nodevalue.js
+++ b/afs/media/js/views/components/resource-instance-nodevalue.js
@@ -8,8 +8,6 @@ define([
     return ko.components.register('views/components/resource-instance-nodevalue', {
         viewModel: function(params) {
             const self = this;
-            let resourceLookup = {};
-            let graphCache = {};
             let relatedResourceNodeValues;
 
             ResourceInstanceSelectViewModel.apply(this, [params]);

--- a/afs/media/js/views/components/resource-instance-nodevalue.js
+++ b/afs/media/js/views/components/resource-instance-nodevalue.js
@@ -1,0 +1,113 @@
+define([
+    'knockout',
+    'arches',
+    'utils/resource',
+    'viewmodels/resource-instance-select',
+    'bindings/select2-query'
+], function(ko, arches, ResourceUtils, ResourceInstanceSelectViewModel) {
+    return ko.components.register('views/components/resource-instance-nodevalue', {
+        viewModel: function(params) {
+            const self = this;
+            let resourceLookup = {};
+            let graphCache = {};
+            let relatedResourceNodeValues;
+
+            ResourceInstanceSelectViewModel.apply(this, [params]);
+
+            this.relatedResourceId = params.relatedResourceId;
+            this.relatedNodeId = params.relatedNodeId;
+
+            this.lookupResourceInstanceData(self.relatedResourceId).then( data => {
+                relatedResourceNodeValues = ResourceUtils.getNodeValues({
+                    nodeId: self.relatedNodeId,
+                }, data._source.tiles).map(rr => rr.resourceId);
+            });
+
+            this.select2Config = {
+                value: self.renderContext === 'search' ? self.value : self.resourceToAdd,
+                clickBubble: true,
+                disabled: self.disabled,
+                multiple: !self.displayOntologyTable ? self.multiple : false,
+                placeholder: this.placeholder() || arches.translations.riSelectPlaceholder,
+                closeOnSelect: true,
+                allowClear: self.renderContext === 'search' ? true : false,
+                onSelect: function(item) {
+                    self.selectedItem(item);
+                    if (self.renderContext !== 'search') {
+                        var ret = self.makeObject(item.resourceinstanceid, item);
+                        self.setValue(ret);
+                        window.setTimeout(function() {
+                            if(self.displayOntologyTable){
+                                self.resourceToAdd("");
+                            }
+                        }, 250);
+                    }    
+                },
+                ajax: {
+                    url: arches.urls.related_resources + self.relatedResourceId + "?paginate=false",
+                    dataType: 'json',
+                    results: function(data) {
+                        const filteredResources = data.related_resources.filter(resource => relatedResourceNodeValues.includes(resource.resourceinstanceid))
+                        return {
+                            results: filteredResources,
+                        };
+                    }
+                },
+                id: function(item) {
+                    return item.resourceinstanceid;
+                },
+                formatResult: function(item) {
+                    if (item.displayname) {
+                        return item.displayname;
+                    }
+                },
+                formatSelection: function(item) {
+                    if (item.displayname) {
+                        return item.displayname;
+                    }
+                },
+                initSelection: function(ele, callback) {
+                    if(self.renderContext === "search" && self.value() !== "") {
+                        var values = self.value();
+                        if(!Array.isArray(self.value())){
+                            values = [self.value()];
+                        }
+        
+                        var lookups = [];
+        
+                        values.forEach(function(val){
+                            var resourceId;
+                            if (typeof val === 'string') {
+                                resourceId = val;
+                            }
+                            else if (ko.unwrap(val.resourceId)) {
+                                resourceId = ko.unwrap(val.resourceId);
+                            }
+        
+                            var resourceInstance = self.lookupResourceInstanceData(resourceId).then(
+                                function(resourceInstance) { return resourceInstance; }
+                            );
+                
+                            if (resourceInstance) { lookups.push(resourceInstance); }
+                        });
+        
+                        Promise.all(lookups).then(function(arr){
+                            if (arr.length) {
+                                let ret = arr.map(function(item) {
+                                    return {"displayname": item["_source"].displayname, "resourceinstanceid": item["_id"]};
+                                });
+                                if(self.multiple === false) {
+                                    ret = ret[0];
+                                }
+                                callback(ret);
+                            }
+                        });
+                    }
+                }
+            };
+        },
+        template: {
+            require: 'text!widget-templates/resource-instance-select'
+        }
+    });
+});

--- a/afs/media/js/views/components/resource-instance-nodevalue.js
+++ b/afs/media/js/views/components/resource-instance-nodevalue.js
@@ -47,7 +47,7 @@ define([
                     url: arches.urls.related_resources + self.relatedResourceId + "?paginate=false",
                     dataType: 'json',
                     results: function(data) {
-                        const filteredResources = data.related_resources.filter(resource => relatedResourceNodeValues.includes(resource.resourceinstanceid))
+                        const filteredResources = data.related_resources.filter(resource => relatedResourceNodeValues.includes(resource.resourceinstanceid));
                         return {
                             results: filteredResources,
                         };

--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -10,6 +10,7 @@ define([
     'viewmodels/card',
     'views/components/iiif-annotation',
     'text!templates/views/components/iiif-popup.htm',
+    'views/components/resource-instance-nodevalue',
 ], function(_, $, arches, ko, koMapping, StepUtils, ResourceUtils, GraphModel, CardViewModel, IIIFAnnotationViewmodel, iiifPopup) {
     function viewModel(params) {
         var self = this;

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sampling-info-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sampling-info-step.js
@@ -4,6 +4,7 @@ define([
     'arches',
     'knockout',
     'uuid',
+    'views/components/resource-instance-nodevalue',
 ], function(_, $, arches, ko, uuid) {
     function viewModel(params) {
         var self = this;

--- a/afs/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.htm
+++ b/afs/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.htm
@@ -356,7 +356,7 @@
                             <div class="afs-workflow-annotator" style="margin-left: -20px;"
                                 data-bind='
                                     component: {
-                                        name: self.form.widgetLookup[$data.partIdentifierAssignmentAnnotatorWidget().widget_id()].name,
+                                        name: "views/components/resource-instance-nodevalue",
                                         params: {
                                             formData: self.physicalThingPartIdentifierAssignmentTile().formData,
                                             tile: self.physicalThingPartIdentifierAssignmentTile(),
@@ -369,6 +369,8 @@
                                             graph: self.form.graph,
                                             type: "resource-editor",
                                             disabled: !self.card.isWritable && !self.preview,
+                                            relatedResourceId: projectResourceId,
+                                            relatedNodeId: "dbaa2022-9ae7-11ea-ab62-dca90488358a",
                                         }
                                     }, 
                                     css:{

--- a/afs/templates/views/components/workflows/sample-taking-workflow/sampling-info-step.htm
+++ b/afs/templates/views/components/workflows/sample-taking-workflow/sampling-info-step.htm
@@ -3,13 +3,16 @@
     <div style="padding: 5px">
         <div class="widget-input-label">{% trans "Samplers" %}</div>
         <div data-bind="component: {
-            name: 'resource-instance-multiselect-widget',
+            name: 'views/components/resource-instance-nodevalue',
             params: {
                 graphids: [
                     'f71f7b9c-b25b-11e9-901e-a4d18cec433a',
                 ],
                 renderContext: 'workflow', 
+                multiple: true,
                 value: samplers,
+                relatedResourceId: projectValue,
+                relatedNodeId: 'dbaa2022-9ae7-11ea-ab62-dca90488358a'
             }
         }"></div>
     </div>


### PR DESCRIPTION
Add the new component extending resource-instance-widget to only show related node values, #833
In order to show the only project team members in the `person` resource instance nodes.
Sampler in sample taking workflow and annotator in analysis area workflows are also updated.