### PR TITLE
Fix highlighting of resource instances #1356

### DIFF
--- a/arches_for_science/templates/views/components/workflows/create-project-workflow/add-things-step.htm
+++ b/arches_for_science/templates/views/components/workflows/create-project-workflow/add-things-step.htm
@@ -13,7 +13,8 @@
                 <div class="workflow-search-list search-result-details">
                     <div data-bind="css: {'loading-mask': reportDataLoading}">
                         <div class="afs-project-search-result-details-container" data-bind="foreach: targetResources">
-                            <div class="search-result-item" data-bind="css: {'selected-instance': $parent.value().map(function(resource){return resource}).indexOf($data['_source']['resourceinstanceid']) >= 0},
+                            <div class="search-result-item" data-bind="css: {'selected-instance': $parent.value().findIndex(
+                                res => res.resourceinstanceid === $data['_source']['resourceinstanceid']) >= 0},
                             click: function(){$parent.updateTileData($data._source)}">
                                 <div style="display: inline-flex;justify-content: space-between; align-items: baseline; width: 100%;">
                                     <div class="summary-report-title" data-bind="text: $parent.getStringValue($data._source.displayname)"></div>


### PR DESCRIPTION
Closes #1356
Regression in 3e3bd2a.

(Missed this in the template when refactoring the form values in the viewmodel to be shaped like resource objects, rather than lists of resource ids.)