### PR TITLE
Fix empty user in edit log

### DIFF
--- a/afs/tests.py
+++ b/afs/tests.py
@@ -1,0 +1,73 @@
+from django.core.management import call_command
+
+from django.test import TestCase
+from django.test.client import Client
+from django.urls import reverse
+
+from arches.app.utils.betterJSONSerializer import JSONSerializer
+from arches.app.models.models import Node, NodeGroup, ResourceInstance, ResourceXResource, TileModel
+from arches.app.models.tile import Tile
+
+def setUpModule():
+    call_command("packages", "-o load_package -s afs/pkg -y".split())
+
+
+class AnalysisAreaAndSampleTakingTests(TestCase):
+    def test_create_delete_analysis_area(self):
+        client = Client()
+        client.login(username="ben", password="Test12345!")
+
+        transaction_id = "10000000-1000-1000-1000-100000000000"
+        graph_id = "9519cb4f-b25b-11e9-8c7b-a4d18cec433a"
+        part_identifier_assignment = "b240c366-8594-11ea-97eb-acde48001122"
+        collection_resource =  "54bf1022-a0b8-4f95-a5e9-82c084b2f53"
+
+        r = ResourceInstance(graph_id=graph_id)
+        r.save()  # not part of the transaction, part of the setup
+        self.addCleanup(r.delete)
+        parent_phys_thing = str(r.pk)
+
+        create_data = {
+            "transaction_id": transaction_id,  # NB: snake_case
+            "parentPhysicalThingResourceid": parent_phys_thing,  # NB: lowercase id
+            "collectionResourceid": collection_resource,
+            "partIdentifierAssignmentTileData": JSONSerializer().serialize(
+                {part_identifier_assignment: []}
+            ),
+            "analysisAreaName": "Test Analysis Area",
+        }
+        response = client.post(reverse("saveanalysisarea"), create_data)
+        self.assertEqual(response.status_code, 200)
+
+        new_resource = ResourceInstance.objects.get(
+            pk=response.json()['result']['memberOfTile']['resourceinstance_id']
+        )
+        arbitrary_nodegroup = NodeGroup.objects.first()
+        new_tile = TileModel(resourceinstance=r, nodegroup=arbitrary_nodegroup)
+        new_tile.save()
+        # Set the transactionid
+        new_tile_data = {part_identifier_assignment: [{"resourceId": str(new_resource.pk)}]}
+        new_tile = Tile.objects.get(tileid=new_tile.pk)
+        new_tile.data = new_tile_data
+        new_tile.save(transaction_id=transaction_id)
+
+        self.addCleanup(new_tile.delete)
+        rxr = ResourceXResource(
+            nodeid=Node.objects.get(pk=part_identifier_assignment),
+            resourceinstanceidfrom=r,
+            resourceinstanceidto=new_resource,
+            tileid=new_tile,
+        )
+        rxr.save(transaction_id=transaction_id)
+        self.addCleanup(rxr.delete)
+
+        delete_data = {
+            "transactionId": transaction_id,  # NB: camelCase
+            "parentPhysicalThingResourceId": parent_phys_thing,  # NB: uppercase id
+            "parentPhysicalThingTileData": JSONSerializer().serialize(new_tile_data),
+        }
+        delete_data = JSONSerializer().serialize(delete_data)
+        content_type = "application/json"
+        response = client.post(reverse("deleteanalysisarea"), delete_data, content_type=content_type)
+
+        self.assertEqual(response.status_code, 200)

--- a/afs/views/analysis_area_and_sample_taking.py
+++ b/afs/views/analysis_area_and_sample_taking.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
@@ -182,8 +182,8 @@ class SaveAnalysisAreaView(SaveAnnotationView):
         part_identifier_assignment_tile_data = JSONDeserializer().deserialize(request.POST.get("partIdentifierAssignmentTileData"))
         part_identifier_assignment_tile_id = request.POST.get("partIdentifierAssignmentTileId") or None
         name = request.POST.get("analysisAreaName")
-        if name:
-            name_object = name
+        if not name:
+            raise ValidationError("Name is required.")
         physical_part_of_object_nodeid = "b240c366-8594-11ea-97eb-acde48001122"
         analysis_area_physical_thing_resourceid = None
         if part_identifier_assignment_tile_data[physical_part_of_object_nodeid]:
