### PR TITLE
Version and dependency changes for 1.1.0a3 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
         "@uppy/dashboard": "^3.5.4",
         "@uppy/drag-drop": "^3.0.3",
         "@uppy/progress-bar": "^3.0.3",
-        "arches": "archesproject/arches#dev/7.6.x",
+        "arches": "archesproject/arches#alpha/7.6.0a1",
         "dom-to-image": "^2.6.0",
         "html2canvas": "^1.4.1",
         "plotly.js-dist": "^2.24.3",
         "three": "^0.148.0"
     },
     "devDependencies": {
-        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/7.6.x"
+        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#alpha/7.6.0a1"
     },
     "scripts": {
         "build_production": "NODE_PATH=arches_for_science/media/node_modules NODE_OPTIONS=--max-old-space-size=2048 NODE_ENV=production arches_for_science/media/node_modules/.bin/webpack --config arches_for_science/webpack/webpack.config.prod.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "boto3==1.25.3",
   "arches-templating>=0.1.2",
 ]
-version = "1.1.0a2"
+version = "1.1.0a3"
 
 [tool.setuptools]
 packages = ["arches_for_science"]


### PR DESCRIPTION
Updates version number and locks front-end dependencies at arches alpha/7.6.0a1

Corresponding branches: 
- arches
https://github.com/archesproject/arches/tree/alpha/7.6.0a1

- arches-dev-dependencies
https://github.com/archesproject/arches-dev-dependencies/tree/alpha/7.6.0a1