### PR TITLE
Fix state restoration when going backward #1314

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -88,7 +88,7 @@ define([
 
         this.value.subscribe(function(a) {
             a.forEach(function(action) {
-                if (action.status === 'added') {
+                                if (action.status === 'added') {
                     let resource;
                     if (self.dirty()) {
                         resource = ko.unwrap(self.targetResources).find(
@@ -150,10 +150,12 @@ define([
                 if (cachedValue['usedSetTileId']){
                     self.usedSetTileId(cachedValue['usedSetTileId']);
                 }
+                if (cachedValue['startValue']) {
+                    self.startValue(ko.unwrap(cachedValue['startValue']));
+                }
                 if (cachedValue["value"]){
-                    self.startValue(ko.unwrap(cachedValue["value"]));
                     self.startValue().forEach(function(val){
-                        self.value.push(val);
+                        self.value.push(val.resourceinstanceid);
                     });
                 }
             } else if (params.action === "update") {
@@ -227,6 +229,7 @@ define([
                     self.usedSetTileId(response.result.projectUsedSetTileId || ko.unwrap(self.usedSetTileId));
                     self.savedData(
                         {
+                            startValue: ko.unwrap(self.startValue),
                             value: ko.unwrap(self.value),
                             projectResourceId: ko.unwrap(self.projectResourceId),
                             collectionResourceId: ko.unwrap(self.collectionResourceId),

--- a/arches_for_science/templates/views/components/workflows/create-project-workflow/add-things-step.htm
+++ b/arches_for_science/templates/views/components/workflows/create-project-workflow/add-things-step.htm
@@ -14,7 +14,7 @@
                     <div data-bind="css: {'loading-mask': reportDataLoading}">
                         <div class="afs-project-search-result-details-container" data-bind="foreach: targetResources">
                             <div class="search-result-item" data-bind="css: {'selected-instance': $parent.value().map(function(resource){return resource}).indexOf($data['_source']['resourceinstanceid']) >= 0},
-                            click: function(){$parent.updateTileData($data['_source']['resourceinstanceid'])}">
+                            click: function(){$parent.updateTileData($data._source)}">
                                 <div style="display: inline-flex;justify-content: space-between; align-items: baseline; width: 100%;">
                                     <div class="summary-report-title" data-bind="text: $parent.getStringValue($data._source.displayname)"></div>
                                 </div>
@@ -51,15 +51,15 @@
                     <div class="wf-multi-tile-card-info">
                         <!-- <div class="workflow-step-icon complete"><span><i class="fa fa-hashtag"></i></span></div> -->
                         <div class="wf-multi-tile-card-info-details">
-                            <dt data-bind="text: $data.displayname"></dt>
+                            <dt data-bind="text: $parent.getStringValue($data.displayname)"></dt>
                             <dd>
-                                <a data-bind="html: $parent.stripTags($data.displaydescription) || 'No description'"></a>
+                                <a data-bind="html: $parent.getStringValue($data.displaydescription) || 'No description'"></a>
                             </dd>
                         </div>
                     </div>
                     <div class="wf-multi-tile-step-card-controls">
                         <span
-                            data-bind="click: function(){$parent.updateTileData($data.resourceinstanceid)}"
+                            data-bind="click: function(){$parent.updateTileData($data)}"
                         >
                             <span>
                                 <i class="fa fa-times-circle"></i>


### PR DESCRIPTION
Closes #1314

- First commit fixes the TypeError
- Second (larger commit) finishes the work from #1239 to make sure that `self.value()` is shaped like an array of resources rather than of resource ids.

This is because for state restoration to work when going backward, we can't rely on all the needed items for the selected sidebar existing in the search results--the user hasn't done a search in this case! What was happening was that the selected resources weren't appearing in the sidebar.


Testing instructions:
Test adding and deleting physical things to projects, including navigating backward. Check sidebar/UI agrees with reality. Check highlighting.