### PR TITLE
1195 save button fix

### DIFF
--- a/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
+++ b/afs/media/js/views/components/workflows/upload-dataset/select-dataset-files-step.js
@@ -313,10 +313,12 @@ define([
                     )
                     part.datasetFiles([...newDatasetFiles, ...datasetInfo.files]);
                     part.nameTileId(datasetInfo.datasetNameTileId);
+                    self.nameDirty(false);
                 } catch(err) {
                     // eslint-disable-next-line no-console
                     console.log('Tile update failed', err);
                     params.form.loading(false);
+                    self.nameDirty(true);
                 }
 
                 saveWorkflowState();


### PR DESCRIPTION
Fixes #1195 by causing the save button to disappear if the name of the dataset is not dirty.