### PR TITLE
Observation Report Changes 936

### DIFF
--- a/afs/media/js/views/components/reports/observation.js
+++ b/afs/media/js/views/components/reports/observation.js
@@ -14,13 +14,14 @@ define([
             params.configKeys = ['tabs', 'activeTabIndex'];
             Object.assign(self, reportUtils);
             self.sections = [
-                {id: 'name', title: 'Names and Classifications'},
-                {id: 'substance', title: 'Substance'},
-                {id: 'location', title: 'Location'},
-                {id: 'parameters', title: 'Parameters & Outcomes'},
-                {id: 'parthood', title: 'Parthood'},
+                {id: 'name', title: 'Names, Identifiers, Classification'},
                 {id: 'description', title: 'Description'},
+                {id: 'substance', title: 'Dates'},
+                {id: 'parameters', title: 'Parameters & Outcomes'},
+                {id: 'parthood', title: 'Parent Project'},
+                {id: 'objects', title: 'Related Objects'},
                 {id: 'documentation', title: 'Documentation'},
+                {id: 'data', title: 'Data'},
                 {id: 'json', title: 'JSON'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);

--- a/afs/media/js/views/components/reports/observation.js
+++ b/afs/media/js/views/components/reports/observation.js
@@ -42,7 +42,6 @@ define([
             self.descriptionCards = {};
             self.documentationCards = {};
             self.substanceCards = {};
-            self.relatedObjectsCards = {};
             self.summary = params.summary;
 
             self.relatedObjectsTableConfig = {
@@ -89,8 +88,6 @@ define([
                 self.documentationCards = {
                     digitalReference: self.cards?.['digital reference to observation'],
                 };
-
-                self.relatedObjectsCards = self.cards?.['object observed during observation'];
 
                 self.substanceCards = {
                     timespan: self.cards?.['timespan of observation'],

--- a/afs/media/js/views/components/reports/observation.js
+++ b/afs/media/js/views/components/reports/observation.js
@@ -17,11 +17,10 @@ define([
                 {id: 'name', title: 'Names, Identifiers, Classification'},
                 {id: 'description', title: 'Description'},
                 {id: 'substance', title: 'Dates'},
-                {id: 'parameters', title: 'Parameters & Outcomes'},
+                {id: 'data', title: 'Data'},
                 {id: 'parthood', title: 'Parent Project'},
                 {id: 'objects', title: 'Related Objects'},
                 {id: 'documentation', title: 'Documentation'},
-                {id: 'data', title: 'Data'},
                 {id: 'json', title: 'JSON'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);
@@ -98,22 +97,22 @@ define([
                     ]
             });
 
-            self.parthoodData = ko.observable({
+            self.dataData = ko.observable({
                 sections: 
                     [
                         {
-                            title: 'Parthood', 
+                            title: 'Parameters & Outcomes', 
                             data: [{
-                                key: 'parent event of observation', 
-                                value: self.getRawNodeValue(self.resource(), 'part of'), 
-                                card: self.cards?.['parent event of observation'],
+                                key: 'recorded value of observation', 
+                                value: self.getRawNodeValue(self.resource(), 'recorded value'), 
+                                card: self.cards?.['recorded value of observation'],
                                 type: 'resource'
                             }]
                         }
                     ]
             });
 
-            self.parameterData = ko.observable({
+            self.descriptionData = ko.observable({
                 sections: 
                     [
                         {
@@ -132,11 +131,6 @@ define([
                                 key: 'object observed during observation', 
                                 value: self.getRawNodeValue(self.resource(), 'observed'), 
                                 card: self.cards?.['object observed during observation'],
-                                type: 'resource'
-                            },{
-                                key: 'recorded value of observation', 
-                                value: self.getRawNodeValue(self.resource(), 'recorded value'), 
-                                card: self.cards?.['recorded value of observation'],
                                 type: 'resource'
                             },{
                                 key: 'person carrying out observation', 

--- a/afs/media/js/views/components/reports/observation.js
+++ b/afs/media/js/views/components/reports/observation.js
@@ -93,21 +93,6 @@ define([
                     timespan: self.cards?.['timespan of observation'],
                 };
             };
-                        
-            self.locationData = ko.observable({
-                sections: 
-                    [
-                        {
-                            title: 'Location of Observation', 
-                            data: [{
-                                key: 'location of observation', 
-                                value: self.getRawNodeValue(self.resource(), 'took place at'), 
-                                card: self.cards?.['location of observation'],
-                                type: 'resource'
-                            }]
-                        }
-                    ]
-            });
 
             self.parthoodData = ko.observable({
                 sections: 
@@ -150,14 +135,14 @@ define([
                                 card: self.cards?.['technique of observation'],
                                 type: 'resource'
                             },{
+                                key: 'location of observation', 
+                                value: self.getRawNodeValue(self.resource(), 'took place at'), 
+                                card: self.cards?.['location of observation'],
+                                type: 'resource'
+                            },{
                                 key: 'procedure / method used during observation', 
                                 value: self.getRawNodeValue(self.resource(), 'used process'), 
                                 card: self.cards?.['parent event of observation'],
-                                type: 'resource'
-                            },{
-                                key: 'object observed during observation', 
-                                value: self.getRawNodeValue(self.resource(), 'observed'), 
-                                card: self.cards?.['object observed during observation'],
                                 type: 'resource'
                             },{
                                 key: 'person carrying out observation', 

--- a/afs/templates/views/components/reports/observation.htm
+++ b/afs/templates/views/components/reports/observation.htm
@@ -73,6 +73,54 @@
                     }
                 }"></div>
             </div>
+            <!-- Related Objects Tab -->
+            <div class="afs-report-page" data-bind="if: activeSection() === 'objects'">
+                <div class="afs-report-section">
+                    <h2 class="afs-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.relatedObjects)}, css: {'fa-angle-double-right': visible.relatedObjects(), 'fa-angle-double-up': !visible.relatedObjects()}" class="fa toggle"></i> {% trans "Related Objects" %}</h2>
+                    <span data-bind="if: relatedObjectsCards && (!collectionOfRelatedObjects().length || relatedObjectsCards.cardinality == 'n')">
+                        <a class="afs-report-a" data-bind="click: function(){addNewTile(relatedObjectsCards)}"><i class="fa fa-mail-reply"></i> {% trans "Add Related Object" %}</a>
+                    </span>
+                    
+                    <!-- Collapsible content -->
+                    <div data-bind="visible: visible.relatedObjects" class="afs-report-collapsible-container pad-lft">
+
+                        <!-- ko ifnot: collectionOfRelatedObjects().length -->
+                        <div class="afs-nodata-note">No objects related to this observation</div>
+                        <!-- /ko -->
+
+                        <!-- ko if: collectionOfRelatedObjects().length -->
+                        <div class="afs-report-subsection" >
+                            <div>
+                                <div class="afs-table pad-btm">
+                                    <table class="table table-striped" cellspacing="0" width="100%">
+                                        <thead>
+                                            <tr class="afs-table-header">
+                                                <th>{% trans "Object" %}</th>
+                                                <th class="min-tabletl">{% trans "Description" %}</th>
+                                                <th class="afs-table-control all"></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody data-bind="dataTablesForEach: { data: collectionOfRelatedObjects, dataTableOptions: relatedObjectsTableConfig }">
+                                            <tr>
+                                                <td data-bind="text: displayname"></td>
+                                                <td data-bind="text: displaydescription" class="display-description"></td>
+                                                <td class="afs-table-control">
+                                                    <div data-bind="if: link">
+                                                        <a data-bind="attr: { href: link }">
+                                                            <i class="fa fa-link"></i>
+                                                        </a>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /ko -->
+                    </div>
+                </div>
+            </div>
             <!-- Dates Tab -->
             <div class="afs-report-page" data-bind="if: activeSection() === 'substance'">
                 <div data-bind="component: {

--- a/afs/templates/views/components/reports/observation.htm
+++ b/afs/templates/views/components/reports/observation.htm
@@ -76,7 +76,7 @@
             <!-- Related Objects Tab -->
             <div class="afs-report-page" data-bind="if: activeSection() === 'objects'">
                 <div class="afs-report-section">
-                    <h2 class="afs-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.relatedObjects)}, css: {'fa-angle-double-right': visible.relatedObjects(), 'fa-angle-double-up': !visible.relatedObjects()}" class="fa toggle"></i> {% trans "Related Objects" %}</h2>
+                    <h2 class="afs-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.relatedObjects)}, css: {'fa-angle-double-right': visible.relatedObjects(), 'fa-angle-double-up': !visible.relatedObjects()}" class="fa toggle"></i> {% trans "Related Physical Things" %}</h2>
                       
                     <!-- Collapsible content -->
                     <div data-bind="visible: visible.relatedObjects" class="afs-report-collapsible-container pad-lft">

--- a/afs/templates/views/components/reports/observation.htm
+++ b/afs/templates/views/components/reports/observation.htm
@@ -87,7 +87,7 @@
 
                         <!-- ko if: collectionOfRelatedObjects().length -->
                         <div class="afs-report-subsection" >
-                            <div>
+                            <div class="firstchild-container">
                                 <div class="afs-table pad-btm">
                                     <table class="table table-striped" cellspacing="0" width="100%">
                                         <thead>

--- a/afs/templates/views/components/reports/observation.htm
+++ b/afs/templates/views/components/reports/observation.htm
@@ -77,10 +77,7 @@
             <div class="afs-report-page" data-bind="if: activeSection() === 'objects'">
                 <div class="afs-report-section">
                     <h2 class="afs-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.relatedObjects)}, css: {'fa-angle-double-right': visible.relatedObjects(), 'fa-angle-double-up': !visible.relatedObjects()}" class="fa toggle"></i> {% trans "Related Objects" %}</h2>
-                    <span data-bind="if: relatedObjectsCards && (!collectionOfRelatedObjects().length || relatedObjectsCards.cardinality == 'n')">
-                        <a class="afs-report-a" data-bind="click: function(){addNewTile(relatedObjectsCards)}"><i class="fa fa-mail-reply"></i> {% trans "Add Related Object" %}</a>
-                    </span>
-                    
+                      
                     <!-- Collapsible content -->
                     <div data-bind="visible: visible.relatedObjects" class="afs-report-collapsible-container pad-lft">
 

--- a/afs/templates/views/components/reports/observation.htm
+++ b/afs/templates/views/components/reports/observation.htm
@@ -46,6 +46,12 @@
                         cards: descriptionCards,
                     }
                 }"></div>
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/default',
+                    params: {
+                        data: descriptionData,
+                    }
+                }"></div>
             </div>
             <!-- Documentation Tab -->
             <div class="afs-report-page" data-bind="if: activeSection() === 'documentation'">
@@ -58,16 +64,7 @@
                     }
                 }"></div>
             </div>            
-            <!-- Location Tab -->
-            <div class="afs-report-page" data-bind="if: activeSection() === 'location'">
-                <div data-bind="component: {
-                    name: 'views/components/reports/scenes/default',
-                    params: {
-                        data: locationData,
-                    }
-                }"></div>
-            </div>
-            <!-- Parthood Tab -->
+            <!-- Parent Project Tab -->
             <div class="afs-report-page" data-bind="if: activeSection() === 'parthood'">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
@@ -76,7 +73,7 @@
                     }
                 }"></div>
             </div>
-            <!-- Substance Tab -->
+            <!-- Dates Tab -->
             <div class="afs-report-page" data-bind="if: activeSection() === 'substance'">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/substance',
@@ -87,12 +84,12 @@
                     }
                 }"></div>
             </div>
-            <!-- Parameters & Outcomes Tab -->
-            <div class="afs-report-page" data-bind="if: activeSection() === 'parameters'">
+            <!-- Data Tab -->
+            <div class="afs-report-page" data-bind="if: activeSection() === 'data'">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
-                        data: parameterData,
+                        data: dataData,
                     }
                 }"></div>
             </div>  


### PR DESCRIPTION
Add physical things that are related to an observation and relocate most of the content that was in the Parameters and Outcomes tab to the Description tab. This addresses #936 sans the spot map requested for the Related Objects tab. 

@njkim or @robgaston could either one of you review this please?