### PR TITLE
Fix second edit morphing back to first edit #1360

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -778,7 +778,6 @@ define([
                                     self.selectAnalysisAreaInstance(analysisAreaInstance);
                                 }
                                 else {
-                                    self.tile.reset();
                                     self.resetCanvasFeatures();
     
                                     var selectedFeature = ko.toJS(self.selectedAnalysisAreaInstanceFeatures().find(function(selectedAnalysisAreaInstanceFeature) {

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -922,7 +922,6 @@ define([
                                     self.selectSampleLocationInstance(sampleLocationInstance);
                                 }
                                 else {
-                                    self.tile.reset();
                                     self.resetCanvasFeatures();
     
                                     const selectedFeature = ko.toJS(self.selectedSampleLocationInstanceFeatures().find(function(selectedSampleLocationInstanceFeature) {


### PR DESCRIPTION
Fixes #1360: where attempting a third edit on sample or analysis shape would (if you're having to reselect it) morph the second saved state back into the first state.

The `tile.reset()` call  removed in this PR was doing the morphing. I don't see any other breakages if I just remove it, but this should be tested.

I believe the resetting we want when toggling to other shapes, in other words, the desired discarding of an abandoned edit, is still occurring because of this:

https://github.com/archesproject/arches-for-science/blob/186cb21da351b057d603a1ab0814328b49baf1c4/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js#L446-L456