### PR TITLE
Fix sampling final summary, #1026

### DIFF
--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-final-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-final-step.js
@@ -256,6 +256,7 @@ define([
                     });
     
                     // get the sample information from sample resource instance (physical thing) and add to the final object
+                    let annotationCounter = 0;
                     sampleAnnotationCollection[canvas].forEach(function(annotation){
                         var sampleResourceId = annotation.sampleResourceId;
     
@@ -266,7 +267,6 @@ define([
                         }
     
                         self.currentLocation = ko.observable();
-                        let annotationCounter = 0;
                         const numberOfAnnotations = sampleAnnotationCollection[canvas].length;
 
                         self.getResourceData(sampleResourceId, self.currentLocation);


### PR DESCRIPTION
Fix the sample taking workflow final step, where the page does not render if there are more than one sample on the same annotation canvas, #1026 