### PR TITLE
Add capability to choose a existing image service during workflow, #1025 

### DIFF
--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
@@ -13,7 +13,7 @@ define([
         params.pageVm.loading(true);
 
         this.isManifestManagerHidden = ko.observable(true);
-        this.shouldShowEditService = ko.observable(false);
+        this.shouldShowEditService = ko.observable(true);
 
         this.selectedPhysicalThingImageServiceName = ko.observable();
         this.selectedPhysicalThingImageServiceName.subscribe(function(imageServiceName) {
@@ -81,7 +81,8 @@ define([
         this.manifestData.subscribe(function(manifestData) {
             if (manifestData) {
                 self.digitalResourceNameTile.data[digitalResourceNameContentNodeId](manifestData.label);
-                self.digitalResourceStatementTile.data[digitalResourceStatementContentNodeId](manifestData.description);
+                const manifestDescription = Array.isArray(manifestData.description) ? manifestData.description[0] : manifestData.description;
+                self.digitalResourceStatementTile.data[digitalResourceStatementContentNodeId](manifestDescription);
                 self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierContentNodeId](manifestData['@id']);
                 self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierTypeNodeId](["f32d0944-4229-4792-a33c-aadc2b181dc7"]); // uniform resource locators concept value id
                 self.digitalResourceServiceTile.data[digitalResourceServiceTypeConformanceNodeId](manifestData['@context']);

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
@@ -13,7 +13,7 @@ define([
         params.pageVm.loading(true);
 
         this.isManifestManagerHidden = ko.observable(true);
-        this.shouldShowEditService = ko.observable(false);
+        this.shouldShowEditService = ko.observable(true);
 
         this.selectedPhysicalThingImageServiceName = ko.observable();
         this.selectedPhysicalThingImageServiceName.subscribe(function(imageServiceName) {

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
@@ -85,7 +85,8 @@ define([
         this.manifestData.subscribe(function(manifestData) {
             if (manifestData) {
                 self.digitalResourceNameTile.data[digitalResourceNameContentNodeId](manifestData.label);
-                self.digitalResourceStatementTile.data[digitalResourceStatementContentNodeId](manifestData.description);
+                const manifestDescription = Array.isArray(manifestData.description) ? manifestData.description[0] : manifestData.description;
+                self.digitalResourceStatementTile.data[digitalResourceStatementContentNodeId](manifestDescription);
                 self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierContentNodeId](manifestData['@id']);
                 self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierTypeNodeId](["f32d0944-4229-4792-a33c-aadc2b181dc7"]); // uniform resource locators concept value id
                 self.digitalResourceServiceTile.data[digitalResourceServiceTypeConformanceNodeId](manifestData['@context']);


### PR DESCRIPTION
Add the capability to choose the existing manifest (image service) during the image service selection step in sample taking, analysis area workflows, #1025 
By utilizing the existing edit tab from the image service manager (previously disabled in the workflow)