### PR TITLE
Fix sample deletion #1405

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -437,7 +437,9 @@ define([
                 });
                 self.analysisAreaInstances.remove(parentPhysicalThing);
                 self.card.tiles.remove(parentPhysicalThing);
-                self.selectAnalysisAreaInstance(undefined);
+                // Clear the selectedAnalysisAreaInstance directly rather than via
+                // selectAnalysisAreaInstance() to avoid adding it back to the canvas.
+                self.selectedAnalysisAreaInstance(undefined);
                 self.resetAnalysisAreasTile();
             });
         };

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -548,7 +548,9 @@ define([
                 });
                 self.sampleLocationInstances.remove(selectedSampleLocationInstance);
                 self.card.tiles.remove(selectedSampleLocationInstance);
-                self.selectSampleLocationInstance(undefined);
+                // Clear the selectedSampleLocationInstance directly rather than via
+                // selectSampleLocationInstance() to avoid adding it back to the canvas.
+                self.selectedSampleLocationInstance(undefined);
                 self.resetSampleLocationTile();
             });
         }


### PR DESCRIPTION
Before, deleting a sample that is selected (e.g. because it had just been saved) would take effect on the tile but not clear itself from the canvas.

***Testing instructions***
- [ ] deletion of samples/analyses takes effect on the canvas immediately
- [ ] saving, manipulating still works, no shapes get respawned onto the canvas out of nowhere

Closes #1405