### PR TITLE
Fix SyntaxWarning in phys thing search workflow step

### DIFF
--- a/afs/views/physical_thing_search.py
+++ b/afs/views/physical_thing_search.py
@@ -20,7 +20,7 @@ class PhysicalThingSearchView(View):
         return self.search_results(request)
 
     def search_results(self, request):
-        has_filters = True if len(list(request.GET.items())) > 1 is not None else False
+        has_filters = len(list(request.GET.items())) > 1
         request.GET = request.GET.copy()
 
         se = SearchEngineFactory().create()


### PR DESCRIPTION
Resolves error seen when running the project:
```py
/Users/jwalls/prj/afs/afs/views/physical_thing_search.py:23: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  has_filters = True if len(list(request.GET.items())) > 1 is not None else False
```

Luckily, `1 is not None` is equivalent to `1` in a comparison (`>`) context, so I don't think this was causing any issues.