### PR TITLE
Lint backend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,13 @@ jobs:
         run: |
           PYTHONPATH="../arches" python manage.py makemigrations --check --settings=arches_for_science.test_settings
 
+      - name: Lint backend
+        working-directory: afs
+        run: |
+          python -m pip install pylint
+          echo "Disabling no-member and no-self-argument due to Django false positives"
+          PYTHONPATH="../arches" pylint arches_for_science --errors-only --disable=no-member,no-self-argument
+
       - name: Run afs unit tests
         working-directory: afs
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,7 @@ jobs:
         working-directory: afs
         run: |
           python -m pip install pylint
-          echo "Disabling no-member and no-self-argument due to Django false positives"
-          PYTHONPATH="../arches" pylint arches_for_science --errors-only --disable=no-member,no-self-argument
+          PYTHONPATH="../arches" pylint arches_for_science --errors-only
 
       - name: Run afs unit tests
         working-directory: afs

--- a/arches_for_science/views/analysis_area_and_sample_taking.py
+++ b/arches_for_science/views/analysis_area_and_sample_taking.py
@@ -336,6 +336,8 @@ class SaveSampleAreaView(SaveAnnotationView):
         )
         tile.save(transaction_id=transactionid, request=request, index=False)
 
+        return tile
+
     def post(self, request):
         physical_part_of_object_nodeid = "b240c366-8594-11ea-97eb-acde48001122"
         part_identifier_assignment_label_nodeid = "3e541cc6-859b-11ea-97eb-acde48001122"

--- a/arches_for_science/views/workflows/upload_dataset/select_dataset_files_step.py
+++ b/arches_for_science/views/workflows/upload_dataset/select_dataset_files_step.py
@@ -167,7 +167,7 @@ class SelectDatasetFilesStep(View):
 
                     # raising the error here will cause the transaction to fail; the resource/tiles will not be saved
                     if raw_response.status_code != 200:
-                        raise
+                        raise Exception
                     else:
                         file_data["tileid"] = response["tileid"]
                         file_data["path"] = response["data"][dataset_file_node_id][0]['path']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,9 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.pylint."messages control"]
+disable = [
+  "no-member",  # Django false positives
+  "no-self-argument",  # Django false positives
+]


### PR DESCRIPTION
Add a CI step to lint the backend. Discussed with @aarongundel after the avoidable error in #1551.

#### Alternatives considered
pylint -- would have caught #1551, deeply configurable
flake8 -- focused more on style/cosmetics. wasn't immediately clear how to just filter down on the important stuff.
ruff -- the new hotness in python linting, but I still don't think it would have caught #1551. sure it will one day, though, and we can switch over when it's fast/mature.