### PR TITLE
hide project report from navbar

### DIFF
--- a/afs/plugins/project-report-workflow.json
+++ b/afs/plugins/project-report-workflow.json
@@ -4,7 +4,7 @@
     "icon": "fa fa-paperclip",
     "component": "views/components/plugins/project-report-workflow",
     "componentname": "project-report-workflow",
-    "config": {},
+    "config": {"show": false},
     "slug": "project-report-workflow",
     "sortorder": 1
 }


### PR DESCRIPTION
hides project report from navbar re #1194 - requires plugin reload for QA.