### PR TITLE
changes for #8177 in arches core - split panel hiding in manifest mgr

### DIFF
--- a/afs/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.htm
+++ b/afs/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.htm
@@ -59,6 +59,7 @@
                 summary: true,
                 shouldShowEditService: $data.shouldShowEditService,
                 manifestData: manifestData,
+                renderContext: 'manifest-workflow'
             }
         }
     "

--- a/afs/templates/views/components/workflows/sample-taking-workflow/sample-taking-image-step.htm
+++ b/afs/templates/views/components/workflows/sample-taking-workflow/sample-taking-image-step.htm
@@ -55,6 +55,7 @@
                 summary: true,
                 shouldShowEditService: $data.shouldShowEditService,
                 manifestData: manifestData,
+                renderContext: 'manifest-workflow'
             }
         }
     "


### PR DESCRIPTION
changes render context whenever manifest manager appears in a workflow to hide the split panel tools.