### PR TITLE
Fetch descriptors from database #1511

### DIFF
--- a/arches_for_science/pkg/extensions/functions/multicard_resource_descriptor.py
+++ b/arches_for_science/pkg/extensions/functions/multicard_resource_descriptor.py
@@ -39,6 +39,9 @@ class MulticardResourceDescriptor(AbstractPrimaryDescriptorsFunction):
     This implementation just fetches the calculated result from the db."""
 
     def get_primary_descriptor_from_nodes(self, resource, config, context=None, descriptor=None):
+        resource.refresh_from_db(fields={"name", "descriptors"})
+        resource.get_descriptor_language(context)
+
         result = ""
         requested_language = context.get("language", None) if context else None
 


### PR DESCRIPTION
Before, importing business data was overwriting the correctly calculated descriptors with Undefined because we were providing the same python object to `save_descriptors()`, oblivious to what had been calculated in the db trigger.

***Testing instructions***
```sh
python3 manage.py packages -o load_package -a arches_for_science -db -dev
python3 manage.py packages -o load_package -s <path to afs-test-pkg/pkg>
```

Then check physical things, ensure they have descriptions. Best to check this with Celery. It worked without celery (probably because we were refetching resource instances at some point).