### PR TITLE
Grab bag of fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,13 @@ jobs:
           pip install .
           echo Project installed
 
+      - name: Install arches dev version
+        working-directory: arches
+        run: |
+          python -m pip uninstall arches -y
+          python -m pip install .
+          echo Arches dev version installed
+
       - name: Install Java, GDAL, and other system dependencies
         run: |
           sudo apt update

--- a/arches_for_science/media/css/report_templates.css
+++ b/arches_for_science/media/css/report_templates.css
@@ -1,13 +1,5 @@
 /*CSS specifically for Arches-HER custom reports*/
 
-/* !important is evil, but necessary to override/revert to default the inline styles for resource-component-abstract */
-.resource-component-abstract {
-    height: auto !important;
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-}
-
 .afs-table-control div
 {
     display: inline;

--- a/arches_for_science/views/download_project_files.py
+++ b/arches_for_science/views/download_project_files.py
@@ -97,7 +97,7 @@ class FileDownloader(View):
                 else:
                     download_files.append({"name": file["name"], "downloadfile": file["file"]})
             except:
-                logger.warn(_("Unable to locate {}".format(file["name"])))
+                logger.warning(_("Unable to locate {}".format(file["name"])))
 
         if len(download_files) > 0:
             zip_stream = zip_utils.create_zip_file(download_files, "downloadfile")


### PR DESCRIPTION
- [Remove resource-component-abstract selector](https://github.com/archesproject/arches-for-science/pull/1496/commits/0078441a0786c83af7d8e9fec1cc0c5b31d83c76) 

Refs https://github.com/archesproject/arches/pull/10379

- Replace a deprecated call to `warn()`
- CI: install arches from dev branch to pick up dependency changes