### PR TITLE
Fix sample/analysis name validation

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -448,7 +448,7 @@ define([
             const annotationLabelNodeid = "3e541cc6-859b-11ea-97eb-acde48001122";
             const annotationPolygonIdentifierNodeid = "97c30c42-8594-11ea-97eb-acde48001122";
             
-            if (!ko.unwrap(self.selectedAnalysisAreaInstance().data[annotationLabelNodeid])) {
+            if (!ko.unwrap(self.selectedAnalysisAreaInstance().data[annotationLabelNodeid]?.[arches.activeLanguage]?.value)) {
                 params.pageVm.alert(new params.form.AlertViewModel('ep-alert-red', "Name required", "Providing a name is required"));
                 return;
             }

--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -567,7 +567,11 @@ define([
                     params.form.value(params.form.savedData());
                 });
             }).fail(function(error){
-                console.log(error);
+                params.pageVm.alert(new params.form.AlertViewModel(
+                    "ep-alert-red",
+                    error.responseJSON.result.title,
+                    error.responseJSON.result.message,
+                ));
                 self.savingTile(false);
             });
         };

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -698,7 +698,11 @@ define([
                 self.selectSampleLocationInstance(undefined);
             })
             .fail(function(error){
-                console.log(error);
+                params.pageVm.alert(new params.form.AlertViewModel(
+                    "ep-alert-red",
+                    error.responseJSON.result.title,
+                    error.responseJSON.result.message,
+                ));
                 self.savingTile(false);                
             })
         };

--- a/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
+++ b/arches_for_science/media/js/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.js
@@ -562,8 +562,9 @@ define([
             var partIdentifierAssignmentLabelNodeId = '3e541cc6-859b-11ea-97eb-acde48001122';
             var partIdentifierAssignmentPolygonIdentifierNodeId = "97c30c42-8594-11ea-97eb-acde48001122"
             const featureCollection = ko.unwrap(self.selectedSampleLocationInstance().data[partIdentifierAssignmentPolygonIdentifierNodeId])
-            if (!ko.unwrap(featureCollection?.features)?.length ||
-                (!ko.unwrap(ko.unwrap(self.selectedSampleLocationInstance().data[partIdentifierAssignmentLabelNodeId])?.[arches.activeLanguage]?.value) && !ko.unwrap(self.selectedSampleLocationInstance().data[partIdentifierAssignmentLabelNodeId])) ) { //Sample Name Node
+            if (!ko.unwrap(featureCollection?.features)?.length ||  // Sample location
+                !ko.unwrap(ko.unwrap(self.selectedSampleLocationInstance().data[partIdentifierAssignmentLabelNodeId])?.[arches.activeLanguage]?.value)  // Sample name
+            ) {
                 params.pageVm.alert(new params.form.AlertViewModel(
                     "ep-alert-red",
                     "Missing Values",


### PR DESCRIPTION
- Fix client-side validation of sample and analysis names
- Surface server errors that might get through anyway

Closes #1419

The fact that empty key-value pairs like `{ value: '', direction: '' }` are truthy was causing issues.