### PR TITLE
upgrade the config for s3 to use sigv4 for uppy endpoint

### DIFF
--- a/arches_for_science/views/s3.py
+++ b/arches_for_science/views/s3.py
@@ -1,4 +1,3 @@
-
 import json
 from django.conf import settings
 from django.http import JsonResponse, HttpResponse
@@ -7,32 +6,37 @@ from django.utils.translation import gettext as _
 from arches.app.views.base import BaseManagerView
 from arches.app.utils.decorators import can_edit_resource_instance
 import boto3
+from botocore.config import Config
 
 KEY_BASE = settings.UPLOADED_FILES_DIR
+
+config = Config(region_name=settings.AWS_S3_REGION_NAME, s3={"signature_version": "s3v4"})
+
 
 @method_decorator(can_edit_resource_instance, name="dispatch")
 class S3MultipartUploaderView(BaseManagerView):
     """S3 Multipart uploader chunks files to allow for parallel uploads to S3"""
+
     def options(self, request):
         response = HttpResponse()
-        response.headers['access-control-allow-headers'] = 'x-csrftoken,accept,content-type,uppy-auth-token,location'
+        response.headers["access-control-allow-headers"] = "x-csrftoken,accept,content-type,uppy-auth-token,location"
         return response
-    
+
     def post(self, request):
         try:
             storage_bucket = settings.AWS_STORAGE_BUCKET_NAME
         except AttributeError:
             raise Exception(_("Django storages for AWS not configured"))
-        
+
         json_body = json.loads(request.body)
         file_name = json_body["filename"]
-        if(file_name and file_name.startswith(KEY_BASE)):
+        if file_name and file_name.startswith(KEY_BASE):
             key = file_name
         else:
             key = KEY_BASE + file_name
 
         response_object = {}
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", config=config)
         resp = s3.create_multipart_upload(
             Bucket=storage_bucket,
             Key=key,
@@ -47,6 +51,7 @@ class S3MultipartUploaderView(BaseManagerView):
 @method_decorator(can_edit_resource_instance, name="dispatch")
 class S3MultipartUploadManagerView(BaseManagerView):
     """Returns all of the parts of a given upload id"""
+
     def get(self, request, uploadid):
         try:
             storage_bucket = settings.AWS_STORAGE_BUCKET_NAME
@@ -63,7 +68,7 @@ class S3MultipartUploadManagerView(BaseManagerView):
             if response["IsTruncated"]:
                 get_parts(client, uploadId, response["NextPartNumberMarker"])
 
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", config=config)
         get_parts(s3, uploadid, 0)
         return JsonResponse(parts, safe=False)
 
@@ -72,22 +77,19 @@ class S3MultipartUploadManagerView(BaseManagerView):
             storage_bucket = settings.AWS_STORAGE_BUCKET_NAME
         except AttributeError:
             raise Exception(_("Django storages for AWS not configured"))
-        
 
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", config=config)
         key = request.GET.get("key", "")
 
-        s3.abort_multipart_upload(
-            storage_bucket,
-            key,
-            uploadid
-        )
+        s3.abort_multipart_upload(storage_bucket, key, uploadid)
 
         return JsonResponse({})
+
 
 @method_decorator(can_edit_resource_instance, name="dispatch")
 class S3BatchSignView(BaseManagerView):
     """generates a batch of presigned urls for a group of part numbers"""
+
     def get(self, request, uploadid):
         try:
             storage_bucket = settings.AWS_STORAGE_BUCKET_NAME
@@ -95,7 +97,7 @@ class S3BatchSignView(BaseManagerView):
             raise Exception(_("Django storages for AWS not configured"))
         key = request.GET.get("key", "")
         part_numbers = [int(x) for x in request.GET.get("partNumbers").split(",")]
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", config=config)
         urls = {}
         urls["presignedUrls"] = [None] * part_numbers[0]
         for part in part_numbers:
@@ -114,46 +116,45 @@ class S3BatchSignView(BaseManagerView):
             )
         return JsonResponse(urls, safe=False)
 
+
 @method_decorator(can_edit_resource_instance, name="dispatch")
 class S3UploadView(BaseManagerView):
     """Generates a single presigned URL to be used in a post to S3 (for small files)"""
+
     def get(self, request):
         try:
             storage_bucket = settings.AWS_STORAGE_BUCKET_NAME
         except AttributeError:
             raise Exception(_("Django storages for AWS not configured"))
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", config=config)
 
         file_name = request.GET.get("filename")
 
-        if(file_name.startswith(KEY_BASE)):
+        if file_name.startswith(KEY_BASE):
             key = file_name
         else:
             key = KEY_BASE + "/" + file_name
 
-        fields={}
+        fields = {}
         response = s3.generate_presigned_post(
             storage_bucket,
             key,
             fields,
             ExpiresIn=300,
         )
-        return JsonResponse({
-            'method': 'post',
-            'url': response['url'],
-            'fields': response['fields'],
-            'expires': 300
-        }, safe=False)
+        return JsonResponse({"method": "post", "url": response["url"], "fields": response["fields"], "expires": 300}, safe=False)
+
 
 @method_decorator(can_edit_resource_instance, name="dispatch")
 class S3UploadPartView(BaseManagerView):
     """Generates a presigned URL for a single part of a multipart upload"""
+
     def get(self, request, uploadid, partnumber):
         try:
             storage_bucket = settings.AWS_STORAGE_BUCKET_NAME
         except AttributeError:
             raise Exception(_("Django storages for AWS not configured"))
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", config=config)
         key = request.GET.get("key", "")
         url = s3.generate_presigned_url(
             "upload_part",
@@ -165,19 +166,20 @@ class S3UploadPartView(BaseManagerView):
             },
             300,
         )
-        return JsonResponse({'url': url, 'expires': 300}, safe=False)
+        return JsonResponse({"url": url, "expires": 300}, safe=False)
 
 
 @method_decorator(can_edit_resource_instance, name="dispatch")
 class S3CompleteUploadView(BaseManagerView):
     """Finalizes a multipart upload in s3"""
+
     def post(self, request, uploadid):
         try:
             storage_bucket = settings.AWS_STORAGE_BUCKET_NAME
         except AttributeError:
             raise Exception(_("Django storages for AWS not configured"))
         key = request.GET.get("key", "")
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", config=config)
         response = s3.complete_multipart_upload(
             Bucket=storage_bucket,
             Key=key,


### PR DESCRIPTION
Change the uppy config to use sigv4 by default.  Uppy doesn't respect django storages signature version by default, so we need to manually enforce it.  