### PR TITLE
Prevent annotations from vanishing when toggling or canceling #1321

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -268,7 +268,7 @@ define([
                 
                 var unaddedSelectedAnalysisAreaInstanceFeatures = self.selectedAnalysisAreaInstanceFeatures().reduce(function(acc, feature) {
                     if (!physicalThingAnnotationNodeAnnotationIds.includes(ko.unwrap(feature.id)) &&
-                        feature.properties.canvas === self.canvas) {
+                        ko.unwrap(feature.properties.canvas) === ko.unwrap(self.canvas)) {
                         feature.properties.tileId = self.selectedAnalysisAreaInstance().tileid;
                         acc.push(ko.toJS(feature));
                     }

--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -424,8 +424,13 @@ define([
                 if(response.ok){
                     return;
                 }
-                
-                throw response;
+                response.json().then(function(error){
+                    params.pageVm.alert(new params.form.AlertViewModel(
+                        "ep-alert-red",
+                        error.title,
+                        error.message,
+                    ));
+                });
             }).then(function(data){
                 parentPhysicalThing.data[physicalThingPartAnnotationNodeId].features().forEach(function(feature){
                     self.deleteFeature(feature);
@@ -434,14 +439,6 @@ define([
                 self.card.tiles.remove(parentPhysicalThing);
                 self.selectAnalysisAreaInstance(undefined);
                 self.resetAnalysisAreasTile();
-            }).catch((response) => {
-                response.json().then(function(error){
-                    params.pageVm.alert(new params.form.AlertViewModel(
-                        "ep-alert-red",
-                        error.title,
-                        error.message,
-                    )); 
-                });
             });
         };
 

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -534,8 +534,13 @@ define([
                 if(response.ok){
                     return;
                 }
-                
-                throw response;
+                response.json().then(function(error){
+                    params.pageVm.alert(new params.form.AlertViewModel(
+                        "ep-alert-red",
+                        error.title,
+                        error.message,
+                    )); 
+                });
             })
             .then(function(data){
                 selectedSampleLocationInstance.data[physicalThingPartAnnotationNodeId].features().forEach(function(feature){
@@ -545,15 +550,6 @@ define([
                 self.card.tiles.remove(selectedSampleLocationInstance);
                 self.selectSampleLocationInstance(undefined);
                 self.resetSampleLocationTile();
-            })
-            .catch((response) => {
-                response.json().then(function(error){
-                    params.pageVm.alert(new params.form.AlertViewModel(
-                        "ep-alert-red",
-                        error.title,
-                        error.message,
-                    )); 
-                });
             });
         }
 

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -286,7 +286,7 @@ define([
                 
                 var unaddedSelectedSampleLocationInstanceFeatures = self.selectedSampleLocationInstanceFeatures().reduce(function(acc, feature) {
                     if (!physicalThingAnnotationNodeAnnotationIds.includes(ko.unwrap(feature.id)) &&
-                        feature.properties.canvas === self.canvas) {
+                        ko.unwrap(feature.properties.canvas) === ko.unwrap(self.canvas)) {
                         feature.properties.tileId = self.selectedSampleLocationInstance().tileid;
                         acc.push(ko.toJS(feature));
                     }


### PR DESCRIPTION
Fixes #1321
Supersedes #1351 (found the root cause this time!)

Brought over the not-strictly-related-but-helpful fix 89f6832d9f45f0a702dbadf706b20b7bd3fd47be for error handling to prevent "response.json is not a function".

Opened a separate issue (#1360) for the "morphing edits" bug I thought I was causing on the other PR; repro'd on 1.1.x.