### PR TITLE
Add action to run project tests #1263

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           elasticsearch-version: 8
 
+      - name: Check for missing migrations
+        working-directory: afs
+        run: |
+          PYTHONPATH="../arches" python manage.py makemigrations --check --settings=arches_for_science.test_settings
+
       - name: Run afs unit tests
         working-directory: afs
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  # push: -- just run on PRs for now
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:13-3.0
+        env:
+          POSTGRES_PASSWORD: postgis
+          POSTGRES_DB: arches
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Check out arches
+        uses: actions/checkout@v3
+        with:
+          repository: archesproject/arches
+          ref: dev/7.5.x
+          path: arches
+
+      - name: Check out afs
+        uses: actions/checkout@v2
+        with:
+          path: afs
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install afs
+        working-directory: afs
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          echo Project installed
+
+      - name: Install Java, GDAL, and other system dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install libxml2-dev libpq-dev openjdk-8-jdk libgdal-dev
+          echo Postgres and ES dependencies installed
+
+      - uses: ankane/setup-elasticsearch@v1
+        with:
+          elasticsearch-version: 8
+
+      - name: Run afs unit tests
+        working-directory: afs
+        run: |
+          PYTHONPATH="../arches" python -W default::DeprecationWarning manage.py test --settings=arches_for_science.test_settings

--- a/arches_for_science/test_settings.py
+++ b/arches_for_science/test_settings.py
@@ -3,9 +3,7 @@ import os
 # Depends on /arches being on the python path, as arches.tests is not importable
 from tests.test_settings import *
 
-INSTALLED_APPS += ("arches_for_science", "arches_templating")
-ROOT_URLCONF = "arches_for_science.urls"
-APP_NAME = "arches_for_science"
+from arches_for_science.settings import INSTALLED_APPS, ROOT_URLCONF, APP_NAME
 APP_ROOT = os.path.dirname(__file__)
 
 # Further settings may need to be added from project, just don't

--- a/arches_for_science/test_settings.py
+++ b/arches_for_science/test_settings.py
@@ -1,0 +1,13 @@
+import os
+
+# Depends on /arches being on the python path, as arches.tests is not importable
+from tests.test_settings import *
+
+INSTALLED_APPS += ("arches_for_science", "arches_templating")
+ROOT_URLCONF = "arches_for_science.urls"
+APP_NAME = "arches_for_science"
+APP_ROOT = os.path.dirname(__file__)
+
+# Further settings may need to be added from project, just don't
+# want to clobber anything from core test settings for now.
+# Also, settings can be overridden directly. See @override_settings

--- a/arches_for_science/tests.py
+++ b/arches_for_science/tests.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 from django.core.management import call_command
 
 from django.test import TestCase
@@ -9,7 +12,10 @@ from arches.app.models.models import Node, NodeGroup, ResourceInstance, Resource
 from arches.app.models.tile import Tile
 
 def setUpModule():
-    call_command("packages", "-o load_package -s arches_for_science/pkg -y".split())
+    # TODO: when py 3.11 is min (soon), we can use contextlib.chdir() context mgr
+    os.chdir(Path(__file__).parent)
+    # TODO: this command isn't using a tempdir, so it's leaving behind files
+    call_command("packages", "-o load_package -s pkg -y".split())
 
 
 class AnalysisAreaAndSampleTakingTests(TestCase):


### PR DESCRIPTION
Closes #1263

If testing locally, you may wish to add the `--keepdb` flag to avoid rebuilding your test database the next time (but then you may want to comment out the command that loads the package at the top of tests.py on that subsequent run).