### PR TITLE
Search all languages when searching physical things #1291

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -255,6 +255,7 @@ define([
                         start: (page - 1) * limit,
                         // eslint-disable-next-line camelcase
                         page_limit: limit,
+                        lang: '*',
                         q: term
                     };
                     return data;


### PR DESCRIPTION
Fixes #1291 

Unlike some other APIs that fallback to a wildcard language search, the search_terms API falls back to the lang code in the request object. The search term index currently is not searchable by language, so until that's fixed in core arches (archesproject/arches#10061), we can restore search functionality by explicitly searching all languages.

#### Demo ####
Before, "Guernica" did not appear in the search widget
<img width="617" alt="Screenshot 2023-09-21 at 4 55 06 PM" src="https://github.com/archesproject/arches-for-science/assets/38668450/99ae2d7f-ba67-4952-9015-e64637f0c68d">

#### Caveats ####
Of course, maybe we'll just wait for archesproject/arches#10061, but I didn't make it far at all with it.