### PR TITLE
Prevent annotations from vanishing when toggling or canceling #1321

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -428,8 +428,13 @@ define([
                 if(response.ok){
                     return;
                 }
-                
-                throw response;
+                response.json().then(function(error){
+                    params.pageVm.alert(new params.form.AlertViewModel(
+                        "ep-alert-red",
+                        error.title,
+                        error.message,
+                    ));
+                });
             }).then(function(data){
                 parentPhysicalThing.data[physicalThingPartAnnotationNodeId].features().forEach(function(feature){
                     self.deleteFeature(feature);
@@ -438,14 +443,6 @@ define([
                 self.card.tiles.remove(parentPhysicalThing);
                 self.selectAnalysisAreaInstance(undefined);
                 self.resetAnalysisAreasTile();
-            }).catch((response) => {
-                response.json().then(function(error){
-                    params.pageVm.alert(new params.form.AlertViewModel(
-                        "ep-alert-red",
-                        error.title,
-                        error.message,
-                    )); 
-                });
             });
         };
 

--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -255,13 +255,18 @@ define([
 
         this.resetCanvasFeatures = function() {
             var annotationNodes = self.annotationNodes();
-            
+
+            var physicalThingAnnotationNodeName = "Analysis Areas";
+            var physicalThingAnnotationNode = annotationNodes.find(function(annotationNode) {
+                return annotationNode.name === physicalThingAnnotationNodeName;
+            });
+
+            if (self.hasExternalCardData()) {
+                savedFeatures = self.form.savedData().data.map(ann => ann.data[physicalThingPartAnnotationNodeId].features[0]);
+                physicalThingAnnotationNode.annotations(savedFeatures);
+                self.updateAnalysisAreaInstances();
+            }
             if (self.selectedAnalysisAreaInstanceFeatures()) {
-                var physicalThingAnnotationNodeName = "Analysis Areas";
-                var physicalThingAnnotationNode = annotationNodes.find(function(annotationNode) {
-                    return annotationNode.name === physicalThingAnnotationNodeName;
-                });
-    
                 var physicalThingAnnotationNodeAnnotationIds = physicalThingAnnotationNode.annotations().map(function(annotation) {
                     return ko.unwrap(annotation.id);
                 });
@@ -276,14 +281,13 @@ define([
                 }, []);
     
                 physicalThingAnnotationNode.annotations([...physicalThingAnnotationNode.annotations(), ...unaddedSelectedAnalysisAreaInstanceFeatures]);
-    
-                var physicalThingAnnotationNodeIndex = annotationNodes.findIndex(function(annotationNode) {
-                    return annotationNode.name === physicalThingAnnotationNodeName;
-                });
-    
-                annotationNodes[physicalThingAnnotationNodeIndex] = physicalThingAnnotationNode;
             }
 
+            var physicalThingAnnotationNodeIndex = annotationNodes.findIndex(function(annotationNode) {
+                return annotationNode.name === physicalThingAnnotationNodeName;
+            });
+
+            annotationNodes[physicalThingAnnotationNodeIndex] = physicalThingAnnotationNode;
             self.annotationNodes(annotationNodes);
         };
 
@@ -781,7 +785,10 @@ define([
                                     self.selectAnalysisAreaInstance(analysisAreaInstance);
                                 }
                                 else {
-                                    self.tile.reset();
+                                    if (!self.hasExternalCardData()) {
+                                        // If there is external (saved) card data, let resetCanvasFeatures() handle it.
+                                        self.tile.reset();
+                                    }
                                     self.resetCanvasFeatures();
     
                                     var selectedFeature = ko.toJS(self.selectedAnalysisAreaInstanceFeatures().find(function(selectedAnalysisAreaInstanceFeature) {

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -273,13 +273,20 @@ define([
 
         this.resetCanvasFeatures = function() {
             var annotationNodes = self.annotationNodes();
-            
+
+            var physicalThingAnnotationNodeName = "Sample Locations";
+            var physicalThingAnnotationNode = annotationNodes.find(function(annotationNode) {
+                return annotationNode.name === physicalThingAnnotationNodeName;
+            });
+
+            if (self.hasExternalCardData()) {
+                // NB: not exactly the same as analysis area, need to drill into savedData()[0]
+                savedFeatures = self.form.savedData()[0].data.map(ann => ann.data[physicalThingPartAnnotationNodeId].features[0]);
+                physicalThingAnnotationNode.annotations(savedFeatures);
+                self.updateAnalysisAreaInstances();
+            }
+
             if (self.selectedSampleLocationInstanceFeatures()) {
-                var physicalThingAnnotationNodeName = "Sample Locations";
-                var physicalThingAnnotationNode = annotationNodes.find(function(annotationNode) {
-                    return annotationNode.name === physicalThingAnnotationNodeName;
-                });
-    
                 var physicalThingAnnotationNodeAnnotationIds = physicalThingAnnotationNode.annotations().map(function(annotation) {
                     return ko.unwrap(annotation.id);
                 });
@@ -295,14 +302,13 @@ define([
                 }, []);
     
                 physicalThingAnnotationNode.annotations([...physicalThingAnnotationNode.annotations(), ...unaddedSelectedSampleLocationInstanceFeatures]);
-    
-                var physicalThingAnnotationNodeIndex = annotationNodes.findIndex(function(annotationNode) {
-                    return annotationNode.name === physicalThingAnnotationNodeName;
-                });
-    
-                annotationNodes[physicalThingAnnotationNodeIndex] = physicalThingAnnotationNode;
             }
 
+            var physicalThingAnnotationNodeIndex = annotationNodes.findIndex(function(annotationNode) {
+                return annotationNode.name === physicalThingAnnotationNodeName;
+            });
+
+            annotationNodes[physicalThingAnnotationNodeIndex] = physicalThingAnnotationNode;
             self.annotationNodes(annotationNodes);
         };
 
@@ -926,7 +932,10 @@ define([
                                     self.selectSampleLocationInstance(sampleLocationInstance);
                                 }
                                 else {
-                                    self.tile.reset();
+                                    if (!self.hasExternalCardData()) {
+                                        // If there is external (saved) card data, let resetCanvasFeatures() handle it.
+                                        self.tile.reset();
+                                    }
                                     self.resetCanvasFeatures();
     
                                     const selectedFeature = ko.toJS(self.selectedSampleLocationInstanceFeatures().find(function(selectedSampleLocationInstanceFeature) {

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -1106,12 +1106,12 @@ define([
                 /* END update canvas */ 
 
                 if (self.form.savedData()) {
-                    self.form.savedData({
-                        ...self.form.savedData(),
-                        data: self.form.savedData().data.filter(
+                    // NB: unlike analysis area, savedData is shaped as an array.
+                    self.form.savedData(
+                        self.form.savedData().filter(
                             ann => ann.data[physicalThingPartAnnotationNodeId].features[0].id !== feature.id()
-                        ),
-                    });
+                        )
+                    );
                 }
             }
 

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -282,7 +282,7 @@ define([
             if (self.form.savedData()) {
                 savedFeatures = self.form.savedData().map(ann => ann.data[physicalThingPartAnnotationNodeId].features[0]);
                 physicalThingAnnotationNode.annotations(savedFeatures);
-                self.updateAnalysisAreaInstances(optionalNewInstance);
+                self.updateSampleLocationInstances(optionalNewInstance);
             }
 
             if (self.selectedSampleLocationInstanceFeatures()) {

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -280,8 +280,7 @@ define([
             });
 
             if (self.form.savedData()) {
-                // NB: not exactly the same as analysis area, need to drill into savedData()[0]
-                savedFeatures = self.form.savedData()[0].data.map(ann => ann.data[physicalThingPartAnnotationNodeId].features[0]);
+                savedFeatures = self.form.savedData().map(ann => ann.data[physicalThingPartAnnotationNodeId].features[0]);
                 physicalThingAnnotationNode.annotations(savedFeatures);
                 self.updateAnalysisAreaInstances(optionalNewInstance);
             }

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -696,7 +696,7 @@ define([
                     self.savingTile(false);
                     params.dirty(false);
                     let mappedInstances = self.sampleLocationInstances().map((instance) => { return { "data": instance.data }});
-                    params.form.savedData(mappedInstances);
+                    params.form.savedData(ko.toJS(mappedInstances));
                     params.form.value(params.form.savedData());
                     params.pageVm.alert("");
                     self.drawFeatures([]);

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -540,8 +540,13 @@ define([
                 if(response.ok){
                     return;
                 }
-                
-                throw response;
+                response.json().then(function(error){
+                    params.pageVm.alert(new params.form.AlertViewModel(
+                        "ep-alert-red",
+                        error.title,
+                        error.message,
+                    )); 
+                });
             })
             .then(function(data){
                 selectedSampleLocationInstance.data[physicalThingPartAnnotationNodeId].features().forEach(function(feature){
@@ -551,15 +556,6 @@ define([
                 self.card.tiles.remove(selectedSampleLocationInstance);
                 self.selectSampleLocationInstance(undefined);
                 self.resetSampleLocationTile();
-            })
-            .catch((response) => {
-                response.json().then(function(error){
-                    params.pageVm.alert(new params.form.AlertViewModel(
-                        "ep-alert-red",
-                        error.title,
-                        error.message,
-                    )); 
-                });
             });
         }
 


### PR DESCRIPTION
Fixes #1321

Before, upon creating n>=2 analysis (or sample) area annotations, two scenarios caused a shape to vanish from the canvas (but not from the sidebar).

1 - Click twice on feature 1 to get edit controls. Deselect it. Result: feature 1 disappears

2 - With feature 2 selected, click Cancel.
Result: feature 2 disappears

Fixing this almost caused a regression in this workflow, so it should be tested also:
1. Save shape 1
2. Save shape 2
3. Select shape 1, make edits, save.
4. Select shape 2
5. Select shape 1 (Result: shape 1 morphs into the first saved state, not the second.)

This was avoided by skipping a tile.reset() call. Worth some thought whether that's okay.

Another issue was almost caused when deleting annotations, so that's worth testing too.