### PR TITLE
Avoid GET requests when selecting physical things in workflow #1219

### DIFF
--- a/afs/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/afs/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -89,15 +89,10 @@ define([
         this.value.subscribe(function(a) {
             a.forEach(function(action) {
                 if (action.status === 'added') {
-                    $.ajax({
-                        url: arches.urls.api_resources(ko.unwrap(action.value)),
-                        data: {
-                            format: 'json',
-                            includetiles: 'false'
-                        }
-                    }).done(function(data) {
-                        self.selectedResources.push(data);
-                    });
+                    const targetResource = ko.unwrap(self.targetResources).find(
+                        r => r._id === ko.unwrap(action.value)
+                    );
+                    self.selectedResources.push(targetResource._source);
                 } else if (action.status === 'deleted') {
                     self.selectedResources().forEach(function(val) {
                         if (val.resourceinstanceid === ko.unwrap(action.value)) {

--- a/afs/templates/views/components/workflows/create-project-workflow/add-things-step.htm
+++ b/afs/templates/views/components/workflows/create-project-workflow/add-things-step.htm
@@ -51,9 +51,9 @@
                     <div class="wf-multi-tile-card-info">
                         <!-- <div class="workflow-step-icon complete"><span><i class="fa fa-hashtag"></i></span></div> -->
                         <div class="wf-multi-tile-card-info-details">
-                            <dt data-bind="text: $parent.getStringValue($data.displayname)"></dt>
+                            <dt data-bind="text: $data.displayname"></dt>
                             <dd>
-                                <a data-bind="html: $parent.stripTags($parent.getStringValue($data.displaydescription)) || 'No description'"></a>
+                                <a data-bind="html: $parent.stripTags($data.displaydescription) || 'No description'"></a>
                             </dd>
                         </div>
                     </div>

--- a/afs/templates/views/components/workflows/create-project-workflow/add-things-step.htm
+++ b/afs/templates/views/components/workflows/create-project-workflow/add-things-step.htm
@@ -51,9 +51,9 @@
                     <div class="wf-multi-tile-card-info">
                         <!-- <div class="workflow-step-icon complete"><span><i class="fa fa-hashtag"></i></span></div> -->
                         <div class="wf-multi-tile-card-info-details">
-                            <dt data-bind="text: $data.displayname"></dt>
+                            <dt data-bind="text: $parent.getStringValue($data.displayname)"></dt>
                             <dd>
-                                <a data-bind="html: $parent.stripTags($data.displaydescription) || 'No description'"></a>
+                                <a data-bind="html: $parent.stripTags($parent.getStringValue($data.displaydescription)) || 'No description'"></a>
                             </dd>
                         </div>
                     </div>


### PR DESCRIPTION
Avoid unnecessary GET requests when selecting physical things in the new project workflow. All the wanted information has already been fetched by the client.

@aarongundel I'd be grateful if you could let me know whether this solves the performance issue you experienced when running in Docker.

Closes #1219