### PR TITLE
Surface backend permission error to the frontend

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/project-name-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/project-name-step.js
@@ -82,6 +82,14 @@ define([
             }).then(function(response) {
                 if (response.ok) {
                     return response.json();
+                } else {
+                    response.json()
+                    .then(data => { params.pageVm.alert(
+                        new params.form.AlertViewModel('ep-alert-red', data.title, data.message)) 
+                    })
+                    .catch(_ => { params.pageVm.alert(
+                        new params.form.AlertViewModel('ep-alert-red', 'Error saving project name')) 
+                    });
                 }
             });
         };


### PR DESCRIPTION
Fixes #1278 

Surface any backend permission error in the project name step to the frontend via an alert.

The loading spinner will continue to appear unless you also apply archesproject/arches#9981

### Demo ###
<img width="883" alt="Screenshot 2023-08-31 at 2 02 41 PM" src="https://github.com/archesproject/arches-for-science-prj/assets/38668450/f58947cb-fbbf-40f1-aaf1-febe9e08c09d">

### Testing instructions ###
1. Login as a user without permissions to add node groups
2. Attempt to use the create project workflow
3. Ensure permission error is shown
4. Loading spinner addressed in archesproject/arches#9981