### PR TITLE
Truncate descriptions in new project workflow

### DIFF
--- a/afs/media/css/project.css
+++ b/afs/media/css/project.css
@@ -178,7 +178,7 @@
 }
 
 
-.wf-multi-tile-card-info-details p {
+.wf-multi-tile-card-info-details {
     max-height: 100px;
     max-width: 150px;
     white-space: nowrap;
@@ -230,7 +230,7 @@
     line-height: 1.4;
 }
 
-.summary-report-description p {
+.summary-report-description {
     max-height: 100px;
     max-width: 800px;
     white-space: nowrap;
@@ -441,7 +441,7 @@
     color: #2b547c;
 }
 
-.final-step .summary-value p {
+.final-step .summary-value {
     max-height: 100px;
     max-width: 800px;
     white-space: nowrap;

--- a/afs/media/css/project.css
+++ b/afs/media/css/project.css
@@ -178,6 +178,14 @@
 }
 
 
+.wf-multi-tile-card-info-details p {
+    max-height: 100px;
+    max-width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis; 
+}
+
 .model-summary-report {
     background: #fff;
     padding: 0px 30px 30px 30px;

--- a/afs/media/css/project.css
+++ b/afs/media/css/project.css
@@ -181,7 +181,11 @@
     max-width: calc(100%);
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis; 
+}
+
+.wf-multi-tile-card-info-details dd {
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .model-summary-report {

--- a/afs/media/css/project.css
+++ b/afs/media/css/project.css
@@ -177,10 +177,8 @@
     font-weight: 800;
 }
 
-
 .wf-multi-tile-card-info-details {
-    max-height: 100px;
-    max-width: 150px;
+    max-width: calc(100%);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis; 
@@ -230,9 +228,8 @@
     line-height: 1.4;
 }
 
-.summary-report-description {
-    max-height: 100px;
-    max-width: 800px;
+.object-search-step .summary-report-description {
+    max-width: 75vw;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -439,14 +436,6 @@
 
 .final-step .summary-value {
     color: #2b547c;
-}
-
-.final-step .summary-value {
-    max-height: 100px;
-    max-width: 800px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .final-step .file-list .file-upload-card {

--- a/afs/media/css/project.css
+++ b/afs/media/css/project.css
@@ -441,6 +441,14 @@
     color: #2b547c;
 }
 
+.final-step .summary-value p {
+    max-height: 100px;
+    max-width: 800px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .final-step .file-list .file-upload-card {
     border-bottom: 1px solid #D3E5F4;
     border-radius: 2px;

--- a/afs/media/css/project.css
+++ b/afs/media/css/project.css
@@ -222,6 +222,14 @@
     line-height: 1.4;
 }
 
+.summary-report-description p {
+    max-height: 100px;
+    max-width: 800px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .summary-report-manifests {
     margin-bottom: 10px;
     font-size: 14px;

--- a/afs/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/afs/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -464,7 +464,7 @@ define([
         this.initialize();
 
         this.stripTags = (original) => {
-            return original.replace(/(<([^>]+)>)/gi, "")
+            return original.replace(/(<([^>]+)>)/gi, "");
         };
     }
 

--- a/afs/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/afs/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -462,6 +462,10 @@ define([
         });
 
         this.initialize();
+
+        this.stripTags = (original) => {
+            return original.replace(/(<([^>]+)>)/gi, "")
+        };
     }
 
     ko.components.register('add-things-step', {

--- a/afs/templates/views/components/workflows/create-project-workflow/add-things-step.htm
+++ b/afs/templates/views/components/workflows/create-project-workflow/add-things-step.htm
@@ -18,7 +18,7 @@
                                 <div style="display: inline-flex;justify-content: space-between; align-items: baseline; width: 100%;">
                                     <div class="summary-report-title" data-bind="text: $data._source.displayname"></div>
                                 </div>
-                                <div class="summary-report-description" data-bind="html: $data._source.displaydescription || 'No description'"></div>
+                                <div class="summary-report-description" data-bind="html: $parent.stripTags($data._source.displaydescription) || 'No description'"></div>
                             </div>
                         </div>
                     </div>
@@ -51,10 +51,10 @@
                     <div class="wf-multi-tile-card-info">
                         <!-- <div class="workflow-step-icon complete"><span><i class="fa fa-hashtag"></i></span></div> -->
                         <div class="wf-multi-tile-card-info-details">
-                        <dt data-bind="text: $data.displayname"></dt>
-                        <dd>
-                            <a data-bind="html: $data.displaydescription || 'No description'"></a>
-                        </dd>
+                            <dt data-bind="text: $data.displayname"></dt>
+                            <dd>
+                                <a data-bind="html: $parent.stripTags($data.displaydescription) || 'No description'"></a>
+                            </dd>
                         </div>
                     </div>
                     <div class="wf-multi-tile-step-card-controls">


### PR DESCRIPTION
There are two instances of physical object descriptions and one instance of a project statement that previously overflowed the div's that contained them. These css changes contain those paragraph elements. #938 