### PR TITLE
Update type label in new project workflow #1234

### DIFF
--- a/afs/media/js/views/components/workflows/create-project-workflow/project-name-step.js
+++ b/afs/media/js/views/components/workflows/create-project-workflow/project-name-step.js
@@ -99,6 +99,12 @@ define([
                 return;
             }
     
+            if (!self.typeValue()) {
+                params.form.error(new Error("Missing Required Value"));
+                params.pageVm.alert(new params.form.AlertViewModel('ep-alert-red', "Missing Required Value", "Project scale is required."));
+                return;
+            }
+
             const nameTileData = {
                 "0b92cf5c-ca85-11e9-95b1-a4d18cec433a": self.nameValue(),
                 "0b92d5a3-ca85-11e9-8ea8-a4d18cec433a": null,

--- a/afs/templates/views/components/workflows/create-project-workflow/project-name-step.htm
+++ b/afs/templates/views/components/workflows/create-project-workflow/project-name-step.htm
@@ -12,7 +12,7 @@
         </div>
     </div>
     <div style="padding: 25px 60px 0px;">
-        <div class="widget-input-label">Project Activity Type</div>
+        <div class="widget-input-label">Scale of Project*</div>
         <div style="margin-top: -20px;" data-bind="component: {
             name: 'concept-radio-widget',
             params: {


### PR DESCRIPTION
**Before**
Before, in the New Project Workflow, the project type was mislabeled, see #1234.

**Now**
![Screenshot 2023-08-10 at 2 01 10 PM](https://github.com/archesproject/arches-for-science-prj/assets/38668450/d245ad76-227c-4941-8c01-996158d7b5f2)


Closes #1234