@@ -194,7 +194,7 @@ class SaveAnalysisAreaView(SaveAnnotationView):
                 if analysis_area_physical_thing_resourceid is None:
                     analysis_area_physical_thing_resourceid = self.create_physical_thing_resource(request, transaction_id)
 
-                name_tile = self.save_physical_thing_name(request, analysis_area_physical_thing_resourceid, transaction_id, name_object)
+                name_tile = self.save_physical_thing_name(request, analysis_area_physical_thing_resourceid, transaction_id, name)
                 type_tile = self.save_physical_thing_type(request, analysis_area_physical_thing_resourceid, transaction_id, "analysis_area")
                 member_of_tile = self.save_physical_thing_related_collection(
                     request, analysis_area_physical_thing_resourceid, transaction_id, collection_resourceid

--- a/afs/views/analysis_area_and_sample_taking.py
+++ b/afs/views/analysis_area_and_sample_taking.py
@@ -26,16 +26,16 @@ def get_related_resource_template(resourceid, relationship_type="", inverse_rela
 
 
 class SaveAnnotationView(View):
-    def create_physical_thing_resource(self, transaction_id):
+    def create_physical_thing_resource(self, request, transaction_id):
         physical_thing_graphid = "9519cb4f-b25b-11e9-8c7b-a4d18cec433a"
         resource = Resource()
         resource.graph_id = physical_thing_graphid
-        resource.save(transaction_id=transaction_id)
+        resource.save(transaction_id=transaction_id, request=request)
         resourceid = str(resource.pk)
 
         return resourceid
 
-    def save_node(self, resourceinstanceid, nodegroupid, nodeid, transactionid, nodevalue, tileid=None):
+    def save_node(self, request, resourceinstanceid, nodegroupid, nodeid, transactionid, nodevalue, tileid=None):
         if tileid is not None:
             tile = Tile.objects.get(pk=tileid)
         else:
@@ -44,21 +44,21 @@ class SaveAnnotationView(View):
             except ObjectDoesNotExist as e:
                 tile = Tile.get_blank_tile(nodeid=nodeid, resourceid=resourceinstanceid)
         tile.data[nodeid] = nodevalue
-        tile.save(transaction_id=transactionid, index=False)
+        tile.save(transaction_id=transactionid, request=request, index=False)
 
         return tile
 
-    def save_tile(self, resourceinstanceid, nodegroupid, transactionid, tiledata, tileid=None):
+    def save_tile(self, request, resourceinstanceid, nodegroupid, transactionid, tiledata, tileid=None):
         if tileid is not None:
             tile = Tile.objects.get(pk=tileid)
         else:
             tile = Tile.get_blank_tile_from_nodegroup_id(nodegroup_id=nodegroupid, resourceid=resourceinstanceid)
         tile.data = tiledata
-        tile.save(transaction_id=transactionid, index=False)
+        tile.save(transaction_id=transactionid, request=request, index=False)
 
         return tile
 
-    def save_related_resource_node(self, resourceinstanceid, nodeid, transactionid, related_resourceid, tileid=None, relationship_type="", inverse_relationship_type=""):
+    def save_related_resource_node(self, request, resourceinstanceid, nodeid, transactionid, related_resourceid, tileid=None, relationship_type="", inverse_relationship_type=""):
         if tileid is not None:
             tile = Tile.objects.get(pk=tileid)
             tile.data[nodeid][0]["resourceId"] = related_resourceid
@@ -69,7 +69,7 @@ class SaveAnnotationView(View):
                 tile = Tile.get_blank_tile(nodeid=nodeid, resourceid=resourceinstanceid)
             related_resource_template = get_related_resource_template(related_resourceid, relationship_type, inverse_relationship_type)
             tile.data[nodeid] = [related_resource_template]
-        tile.save(transaction_id=transactionid, index=False)
+        tile.save(transaction_id=transactionid, request=request, index=False)
 
         return tile
 
@@ -104,7 +104,7 @@ class SaveAnnotationView(View):
 
         return tile
 
-    def save_physical_thing_name(self, resourceid, transactionid, name, tileid=None):
+    def save_physical_thing_name(self, request, resourceid, transactionid, name, tileid=None):
         physical_thing_name_nodegroupid = "b9c1ced7-b497-11e9-a4da-a4d18cec433a"
         physical_thing_name_nodeid = "b9c1d8a6-b497-11e9-876b-a4d18cec433a"
         physical_thing_name_type_nodeid = "b9c1d7ab-b497-11e9-9ab7-a4d18cec433a"
@@ -123,11 +123,11 @@ class SaveAnnotationView(View):
         tile.data[physical_thing_name_nodeid][get_language()] = {"value": name, "direction": "rtl" if get_language_bidi() else "ltr"}
         tile.data[physical_thing_name_type_nodeid] = [preferred_terms_conceptid]
         tile.data[physical_thing_name_language_nodeid] = [english_conceptid]
-        tile.save(transaction_id=transactionid, index=False)
+        tile.save(transaction_id=transactionid, request=request, index=False)
 
         return tile
 
-    def save_physical_thing_type(self, resourceid, transactionid, type):
+    def save_physical_thing_type(self, request, resourceid, transactionid, type):
         physical_thing_type_nodeid = "8ddfe3ab-b31d-11e9-aff0-a4d18cec433a"
         physical_thing_types = {
             "analysis_area": ["31d97bdd-f10f-4a26-958c-69cb5ab69af1"],
@@ -135,31 +135,31 @@ class SaveAnnotationView(View):
             "sample": ["77d8cf19-ce9c-4e0a-bde1-9148d870e11c"],
         }
         physical_thing_type = physical_thing_types[type]
-        tile = self.save_node(resourceid, physical_thing_type_nodeid, physical_thing_type_nodeid, transactionid, physical_thing_type)
+        tile = self.save_node(request, resourceid, physical_thing_type_nodeid, physical_thing_type_nodeid, transactionid, physical_thing_type)
         return tile
 
-    def save_physical_thing_related_collection(self, resourceinstanceid, transactionid, related_resourceid):
+    def save_physical_thing_related_collection(self, request, resourceinstanceid, transactionid, related_resourceid):
         physical_thing_member_of_nodeid = "63e49254-c444-11e9-afbe-a4d18cec433a"
         relationship_type = "31327077-8af5-4398-bbcc-e75675a9d37e"
         inverse_relationship_type = "6e7cf6a4-aba0-4a17-9a36-c69412212699"
-        tile = self.save_related_resource_node(resourceinstanceid, physical_thing_member_of_nodeid, transactionid, related_resourceid, relationship_type=relationship_type, inverse_relationship_type=inverse_relationship_type)
+        tile = self.save_related_resource_node(request, resourceinstanceid, physical_thing_member_of_nodeid, transactionid, related_resourceid, relationship_type=relationship_type, inverse_relationship_type=inverse_relationship_type)
         return tile
 
-    def save_physical_thing_part_of_tile(self, resourceid, transactionid, related_resourceid):
+    def save_physical_thing_part_of_tile(self, request, resourceid, transactionid, related_resourceid):
         physical_thing_part_of_nodeid = "f8d5fe4c-b31d-11e9-9625-a4d18cec433a"
         relationship_type = "da51c93e-950e-4801-90a7-31beff7d4f2b"
         inverse_relationship_type = "6d2969ea-41a2-4866-be92-14ba2b24f338"
-        tile = self.save_related_resource_node(resourceid, physical_thing_part_of_nodeid, transactionid, related_resourceid, relationship_type=relationship_type, inverse_relationship_type=inverse_relationship_type)
+        tile = self.save_related_resource_node(request, resourceid, physical_thing_part_of_nodeid, transactionid, related_resourceid, relationship_type=relationship_type, inverse_relationship_type=inverse_relationship_type)
         return tile
 
-    def save_parent_physical_thing_part_of_tile(self, resourceid, related_resourceid, transactionid, tiledata, tileid):
+    def save_parent_physical_thing_part_of_tile(self, request, resourceid, related_resourceid, transactionid, tiledata, tileid):
         part_identifier_assignment_nodegroupid = "fec59582-8593-11ea-97eb-acde48001122"
         physical_part_of_object_nodeid = "b240c366-8594-11ea-97eb-acde48001122"
         relationship_type = "6d2969ea-41a2-4866-be92-14ba2b24f338"
         inverse_relationship_type = "02404924-40a4-44aa-bc07-e7b70e5cc718"
         related_resource_template = get_related_resource_template(related_resourceid, relationship_type, inverse_relationship_type)
         tiledata[physical_part_of_object_nodeid] = [related_resource_template]
-        tile = self.save_tile(resourceid, part_identifier_assignment_nodegroupid, transactionid, tiledata, tileid)
+        tile = self.save_tile(request, resourceid, part_identifier_assignment_nodegroupid, transactionid, tiledata, tileid)
         return tile
 
 
@@ -192,17 +192,18 @@ class SaveAnalysisAreaView(SaveAnnotationView):
         try:
             with transaction.atomic():
                 if analysis_area_physical_thing_resourceid is None:
-                    analysis_area_physical_thing_resourceid = self.create_physical_thing_resource(transaction_id)
+                    analysis_area_physical_thing_resourceid = self.create_physical_thing_resource(request, transaction_id)
 
-                name_tile = self.save_physical_thing_name(analysis_area_physical_thing_resourceid, transaction_id, name_object)
-                type_tile = self.save_physical_thing_type(analysis_area_physical_thing_resourceid, transaction_id, "analysis_area")
+                name_tile = self.save_physical_thing_name(request, analysis_area_physical_thing_resourceid, transaction_id, name_object)
+                type_tile = self.save_physical_thing_type(request, analysis_area_physical_thing_resourceid, transaction_id, "analysis_area")
                 member_of_tile = self.save_physical_thing_related_collection(
-                    analysis_area_physical_thing_resourceid, transaction_id, collection_resourceid
+                    request, analysis_area_physical_thing_resourceid, transaction_id, collection_resourceid
                 )
                 part_of_tile = self.save_physical_thing_part_of_tile(
-                    analysis_area_physical_thing_resourceid, transaction_id, parent_physical_thing_resourceid
+                    request, analysis_area_physical_thing_resourceid, transaction_id, parent_physical_thing_resourceid
                 )
                 physical_part_of_object_tile = self.save_parent_physical_thing_part_of_tile(
+                    request,
                     parent_physical_thing_resourceid,
                     analysis_area_physical_thing_resourceid,
                     transaction_id,
@@ -232,6 +233,7 @@ class SaveAnalysisAreaView(SaveAnnotationView):
 class SaveSampleAreaView(SaveAnnotationView):
     def save_sampling_unit_tile(
         self,
+        request,
         sampling_activity_resourceid,
         parent_physical_thing_resourceid,
         sample_area_physical_thing_resourceid,
@@ -272,11 +274,11 @@ class SaveSampleAreaView(SaveAnnotationView):
         tile.data[sampling_area_sample_created_nodeid] = [get_related_resource_template(sample_physical_thing_resourceid)]
         tile.data[sampling_area_visualization_nodeid] = sample_area_visualization
 
-        tile.save(transaction_id=transactionid, index=False)
+        tile.save(transaction_id=transactionid, request=request, index=False)
 
         return tile
 
-    def save_sample_statement_tile(self, resourceid, statement, type, tileid=None):
+    def save_sample_statement_tile(self, request, resourceid, statement, type, tileid=None):
         statement_nodegroupid = "1952bb0a-b498-11e9-a679-a4d18cec433a"
         statement_type_nodeid = "1952e470-b498-11e9-b261-a4d18cec433a"
         statement_content_nodeid = "1953016e-b498-11e9-9445-a4d18cec433a"
@@ -307,16 +309,16 @@ class SaveSampleAreaView(SaveAnnotationView):
         tile.data[statement_content_nodeid][get_language()] = {"value": statement, "direction": "rtl" if get_language_bidi() else "ltr"}
         tile.data[statement_type_nodeid] = [statement_types[type]]
         tile.data[statement_language_nodeid] = [english_conceptid]
-        tile.save(index=False)
+        tile.save(request, index=False)
 
         return tile
 
-    def save_removed_from_tile(self, sample_resourceid, removed_from_resourceids, transactionid):
+    def save_removed_from_tile(self, request, sample_resourceid, removed_from_resourceids, transactionid):
         removed_from_nodeid = "38814345-d2bd-11e9-b9d6-a4d18cec433a"
         removal_from_object_nodegroupid = "b11f217a-d2bc-11e9-8dfa-a4d18cec433a"
         removed_from_related_list = [get_related_resource_template(resourceid) for resourceid in removed_from_resourceids]
         tile = self.save_node(
-            sample_resourceid, removal_from_object_nodegroupid, removed_from_nodeid, transactionid, removed_from_related_list
+            request, sample_resourceid, removal_from_object_nodegroupid, removed_from_nodeid, transactionid, removed_from_related_list
         )
         tile.save(transaction_id=transactionid, index=False)
 
@@ -357,32 +359,33 @@ class SaveSampleAreaView(SaveAnnotationView):
             with transaction.atomic():
                 # saving the sample area resource and tiles
                 if sample_area_physical_thing_resourceid is None:
-                    sample_area_physical_thing_resourceid = self.create_physical_thing_resource(transaction_id)
+                    sample_area_physical_thing_resourceid = self.create_physical_thing_resource(request, transaction_id)
 
                 sample_area_name_tile = self.save_physical_thing_name(
-                    sample_area_physical_thing_resourceid, transaction_id, sample_area_name
+                    request, sample_area_physical_thing_resourceid, transaction_id, sample_area_name
                 )
-                sample_area_type_tile = self.save_physical_thing_type(sample_area_physical_thing_resourceid, transaction_id, "sample_area")
+                sample_area_type_tile = self.save_physical_thing_type(request, sample_area_physical_thing_resourceid, transaction_id, "sample_area")
                 sample_area_member_of_tile = self.save_physical_thing_related_collection(
-                    sample_area_physical_thing_resourceid, transaction_id, collection_resourceid
+                    request, sample_area_physical_thing_resourceid, transaction_id, collection_resourceid
                 )
                 sample_area_part_of_tile = self.save_physical_thing_part_of_tile(
-                    sample_area_physical_thing_resourceid, transaction_id, parent_physical_thing_resourceid
+                    request, sample_area_physical_thing_resourceid, transaction_id, parent_physical_thing_resourceid
                 )
 
                 # saving the sample resource and tiles
                 if sample_physical_thing_resourceid is None:
-                    sample_physical_thing_resourceid = self.create_physical_thing_resource(transaction_id)
+                    sample_physical_thing_resourceid = self.create_physical_thing_resource(request, transaction_id)
 
-                sample_name_tile = self.save_physical_thing_name(sample_physical_thing_resourceid, transaction_id, sample_name)
-                sample_type_tile = self.save_physical_thing_type(sample_physical_thing_resourceid, transaction_id, "sample")
+                sample_name_tile = self.save_physical_thing_name(request, sample_physical_thing_resourceid, transaction_id, sample_name)
+                sample_type_tile = self.save_physical_thing_type(request, sample_physical_thing_resourceid, transaction_id, "sample")
                 sample_member_of_tile = self.save_physical_thing_related_collection(
-                    sample_physical_thing_resourceid, transaction_id, collection_resourceid
+                    request, sample_physical_thing_resourceid, transaction_id, collection_resourceid
                 )
                 sample_part_of_tile = self.save_physical_thing_part_of_tile(
-                    sample_physical_thing_resourceid, transaction_id, parent_physical_thing_resourceid
+                    request, sample_physical_thing_resourceid, transaction_id, parent_physical_thing_resourceid
                 )
                 removed_from_tile = self.save_removed_from_tile(
+                    request,
                     sample_physical_thing_resourceid,
                     [parent_physical_thing_resourceid, sample_area_physical_thing_resourceid],
                     transaction_id,
@@ -390,6 +393,7 @@ class SaveSampleAreaView(SaveAnnotationView):
 
                 # saving the sampling activity resource and tiles
                 sampling_unit_tile = self.save_sampling_unit_tile(
+                    request,
                     sampling_activity_resourceid,
                     parent_physical_thing_resourceid,
                     sample_area_physical_thing_resourceid,
@@ -399,13 +403,14 @@ class SaveSampleAreaView(SaveAnnotationView):
                 )
 
                 sample_description_tile = self.save_sample_statement_tile(
-                    sample_physical_thing_resourceid, sample_description, "description"
+                    request, sample_physical_thing_resourceid, sample_description, "description"
                 )
 
-                sample_motivation_tile = self.save_sample_statement_tile(sample_physical_thing_resourceid, sample_motivation, "motivation")
+                sample_motivation_tile = self.save_sample_statement_tile(request, sample_physical_thing_resourceid, sample_motivation, "motivation")
 
                 # saving the parent physical thing area resource and tiles
                 physical_part_of_object_tile = self.save_parent_physical_thing_part_of_tile(
+                    request,
                     parent_physical_thing_resourceid,
                     sample_area_physical_thing_resourceid,
                     transaction_id,


### PR DESCRIPTION
### Before ###
In the sample taking / analysis area workflows, it was possible to have a pending transaction where all of the EditLog entries lacked a user id. For non-superusers, this would prevent deleting the workflow, because there is a check that at least one EditLog entry exists for the transaction for the user attempting the deletion.


### Now ###
The user is included with the edit log entries.

Closes #1252