### PR TITLE
Allow toggling samples & regions in add things step UI #1378

### DIFF
--- a/arches_for_science/media/css/project.css
+++ b/arches_for_science/media/css/project.css
@@ -100,6 +100,27 @@
     padding-right: 5px;
 }
 
+.child-exclusion {
+    display: inline-flex;
+    flex-direction: row;
+    justify-content: center;
+    margin-left: 10px;
+}
+
+.child-exclusion .toggle-container {
+    padding-bottom: 0px;
+    display: inline-flex;
+}
+
+.child-exclusion .toggle-container .arches-toggle-sm {
+    margin: 0;
+    color: #888;
+}
+
+.child-exclusion .toggle-container .arches-toggle-subtitle {
+    display: none;
+}
+
 .object-search-step .search-results-footer {
     height: 55px;
     background-color: #f3f3f3;

--- a/arches_for_science/media/css/project.css
+++ b/arches_for_science/media/css/project.css
@@ -198,6 +198,10 @@
     cursor: pointer;
 }
 
+.wf-multi-tile-step-list .child {
+    margin-left: 20px;
+}
+
 .wf-multi-tile-btn-complete {
     position: absolute;
     bottom: 305px;

--- a/arches_for_science/media/css/project.css
+++ b/arches_for_science/media/css/project.css
@@ -209,6 +209,7 @@
     max-width: calc(100%);
     white-space: nowrap;
     overflow: hidden;
+    text-wrap: unset;
 }
 
 .wf-multi-tile-card-info-details dd {

--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -112,6 +112,7 @@ define([
                     });
                 }
             });
+            self.sortSelectedResources();
         }, null, "arrayChange");
 
         const loadExistingCollection = async function(){
@@ -133,6 +134,25 @@ define([
                     self.value.push(val);
                 });    
             }
+        };
+
+        this.sortSelectedResources = () => {
+            const sortedDisplayNames = self.selectedResources().map(
+                res => self.getStringValue(res.displayname)
+            ).map(val => val.toLowerCase()).sort();
+
+            const resourceSortFn = (a, b) => {
+                const aIndex = sortedDisplayNames.indexOf(self.getStringValue(a.displayname).toLowerCase());
+                const bIndex = sortedDisplayNames.indexOf(self.getStringValue(b.displayname).toLowerCase());
+                if (aIndex < bIndex) {
+                    return -1;
+                } else if (aIndex === bIndex) {
+                    return 0;
+                }
+                return 1;
+            };
+            this.selectedResources().sort(resourceSortFn);
+            this.selectedResources.valueHasMutated();
         };
 
         this.initialize = function(){

--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -429,6 +429,13 @@ define([
             self.updateSearchResults(self.termFilter(), query['paging-filter']);
         });
 
+        this.includeSamples.subscribe(function(val) {
+            self.updateSearchResults(self.termFilter());
+        });
+        this.includeAnalysisAreas.subscribe(function(val) {
+            self.updateSearchResults(self.termFilter());
+        });
+
         this.initialize();
 
         this.stripTags = (original) => {

--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -156,7 +156,7 @@ define([
 
             // Then, reorder child physical things under parents.
             const sortedParents = this.selectedResources().filter(resource =>
-                !Object.values(self.childPhysicalThingValue).includes(self.getChildPhysicalThingType(resource))
+                !self.resourceIsSampleOrAnalysis(resource)
             );
             const childrenByParentResourceId = {};
             for (const child of this.selectedResources().filter(r => !sortedParents.includes(r))) {
@@ -502,7 +502,11 @@ define([
         this.getChildPhysicalThingType = (resource) => {
             return resource.tiles.find(tile => tile.data[self.physicalThingTypeNodeId] !== undefined)
             ?.data?.[this.physicalThingTypeNodeId]?.[0];
-        }
+        };
+
+        this.resourceIsSampleOrAnalysis = (resource) => {
+            return Object.values(self.childPhysicalThingValue).includes(self.getChildPhysicalThingType(resource));
+        };
     }
 
     ko.components.register('add-things-step', {

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -343,7 +343,7 @@ define([
                 }
             }
 
-            const tilesBelongingToManifest = this.tilesBelongingToManifest(self.card.tiles(), self.canvases());
+            const tilesBelongingToManifest = this.tilesBelongingToManifest(self.card.tiles());
             tilesBelongingToManifest.forEach(tile => tile.samplingActivityResourceId = tile.samplingActivityResourceId ? tile.samplingActivityResourceId : ko.observable());
             self.sampleLocationInstances(tilesBelongingToManifest);
         };

--- a/arches_for_science/templates/views/components/workflows/create-project-workflow/add-things-step.htm
+++ b/arches_for_science/templates/views/components/workflows/create-project-workflow/add-things-step.htm
@@ -6,6 +6,34 @@
         <div class="workflow-search-count">
             <div class="count-number" data-bind="text: totalResults()"></div><div>Physical Things</div>
         </div>
+        <div class="child-exclusion">
+            <div
+            data-bind="
+                component: {
+                    name: 'views/components/simple-switch',
+                    params: {
+                        value: includeSamples,
+                        config: {
+                            label: 'Include samples',
+                        }
+                    }
+                }
+            "
+            ></div>
+            <div
+                data-bind="
+                    component: {
+                        name: 'views/components/simple-switch',
+                        params: {
+                            value: includeAnalysisAreas,
+                            config: {
+                                label: 'Include analysis areas',
+                            }
+                        }
+                    }
+                "
+            ></div>
+        </div>
     </div>
     <div class="workflow-search-results">
         <div class="workflow-search-results-full-container">

--- a/arches_for_science/templates/views/components/workflows/create-project-workflow/add-things-step.htm
+++ b/arches_for_science/templates/views/components/workflows/create-project-workflow/add-things-step.htm
@@ -76,7 +76,7 @@
                 </div>
                 <!--/ko -->
                 <!-- ko foreach: selectedResources -->
-                <div class="wf-multi-tile-step-card" >
+                <div class="wf-multi-tile-step-card" data-bind="css: { child: $parent.resourceIsSampleOrAnalysis($data) }">
                     <div class="wf-multi-tile-card-info">
                         <!-- <div class="workflow-step-icon complete"><span><i class="fa fa-hashtag"></i></span></div> -->
                         <div class="wf-multi-tile-card-info-details">


### PR DESCRIPTION
Closes #1378

- Add toggles for filtering samples/analysis areas out of search results
- Sort collection in sidebar alphabetically by parent
- Group and indent children under parent

### Demo ###
![Screenshot 2023-10-26 at 12 02 01 PM](https://github.com/archesproject/arches-for-science/assets/38668450/697a1ff5-22dc-4199-8f5f-d20e326c22ff)

