### PR TITLE
Unselect sample on save #1249

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -687,6 +687,10 @@ define([
                 $.getJSON(arches.urls.api_card + self.physicalThingResourceId).then(function(data) {
                     self.loadExternalCardData(data);
                 });
+
+                // Unselect the sample so that it does not disappear when re-edited
+                // https://github.com/archesproject/arches-for-science/issues/1249
+                self.selectSampleLocationInstance(undefined);
             })
             .fail(function(error){
                 console.log(error);


### PR DESCRIPTION
In addition to fixing the underlying bug where a sample would be cleared from the canvas once reselected, this also brings the sample workflow into agreement with the analysis workflow. Now, in both workflows, on save, nothing is automatically selected.

Suggest retesting the workflow from #1249. Ensure a sample can be re-edited after saving, and that all changes persist through completion of the workflow.

Closes #1249