### PR TITLE
unchecked responses fail with mysterious messages

### DIFF
--- a/afs/media/js/views/components/reports/scenes/json.js
+++ b/afs/media/js/views/components/reports/scenes/json.js
@@ -24,7 +24,7 @@ define([
             self.setSelectedJson = async (format) => {
                 if(!self.json[format]){
                     const response = await fetch(`${arches.urls.api_resources(self.resourceInstanceId)}?format=${format}`);
-                    self.json[format] = await response.json();
+                    self.json[format] = response.ok ? await response.json() : undefined;
                 }
                 self.selectedJSON(JSON.stringify(self.json[format], null, 2));
                 self.selectedFormat(format);

--- a/afs/media/js/views/components/reports/scenes/json.js
+++ b/afs/media/js/views/components/reports/scenes/json.js
@@ -21,10 +21,10 @@ define([
                 json: ko.observable(true)
             };
 
-            self.setSelectedJson = async (format) => {
+            self.setSelectedJson = async(format) => {
                 if(!self.json[format]){
                     const response = await fetch(`${arches.urls.api_resources(self.resourceInstanceId)}?format=${format}`);
-                    self.json[format] = response.ok ? await response.json() : undefined;
+                    self.json[format] = response.ok ? await response.json() : 'Error Retrieving JSON for view.'; // let the user know if the json couldn't be retrieved.
                 }
                 self.selectedJSON(JSON.stringify(self.json[format], null, 2));
                 self.selectedFormat(format);

--- a/afs/media/js/views/components/workflows/chemical-analysis-workflow/ca-upload-files-step.js
+++ b/afs/media/js/views/components/workflows/chemical-analysis-workflow/ca-upload-files-step.js
@@ -216,6 +216,8 @@ define([
                         );
                         self.files([...newDatasetFiles, ...datasetInfo.files]);
                         self.datasetNameTileId = datasetInfo.datasetNameTileId;
+                    } else {
+                        throw('Error saving uploaded files', resp); // rethrow with easier to understand message.  
                     }
                 } catch(err) {
                     // eslint-disable-next-line no-console

--- a/afs/media/js/views/components/workflows/chemical-analysis-workflow/ca-upload-files-step.js
+++ b/afs/media/js/views/components/workflows/chemical-analysis-workflow/ca-upload-files-step.js
@@ -73,7 +73,9 @@ define([
                                 "X-CSRFToken": Cookies.get('csrftoken')
                             }
                         });
+                        
 
+                        // .json should not typically be awaited without "ok" checking - but 500 seems to return json body in some cases.
                         const body = await resp.json();
 
                         if(resp.status == 200 || (resp.status == 500 && body?.message?.includes("likely already deleted"))){
@@ -202,17 +204,19 @@ define([
                     });
 
                     self.loading(false);
-                    const datasetInfo = await resp.json();
-                    self.observationReferenceTileId = datasetInfo.observationReferenceTileId;
-                    this.datasetId = datasetInfo.datasetResourceId;
-                    const newDatasetFiles = self.files().filter(
-                        x => datasetInfo.removedFiles.find(
-                            y => {
-                                return ko.unwrap(x.tileId) == ko.unwrap(y.tileid);
-                            }) == undefined
-                    );
-                    self.files([...newDatasetFiles, ...datasetInfo.files]);
-                    self.datasetNameTileId = datasetInfo.datasetNameTileId;
+                    if(resp.ok) {
+                        const datasetInfo = await resp.json();
+                        self.observationReferenceTileId = datasetInfo.observationReferenceTileId;
+                        this.datasetId = datasetInfo.datasetResourceId;
+                        const newDatasetFiles = self.files().filter(
+                            x => datasetInfo.removedFiles.find(
+                                y => {
+                                    return ko.unwrap(x.tileId) == ko.unwrap(y.tileid);
+                                }) == undefined
+                        );
+                        self.files([...newDatasetFiles, ...datasetInfo.files]);
+                        self.datasetNameTileId = datasetInfo.datasetNameTileId;
+                    }
                 } catch(err) {
                     // eslint-disable-next-line no-console
                     console.log('Tile update failed', err);

--- a/afs/media/js/views/components/workflows/project-report-workflow/add-annotations.js
+++ b/afs/media/js/views/components/workflows/project-report-workflow/add-annotations.js
@@ -88,14 +88,23 @@ define([
 
         const fetchResource = async function(resourceid) {
             const response = await window.fetch(arches.urls.api_resources(resourceid) + '?format=json&compact=false&v=beta');
-            const resource = response.ok ? await response.json() : undefined;
-            return resource;
+
+            if (response.ok) {
+                return await response.json();
+            } else { 
+                throw('error retrieving resource', response); // throw - this should never happen. 
+            }
         };
 
         const getRelatedResources = async function(resourceid) {
             const response = await window.fetch(arches.urls.related_resources + resourceid + "?paginate=false");
-            const resources = response.ok ? await response.json() : undefined;
-            return resources;
+
+            if (response.ok) {
+                return await response.json();
+            } else { 
+                throw('error retrieving related resources', response); // throw - this should never happen. 
+            }
+
         };
 
         (async() => {
@@ -286,7 +295,7 @@ define([
                             fileId
                         };
                     } else {
-                        throw('error saving temp file!'); // we can't continue - we have to be able to save these files since they'll be in the report.
+                        throw('error saving temp file!', response); // we can't continue - we have to be able to save these files since they'll be in the report.
                     }
                 } else {
                     return screenshot;

--- a/afs/media/js/views/components/workflows/project-report-workflow/add-annotations.js
+++ b/afs/media/js/views/components/workflows/project-report-workflow/add-annotations.js
@@ -88,12 +88,14 @@ define([
 
         const fetchResource = async function(resourceid) {
             const response = await window.fetch(arches.urls.api_resources(resourceid) + '?format=json&compact=false&v=beta');
-            return await response.json();
+            const resource = response.ok ? await response.json() : undefined;
+            return resource;
         };
 
-        const getRelatedResources = async function(resourceid, relatedResources) {
+        const getRelatedResources = async function(resourceid) {
             const response = await window.fetch(arches.urls.related_resources + resourceid + "?paginate=false");
-            return await response.json();
+            const resources = response.ok ? await response.json() : undefined;
+            return resources;
         };
 
         (async() => {
@@ -276,12 +278,16 @@ define([
                             "X-CSRFToken": cookies.get('csrftoken')
                         }
                     });
-                    const responseJson = await response.json();
-                    const fileId = responseJson['file_id'];
-                    return {
-                        imageName: screenshot.imageName, 
-                        fileId
-                    };
+                    if(response.ok){
+                        const responseJson = await response.json();
+                        const fileId = responseJson['file_id'];
+                        return {
+                            imageName: screenshot.imageName, 
+                            fileId
+                        };
+                    } else {
+                        throw('error saving temp file!'); // we can't continue - we have to be able to save these files since they'll be in the report.
+                    }
                 } else {
                     return screenshot;
                 }

--- a/afs/media/js/views/components/workflows/project-report-workflow/download-project-files.js
+++ b/afs/media/js/views/components/workflows/project-report-workflow/download-project-files.js
@@ -52,23 +52,26 @@ define([
 
             for (const observataion of projectObservations) {
                 const relatedFiles = ko.observableArray();
-                const response = await window.fetch(arches.urls.related_resources + observataion.resourceinstanceid  + "?paginate=false")
-                const json = await response.json();
-                observation = json.resource_instance;
-                observation.expanded = ko.observable();
-                observation.description = observation.descriptors[arches.activeLanguage].description;
-                digitalResources = json.related_resources.filter(res => res.graph_id == digitalResourcegGraphId);
-                digitalResources.forEach((res) => 
-                    res.tiles.forEach((tile) => {
-                        if (tile.nodegroup_id == fileNodeId) {
-                            const selected = ko.observable();
-                            const interpretation = res.tiles.find(tile2 => tile2.parenttile_id == tile.tileid)?.data[fileStatementContentNodeId][arches.activeLanguage].value;
-                            const file = { ...tile.data[fileNodeId][0], interpretation, selected };
-                            relatedFiles.push(file);
-                        }
-                    })
-                );
-                self.relatedObservations.push({ ...observation, relatedFiles});
+                const response = await window.fetch(arches.urls.related_resources + observataion.resourceinstanceid  + "?paginate=false");
+                
+                if(response.ok) {
+                    const json = await response.json();
+                    observation = json.resource_instance;
+                    observation.expanded = ko.observable();
+                    observation.description = observation.descriptors[arches.activeLanguage].description;
+                    digitalResources = json.related_resources.filter(res => res.graph_id == digitalResourcegGraphId);
+                    digitalResources.forEach((res) => 
+                        res.tiles.forEach((tile) => {
+                            if (tile.nodegroup_id == fileNodeId) {
+                                const selected = ko.observable();
+                                const interpretation = res.tiles.find(tile2 => tile2.parenttile_id == tile.tileid)?.data[fileStatementContentNodeId][arches.activeLanguage].value;
+                                const file = { ...tile.data[fileNodeId][0], interpretation, selected };
+                                relatedFiles.push(file);
+                            }
+                        })
+                    );
+                    self.relatedObservations.push({ ...observation, relatedFiles});
+                }
             }
             self.relatedObservations.sort((a,b) => b.relatedFiles().length - a.relatedFiles().length);
         };

--- a/afs/media/js/views/components/workflows/project-report-workflow/report-template-select.js
+++ b/afs/media/js/views/components/workflows/project-report-workflow/report-template-select.js
@@ -18,30 +18,33 @@ define([
 
         this.getTemplates = async() => {
             const response = await fetch(arches.urls.reports_list);
-            const data = await response.json();
-            archesTemplates = data.map(template => {
-                if(!template.thumbnail){
-                    template.thumbnail = {
-                        'name': null,
-                        'url': null
+
+            if(response.ok) {
+                const data = await response.json();
+                archesTemplates = data.map(template => {
+                    if(!template.thumbnail){
+                        template.thumbnail = {
+                            'name': null,
+                            'url': null
+                        };
+                    }
+                    if(!template.preview){
+                        template.preview = {
+                            'name': null,
+                            'url': null
+                        };
+                    }
+                    return {
+                        id: template.templateid,
+                        name: template.name,
+                        format: template.template.name.split('.').pop(),
+                        description: template.description,
+                        template: template.template.url,
+                        preview: template.preview.url,
+                        thumbnail: template.thumbnail.url,
                     };
-                }
-                if(!template.preview){
-                    template.preview = {
-                        'name': null,
-                        'url': null
-                    };
-                }
-                return {
-                    id: template.templateid,
-                    name: template.name,
-                    format: template.template.name.split('.').pop(),
-                    description: template.description,
-                    template: template.template.url,
-                    preview: template.preview.url,
-                    thumbnail: template.thumbnail.url,
-                };
-            });
+                });
+            }
             this.docxTemplates = archesTemplates.filter(template => template.format === 'docx');
             this.pptTemplates = archesTemplates.filter(template => template.format === 'pptx');
             // this.xlsxTemplates = archesTemplates.filter(template => template.format === 'xlsx');

--- a/afs/media/js/views/components/workflows/project-report-workflow/report-template-select.js
+++ b/afs/media/js/views/components/workflows/project-report-workflow/report-template-select.js
@@ -44,6 +44,8 @@ define([
                         thumbnail: template.thumbnail.url,
                     };
                 });
+            } else {
+                throw('couldn\'t fetch report templates', response)
             }
             this.docxTemplates = archesTemplates.filter(template => template.format === 'docx');
             this.pptTemplates = archesTemplates.filter(template => template.format === 'pptx');


### PR DESCRIPTION
Some fetch requests aren't being properly checked for response codes.  These can cause strange error messages and throw the end user off - making them think there's a frontend issue or somesuch, rather than a bad response from the backend.  