### PR TITLE
Disable save and cancel buttons in sample/analysis workflows #1347

### DIFF
--- a/arches_for_science/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.htm
+++ b/arches_for_science/templates/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.htm
@@ -447,14 +447,14 @@
 <div class="workbench-button-panel">
     <button 
         class="btn btn-success" 
-        data-bind="click: $data.saveAnalysisAreaTile, css: {disabled: !$data.tileDirty()}""
+        data-bind="click: $data.saveAnalysisAreaTile, css: {disabled: !$data.tileDirty()}, attr: {disabled: !$data.tileDirty()}"
     >
         <i class="ion-android-cloud-done"></i>
         <span>{% trans 'Save' %}</span>
     </button>
     <button 
         class="btn btn-danger" 
-        data-bind="click: $data.resetAnalysisAreasTile, css: {disabled: !$data.tileDirty()}"
+        data-bind="click: $data.resetAnalysisAreasTile, css: {disabled: !$data.tileDirty()}, attr: {disabled: !$data.tileDirty()}"
     >
         <i class="ion-android-cancel}"></i>
         <span>{% trans 'Cancel' %}</span>

--- a/arches_for_science/templates/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.htm
+++ b/arches_for_science/templates/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.htm
@@ -418,14 +418,14 @@
     <div class="workbench-button-panel">
         <button 
             class="btn btn-success" 
-            data-bind="click: $data.saveSampleLocationTile, css: {disabled: !$data.tileDirty()}"
+            data-bind="click: $data.saveSampleLocationTile, css: {disabled: !$data.tileDirty()}, attr: {disabled: !$data.tileDirty()}"
         >
             <i class="ion-android-cloud-done"></i>
             <span style="padding-left: 4px">{% trans 'Save' %}</span>
         </button>
         <button 
             class="btn btn-danger" 
-            data-bind="click: $data.resetSampleLocationTile, css: {disabled: !$data.tileDirty()}"
+            data-bind="click: $data.resetSampleLocationTile, css: {disabled: !$data.tileDirty()}, attr: {disabled: !$data.tileDirty()}"
         >
             <i class="ion-android-cancel"></i>
             <span style="padding-left: 4px">{% trans 'Cancel' %}</span>


### PR DESCRIPTION
Before, the save & cancel buttons were styled as disabled but not disabled in fact.

Fixes #1347