### PR TITLE
Improve undo action in instrument info steps #1428

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/chemical-analysis-workflow/ca-instrument-info-step.js
+++ b/arches_for_science/media/js/views/components/workflows/chemical-analysis-workflow/ca-instrument-info-step.js
@@ -49,7 +49,7 @@ define([
         let procedureTileId = getProp('procedure', 'tileid');
         let projectTileId = getProp('project', 'tileid');
         let observedThingTileid = getProp('observedThing', 'tileid');
-        let observationTypeTileId = getProp('type', 'tileid');
+        let observationTypeTileId = getProp('observationType', 'tileid');
         let dateTileId = getProp('date', 'tileid');
         let nameTileId = getProp('name', 'tileid');
 
@@ -67,6 +67,7 @@ define([
 
         const snapshot = {
             dateValue: self.dateValue(),
+            observationType: self.observationType(),
             instrumentValue: self.instrumentValue(),
             procedureValue: self.procedureValue(),
             parameterValue: self.parameterValue()
@@ -99,6 +100,10 @@ define([
                     self.instrumentName(data._source.displayname);
                     self.nameValue(`Observation of ${physThingName} with ${data._source.displayname} ${self.dateValue()}`);
                 });
+            }
+            if (!val) {
+                self.instrumentName(null);
+                self.nameValue(null);
             }
         });
 
@@ -169,12 +174,12 @@ define([
         };
 
         params.form.reset = function(){
-            self.nameValue(null);
-            self.instrumentName(null);
-            self.dateValue(snapshot.dateValue);
+            self.observationType(snapshot.observationType);
             self.instrumentValue(snapshot.instrumentValue);
             self.procedureValue(snapshot.procedureValue);
             self.parameterValue(snapshot.parameterValue);
+            // Must run after instrument update, reads instrumentName()
+            self.dateValue(snapshot.dateValue);
         };
 
         this.saveTextualWorkType = function(){

--- a/arches_for_science/media/js/views/components/workflows/chemical-analysis-workflow/ca-instrument-info-step.js
+++ b/arches_for_science/media/js/views/components/workflows/chemical-analysis-workflow/ca-instrument-info-step.js
@@ -128,6 +128,10 @@ define([
             };
         });
 
+        if (!params.form.savedData()) {
+            params.form.savedData(this.updatedValue());
+        };
+
         this.updatedValue.subscribe(function(val){
             params.value(val);
         });
@@ -165,10 +169,12 @@ define([
         };
 
         params.form.reset = function(){
+            self.nameValue(null);
+            self.instrumentName(null);
+            self.dateValue(snapshot.dateValue);
             self.instrumentValue(snapshot.instrumentValue);
             self.procedureValue(snapshot.procedureValue);
             self.parameterValue(snapshot.parameterValue);
-            params.form.hasUnsavedData(false);
         };
 
         this.saveTextualWorkType = function(){

--- a/arches_for_science/media/js/views/components/workflows/chemical-analysis-workflow/ca-instrument-info-step.js
+++ b/arches_for_science/media/js/views/components/workflows/chemical-analysis-workflow/ca-instrument-info-step.js
@@ -119,8 +119,17 @@ define([
             }
         });
 
+        this.isEmpty = obj => {
+            return Object.values(obj).every(
+                val => val === null ||
+                Object.values(val).every(
+                    innerVal => innerVal === null || innerVal instanceof Array && innerVal.length === 0
+                )
+            )
+        };
+
         this.updatedValue = ko.pureComputed(function(){
-            return {
+            const updated = {
                 instrument: {value: self.instrumentValue(), tileid: instrumentTileId},
                 procedure: {value: self.procedureValue(), tileid: procedureTileId},
                 parameter: {value: self.parameterValue(), tileid: parameterTileId},
@@ -131,11 +140,15 @@ define([
                 observationType: {value: self.observationType(), tileid: observationTypeTileId},
                 observationInstanceId: self.observationInstanceId()
             };
+            if (self.isEmpty(updated)) {
+                return undefined;  // null would trigger dirty state, i.e. null !== undefined
+            }
+            return updated;
         });
 
         if (!params.form.savedData()) {
             params.form.savedData(this.updatedValue());
-        };
+        }
 
         this.updatedValue.subscribe(function(val){
             params.value(val);

--- a/arches_for_science/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
+++ b/arches_for_science/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
@@ -128,8 +128,17 @@ define([
             }
         });
 
+        this.isEmpty = obj => {
+            return Object.values(obj).every(
+                val => val === null ||
+                Object.values(val).every(
+                    innerVal => innerVal === null || innerVal instanceof Array && innerVal.length === 0
+                )
+            )
+        };
+
         this.updatedValue = ko.pureComputed(function(){
-            return {
+            const updated = {
                 instrument: {value: self.instrumentValue(), tileid: instrumentTileId},
                 procedure: {value: self.procedureValue(), tileid: procedureTileId},
                 parameter: {value: self.parameterValue(), tileid: parameterTileId},
@@ -140,11 +149,15 @@ define([
                 observationType: {value: self.observationType(), tileid: observationTypeTileId},
                 observationInstanceId: self.observationInstanceId()
             };
+            if (self.isEmpty(updated)) {
+                return undefined;  // null would trigger dirty state, i.e. null !== undefined
+            }
+            return updated;
         });
 
         if (!params.form.savedData()) {
             params.form.savedData(this.updatedValue());
-        };
+        }
 
         this.updatedValue.subscribe(function(val){
             params.value(val);

--- a/arches_for_science/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
+++ b/arches_for_science/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
@@ -137,6 +137,10 @@ define([
             };
         });
 
+        if (!params.form.savedData()) {
+            params.form.savedData(this.updatedValue());
+        };
+
         this.updatedValue.subscribe(function(val){
             params.value(val);
         });
@@ -174,10 +178,12 @@ define([
         };
 
         params.form.reset = function(){
+            self.nameValue(null);
+            self.instrumentName(null);
+            self.dateValue(snapshot.dateValue);
             self.instrumentValue(snapshot.instrumentValue);
             self.procedureValue(snapshot.procedureValue);
             self.parameterValue(snapshot.parameterValue);
-            params.form.hasUnsavedData(false);
         };
 
         this.saveTextualWorkType = function(){

--- a/arches_for_science/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
+++ b/arches_for_science/media/js/views/components/workflows/upload-dataset/instrument-info-step.js
@@ -58,7 +58,7 @@ define([
         let procedureTileId = getProp('procedure', 'tileid');
         let projectTileId = getProp('project', 'tileid');
         let observedThingTileid = getProp('observedThing', 'tileid');
-        let observationTypeTileId = getProp('type', 'tileid');
+        let observationTypeTileId = getProp('observationType', 'tileid');
         let dateTileId = getProp('date', 'tileid');
         let nameTileId = getProp('name', 'tileid');
 
@@ -76,6 +76,7 @@ define([
 
         const snapshot = {
             dateValue: self.dateValue(),
+            observationType: self.observationType(),
             instrumentValue: self.instrumentValue(),
             procedureValue: self.procedureValue(),
             parameterValue: self.parameterValue()
@@ -108,6 +109,10 @@ define([
                     self.instrumentName(data._source.displayname);
                     self.nameValue(`Observation of ${physThingName} with ${data._source.displayname} ${self.dateValue()}`);
                 });
+            }
+            if (!val) {
+                self.instrumentName(null);
+                self.nameValue(null);
             }
         });
 
@@ -178,12 +183,12 @@ define([
         };
 
         params.form.reset = function(){
-            self.nameValue(null);
-            self.instrumentName(null);
-            self.dateValue(snapshot.dateValue);
+            self.observationType(snapshot.observationType);
             self.instrumentValue(snapshot.instrumentValue);
             self.procedureValue(snapshot.procedureValue);
             self.parameterValue(snapshot.parameterValue);
+            // Must run after instrument update, reads instrumentName()
+            self.dateValue(snapshot.dateValue);
         };
 
         this.saveTextualWorkType = function(){


### PR DESCRIPTION
Fixes #1428

- Fixes "cannot write to ko.computed"
- Fixes Undo button still showing active after using it to clear
- Allows clearing date entries with Undo

- Fixes observation type cannot be cleared with undo button (#1475)