### PR TITLE
lock select project step immediately instead of on delay

### DIFF
--- a/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
+++ b/arches_for_science/media/js/views/components/workflows/create-project-workflow/add-things-step.js
@@ -205,6 +205,7 @@ define([
                 }
             } else if (params.action === "update") {
                 loadExistingCollection();
+                params.form.lockExternalStep("select-project", true);
             }
         };
 
@@ -280,9 +281,6 @@ define([
                             usedSetTileId: ko.unwrap(self.usedSetTileId),
                         }
                     );
-                    if (params.action === "update") {
-                        params.form.lockExternalStep("select-project", true);
-                    }
                 })
                 .fail((err) => {
                     // eslint-disable-next-line no-console


### PR DESCRIPTION
When moving through the update collection workflow, it's possible to select a project and move forward - then move back to the initial step and clear it.  You can still advance forward because the workflow step's initial state (the value you initially selected) is different from its end state (no value selected).  To prevent this condition from happening, lock the initial step after we advance past it.

This is a "band-aid" fix.  A better fix would be improved step validation.    