### PR TITLE
Add error handling to project name step #1354

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/project-name-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/project-name-step.js
@@ -83,7 +83,7 @@ define([
                         new params.form.AlertViewModel('ep-alert-red', data.title, data.message)) 
                     })
                     .catch(_ => { params.pageVm.alert(
-                        new params.form.AlertViewModel('ep-alert-red', 'Error saving project name')) 
+                        new params.form.AlertViewModel('ep-alert-red', params.form.error() || 'Error saving project name')) 
                     });
                 }
             });

--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/project-name-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/project-name-step.js
@@ -130,16 +130,24 @@ define([
 
             return self.saveTile(nameTileData, nameNodeGroupId, self.projectResourceId(), nameTileId())
                 .then(function(data) {
-                    nameTileId(data.tileid);
-                    self.projectResourceId(data.resourceinstance_id);
-                    return self.saveTile(typeTileData, typeNodeGroupId, data.resourceinstance_id, typeTileId());
+                    if (data) {
+                        nameTileId(data.tileid);
+                        self.projectResourceId(data.resourceinstance_id);
+                        return self.saveTile(typeTileData, typeNodeGroupId, data.resourceinstance_id, typeTileId());
+                    } else {
+                        params.form.error('Error saving project name');
+                    }
                 })
                 .then(function(data) {
-                    typeTileId(data.tileid);
-                    params.form.savedData(params.form.value());
-                    params.form.complete(true);
-                    params.form.dirty(false);
-                    params.pageVm.alert("");
+                    if (data) {
+                        typeTileId(data.tileid);
+                        params.form.savedData(params.form.value());
+                        params.form.complete(true);
+                        params.form.dirty(false);
+                        params.pageVm.alert("");
+                    } else {
+                        params.form.error('Error saving project type');
+                    }
                 });
         };
     }


### PR DESCRIPTION
Closes #1354 (well, in a way...)

**Before**
In #1354, the video shows a TileValidationError causing the new project workflow to skip from step 1 to step 3 (or as many steps as errors you caused). Since #1340 was merged, to reproduce it, you need to throw a TileValidationError or some other backend error somewhere in tile.py.

**After**
Now, by setting params.form.error(), we ensure that the promise is rejected. Here is the subscription to `params.form.error`, where it runs `componentBasedStepReject`:

https://github.com/archesproject/arches/blob/d084723fd602d81cc88f357162878fc27e5a069c/arches/app/media/js/views/components/workflows/workflow-component-abstract.js#L811-L816

**Next steps**
Maybe we should audit the other workflow steps for this pattern?