### PR TITLE
Fix 500 error from undefined manifest description #1228

### DIFF
--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
@@ -7,8 +7,9 @@ define([
     'models/graph',
     'viewmodels/card',
     'templates/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.htm',
+    'views/components/workflows/stringUtils',
     'views/components/plugins/manifest-manager',
-], function(_, $, arches, ko, koMapping, GraphModel, CardViewModel, analysisAreasImageStepTemplate) {
+], function(_, $, arches, ko, koMapping, GraphModel, CardViewModel, analysisAreasImageStepTemplate, stringUtils) {
     function viewModel(params) {
         var self = this;
         params.pageVm.loading(true);
@@ -80,23 +81,15 @@ define([
         const digitalResourceServiceTypeNodeId= '5ceedd21-ca7c-11e9-a60f-a4d18cec433a';
         const digitalResourceTypeNodeId = '09c1778a-ca7b-11e9-860b-a4d18cec433a';
 
-        this.buildStrObject = str => {
-            return {[arches.activeLanguage]: {
-                "value": str || '',
-                "direction": arches.languages.find(lang => lang.code == arches.activeLanguage).default_direction
-            }};
-        };
-
-
         this.manifestData = ko.observable();
         this.manifestData.subscribe(function(manifestData) {
             if (manifestData) {
-                self.digitalResourceNameTile.data[digitalResourceNameContentNodeId](self.buildStrObject(manifestData.label));
-                const manifestDescription = Array.isArray(manifestData.description) ? self.buildStrObject(manifestData.description[0]) : self.buildStrObject(manifestData.description);
+                self.digitalResourceNameTile.data[digitalResourceNameContentNodeId](stringUtils.buildStrObject(manifestData.label));
+                const manifestDescription = Array.isArray(manifestData.description) ? stringUtils.buildStrObject(manifestData.description[0]) : stringUtils.buildStrObject(manifestData.description);
                 self.digitalResourceStatementTile.data[digitalResourceStatementContentNodeId](manifestDescription);
-                self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierContentNodeId](self.buildStrObject(manifestData['@id']));
+                self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierContentNodeId](stringUtils.buildStrObject(manifestData['@id']));
                 self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierTypeNodeId](["f32d0944-4229-4792-a33c-aadc2b181dc7"]); // uniform resource locators concept value id
-                self.digitalResourceServiceTile.data[digitalResourceServiceTypeConformanceNodeId](self.buildStrObject(manifestData['@context']));
+                self.digitalResourceServiceTile.data[digitalResourceServiceTypeConformanceNodeId](stringUtils.buildStrObject(manifestData['@context']));
             }
             else {
                 self.digitalResourceNameTile.data[digitalResourceNameContentNodeId](null);

--- a/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
+++ b/afs/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-image-step.js
@@ -82,7 +82,7 @@ define([
 
         this.buildStrObject = str => {
             return {[arches.activeLanguage]: {
-                "value": str,
+                "value": str || '',
                 "direction": arches.languages.find(lang => lang.code == arches.activeLanguage).default_direction
             }};
         };

--- a/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
+++ b/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js
@@ -7,8 +7,9 @@ define([
     'models/graph',
     'viewmodels/card',
     'templates/views/components/workflows/sample-taking-workflow/sample-taking-image-step.htm',
+    'views/components/workflows/stringUtils',
     'views/components/plugins/manifest-manager',
-], function(_, $, arches, ko, koMapping, GraphModel, CardViewModel, sampleTakingImageStepTemplate) {
+], function(_, $, arches, ko, koMapping, GraphModel, CardViewModel, sampleTakingImageStepTemplate, stringUtils) {
     function viewModel(params) {
         var self = this;
         params.pageVm.loading(true);
@@ -87,19 +88,15 @@ define([
         this.manifestData = ko.observable();
         this.manifestData.subscribe(function(manifestData) {
             if (manifestData) {
-                const digitalResourceName = {};
-                digitalResourceName[arches.activeLanguage] = {"value": manifestData.label, "direction": arches.activeLanguageDir};
+                const digitalResourceName = stringUtils.buildStrObject(manifestData.label);
                 self.digitalResourceNameTile.data[digitalResourceNameContentNodeId](digitalResourceName);                
                 const manifestDescription = Array.isArray(manifestData.description) ? manifestData.description[0] : manifestData.description;
-                const manifestDescriptionTileValue = {};
-                manifestDescriptionTileValue[arches.activeLanguage] = {"value": manifestDescription || "", "direction": arches.activeLanguageDir};
+                const manifestDescriptionTileValue = stringUtils.buildStrObject(manifestDescription);
                 self.digitalResourceStatementTile.data[digitalResourceStatementContentNodeId](manifestDescriptionTileValue);                
-                const manifestContentIdValue = {};
-                manifestContentIdValue[arches.activeLanguage] = {"value": manifestData['@id'], "direction": arches.activeLanguageDir};
+                const manifestContentIdValue = stringUtils.buildStrObject(manifestData['@id']);
                 self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierContentNodeId](manifestContentIdValue);
                 self.digitalResourceServiceIdentifierTile.data[digitalResourceServiceIdentifierTypeNodeId](["f32d0944-4229-4792-a33c-aadc2b181dc7"]); // uniform resource locators concept value id               
-                const conformanceNodeValue = {};
-                conformanceNodeValue[arches.activeLanguage] = {"value": manifestData['@context'], "direction": arches.activeLanguageDir};
+                const conformanceNodeValue = stringUtils.buildStrObject(manifestData['@context']);
                 self.digitalResourceServiceTile.data[digitalResourceServiceTypeConformanceNodeId](conformanceNodeValue);
             }
             else {

--- a/afs/media/js/views/components/workflows/stringUtils.js
+++ b/afs/media/js/views/components/workflows/stringUtils.js
@@ -1,0 +1,12 @@
+define(['arches'], function(arches) {
+    return {
+        buildStrObject: function(str) {
+            return {[arches.activeLanguage]: {
+                "value": str || '',
+                "direction": arches.languages.find(
+                        lang => lang.code == arches.activeLanguage
+                    ).default_direction,
+            }};
+        },
+    };
+});


### PR DESCRIPTION
Closes #1228

Keeps the analysis areas workflow in sync with the sample taking workflow, which guarded against the reported issue like this:
https://github.com/archesproject/arches-for-science-prj/blob/b14a0a60d30886c9e26d0b8be41d7a69b6aa5b46/afs/media/js/views/components/workflows/sample-taking-workflow/sample-taking-image-step.js#L95

***
Note: with the time remaining this afternoon, I'll look into factoring out a util that could be shared by the two files.