### PR TITLE
Remove files before save to local storage, #908

### DIFF
--- a/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
@@ -430,10 +430,14 @@ define([
 
                 params.form.savedData({ 
                     observationReferenceTileId: self.observationReferenceTileId(),
-                    parts: self.parts().map(x => 
+                    parts: self.parts().map(x =>
                         {
+                            fileObjects = x.datasetFiles().map(file => { 
+                                delete file.dataURL;
+                                return file;
+                            } );
                             return {
-                                datasetFiles: x.datasetFiles().map(x => { return {...x, tileId: x.tileId()} }),
+                                datasetFiles: fileObjects.map(x => { return {...x, tileId: x.tileId()} }),
                                 datasetId: x.datasetId(),
                                 nameTileId: x.nameTileId(),
                                 datasetName: x.datasetName() || '',


### PR DESCRIPTION
Remove the files from savedData before saving it to the local storage, #908
The upload Dataset workflow- select dataset file step saves the files along with params which creates some storage size issue. So, the files are removed before saving it to local storage.