### PR TITLE
Remove `--no-use-pep517` flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY ./arches ${ARCHES_ROOT}
 # From here, run commands from ARCHES_ROOT
 WORKDIR ${ARCHES_ROOT}
 
-RUN pip install -e . --user --no-use-pep517 && pip install -r arches/install/requirements.txt && pip install -r arches/install/requirements_dev.txt
+RUN pip install -e . --user && pip install -r arches/install/requirements.txt && pip install -r arches/install/requirements_dev.txt
 
 COPY /afs/afs/install/requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/docker/webpack/Dockerfile
+++ b/docker/webpack/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get -y install curl \
   && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get install nodejs && npm install -g yarn && apt install wait-for-it
 WORKDIR ${ARCHES_ROOT}
-RUN pip install -e . --user --no-use-pep517  
+RUN pip install -e . --user
 RUN pip install -r arches/install/requirements.txt 
 RUN pip install -r arches/install/requirements_dev.txt
 COPY /afs/docker/webpack/entrypoint.sh ${WEB_ROOT}/entrypoint.sh


### PR DESCRIPTION
Multiple reporters indicated having to remove this flag in order to build.

See https://archesproject.slack.com/archives/C18GGP4RX/p1687190033094489.

@aarongundel let me know if this still builds without issue on non-Apple Silicon architectures. Thanks!