### PR TITLE
Anticipate v8 breaking change to TileModel.nodegroup

### DIFF
--- a/arches_for_science/management/commands/update_docs.py
+++ b/arches_for_science/management/commands/update_docs.py
@@ -266,7 +266,7 @@ class Command(BaseCommand):
                     path = self.get_inbound_path(node)
 
                     if options["count"] and graph.isresource:
-                        c = archesmodels.TileModel.objects.filter(nodegroup=node.nodegroup).count()
+                        c = archesmodels.TileModel.objects.filter(nodegroup_id=node.nodegroup.pk).count()
                     else:
                         c = -1
                     writer.writerow(

--- a/arches_for_science/settings.py
+++ b/arches_for_science/settings.py
@@ -80,7 +80,9 @@ DATABASES = {
         "ENGINE": "django.contrib.gis.db.backends.postgis",
         "HOST": "localhost",
         "NAME": "arches_for_science",
-        "OPTIONS": {},
+        "OPTIONS": {
+            "options": "-c cursor_tuple_fraction=1",
+        },
         "PASSWORD": "postgis",
         "PORT": "5432",
         "POSTGIS_TEMPLATE": "template_postgis",

--- a/arches_for_science/views/analysis_area_and_sample_taking.py
+++ b/arches_for_science/views/analysis_area_and_sample_taking.py
@@ -39,7 +39,7 @@ class SaveAnnotationView(View):
             tile = Tile.objects.get(pk=tileid)
         else:
             try:
-                tile = Tile.objects.get(resourceinstance=resourceinstanceid, nodegroup=nodegroupid)
+                tile = Tile.objects.get(resourceinstance=resourceinstanceid, nodegroup_id=nodegroupid)
             except ObjectDoesNotExist as e:
                 tile = Tile.get_blank_tile(nodeid=nodeid, resourceid=resourceinstanceid)
         tile.data[nodeid] = nodevalue
@@ -73,7 +73,7 @@ class SaveAnnotationView(View):
             tile.data[nodeid][0]["resourceId"] = related_resourceid
         else:
             try:
-                tile = Tile.objects.get(resourceinstance=resourceinstanceid, nodegroup=nodeid)
+                tile = Tile.objects.get(resourceinstance=resourceinstanceid, nodegroup_id=nodeid)
             except ObjectDoesNotExist as e:
                 tile = Tile.get_blank_tile(nodeid=nodeid, resourceid=resourceinstanceid)
             related_resource_template = get_related_resource_template(related_resourceid, relationship_type, inverse_relationship_type)
@@ -100,7 +100,7 @@ class SaveAnnotationView(View):
             tile = Tile.objects.get(pk=tileid)
         else:
             try:
-                tile = Tile.objects.get(resourceinstance=resourceinstanceid, nodegroup=nodeid)
+                tile = Tile.objects.get(resourceinstance=resourceinstanceid, nodegroup_id=nodeid)
             except ObjectDoesNotExist as e:
                 tile = Tile.get_blank_tile(nodeid=nodeid, resourceid=resourceinstanceid)
                 tile.data[nodeid] = []
@@ -125,7 +125,7 @@ class SaveAnnotationView(View):
             tile = Tile.objects.get(pk=tileid)
         else:
             try:
-                tile = Tile.objects.get(resourceinstance=resourceid, nodegroup=physical_thing_name_nodegroupid)
+                tile = Tile.objects.get(resourceinstance=resourceid, nodegroup_id=physical_thing_name_nodegroupid)
             except ObjectDoesNotExist as e:
                 tile = Tile.get_blank_tile(nodeid=physical_thing_name_nodeid, resourceid=resourceid)
         tile.data[physical_thing_name_nodeid] = {}
@@ -294,7 +294,7 @@ class SaveSampleAreaView(SaveAnnotationView):
         else:
             tile = None
             try:
-                tiles = Tile.objects.filter(resourceinstance=sampling_activity_resourceid, nodegroup=sampling_unit_nodegroupid)
+                tiles = Tile.objects.filter(resourceinstance=sampling_activity_resourceid, nodegroup_id=sampling_unit_nodegroupid)
                 for t in tiles:
                     if t.data[sampling_area_nodeid][0]["resourceId"] == sample_area_physical_thing_resourceid:
                         tile = t
@@ -340,7 +340,7 @@ class SaveSampleAreaView(SaveAnnotationView):
         else:
             tile = None
             try:
-                tiles = Tile.objects.filter(resourceinstance=resourceid, nodegroup=statement_nodegroupid)
+                tiles = Tile.objects.filter(resourceinstance=resourceid, nodegroup_id=statement_nodegroupid)
                 for t in tiles:
                     if statement_types[type] in t.data[statement_type_nodeid]:
                         tile = t
@@ -402,7 +402,7 @@ class SaveSampleAreaView(SaveAnnotationView):
             sample_area_physical_thing_resourceid = part_identifier_assignment_tile_data[physical_part_of_object_nodeid][0]["resourceId"]
 
         sample_physical_thing_resourceid = None
-        sampling_unit_tiles = Tile.objects.filter(resourceinstance=sampling_activity_resourceid, nodegroup=sampling_unit_nodegroupid)
+        sampling_unit_tiles = Tile.objects.filter(resourceinstance=sampling_activity_resourceid, nodegroup_id=sampling_unit_nodegroupid)
         for sampling_unit_tile in sampling_unit_tiles:
             if sampling_unit_tile.data[sampling_area_nodeid][0]["resourceId"] == sample_area_physical_thing_resourceid:
                 sample_physical_thing_resourceid = sampling_unit_tile.data[sampling_area_sample_created_nodeid][0]["resourceId"]
@@ -556,7 +556,9 @@ class DeleteSampleAreaView(View):
 
         try:
             sample_physical_thing_resourceid = None
-            sampling_unit_tiles = Tile.objects.filter(resourceinstance_id=sampling_activity_resourceid, nodegroup=sampling_unit_nodegroupid)
+            sampling_unit_tiles = Tile.objects.filter(
+                resourceinstance_id=sampling_activity_resourceid, nodegroup_id=sampling_unit_nodegroupid
+            )
             for sampling_unit_tile in sampling_unit_tiles:
                 if sampling_unit_tile.data[sampling_area_nodeid][0]["resourceId"] == sample_area_physical_thing_resourceid:
                     sample_physical_thing_resourceid = sampling_unit_tile.data[sampling_area_sample_created_nodeid][0]["resourceId"]

--- a/arches_for_science/views/update_resource_list.py
+++ b/arches_for_science/views/update_resource_list.py
@@ -147,7 +147,7 @@ class UpdateResourceListView(View):
                         tile = Tile.objects.get(pk=tile_id)
                     else:
                         try:
-                            tile = Tile.objects.get(resourceinstance=resource_id, nodegroup=member_of_set_node_id)
+                            tile = Tile.objects.get(resourceinstance=resource_id, nodegroup_id=member_of_set_node_id)
                         except ObjectDoesNotExist as e:
                             tile = Tile.get_blank_tile(nodeid=member_of_set_node_id, resourceid=resource_id)
                             tile.data[member_of_set_node_id] = []

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,6 @@ from django.utils.translation import get_language
 
 from arches.app.utils.betterJSONSerializer import JSONSerializer
 from arches.app.models.models import GraphModel, Node, NodeGroup, ResourceInstance, ResourceXResource, TileModel
-from arches.app.models.system_settings import settings
 from arches.app.models.tile import Tile
 
 PHYSICAL_THING_GRAPH_ID = "9519cb4f-b25b-11e9-8c7b-a4d18cec433a"
@@ -40,7 +39,7 @@ class AnalysisAreaAndSampleTakingTests(TestCase):
 
     def make_tile(self, parent_phys_thing, data, transaction_id):
         arbitrary_nodegroup = NodeGroup.objects.first()
-        new_tile = TileModel(resourceinstance=parent_phys_thing, nodegroup=arbitrary_nodegroup)
+        new_tile = TileModel(resourceinstance=parent_phys_thing, nodegroup_id=arbitrary_nodegroup.pk)
         new_tile.save()
         # Set the transactionid
         new_tile = Tile.objects.get(tileid=new_tile.pk)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,8 +1,6 @@
 from django.core.management import call_command
-
 from django.contrib.auth.models import User
 from django.test import TestCase
-from django.test.client import Client
 from django.urls import reverse
 from django.utils.translation import get_language
 
@@ -26,11 +24,6 @@ def setUpModule():
 
 
 class AnalysisAreaAndSampleTakingTests(TestCase):
-    def login(self, username="dev", password="dev"):
-        client = Client()
-        client.login(username=username, password=password)
-        return client
-
     def get_resource_instance(self, graph_id):
         r = ResourceInstance(graph_id=graph_id)
         r.save()  # not part of the transaction, part of the setup
@@ -51,7 +44,7 @@ class AnalysisAreaAndSampleTakingTests(TestCase):
 
     def test_create_delete_analysis_area(self):
         # TODO: fails with dev/dev? 🤔
-        client = self.login(username="ben", password="Test12345!")
+        self.client.login(username="ben", password="Test12345!")
 
         transaction_id = "10000000-1000-1000-1000-100000000000"
         parent_phys_thing = self.get_resource_instance(PHYSICAL_THING_GRAPH_ID)
@@ -70,7 +63,7 @@ class AnalysisAreaAndSampleTakingTests(TestCase):
             ),
             "analysisAreaName": "Test Analysis Area",
         }
-        response = client.post(reverse("saveanalysisarea"), create_data)
+        response = self.client.post(reverse("saveanalysisarea"), create_data)
         self.assertEqual(response.status_code, 200)
 
         new_resource = ResourceInstance.objects.get(pk=response.json()["result"]["memberOfTile"]["resourceinstance_id"])
@@ -92,12 +85,12 @@ class AnalysisAreaAndSampleTakingTests(TestCase):
         }
         delete_data = JSONSerializer().serialize(delete_data)
         content_type = "application/json"
-        response = client.post(reverse("deleteanalysisarea"), delete_data, content_type=content_type)
+        response = self.client.post(reverse("deleteanalysisarea"), delete_data, content_type=content_type)
 
         self.assertEqual(response.status_code, 200)
 
     def test_create_delete_sample(self):
-        client = self.login()
+        self.client.login(username="dev", password="dev")
 
         transaction_id = "10000000-1000-1000-1000-100000000001"
         parent_phys_thing = self.get_resource_instance(PHYSICAL_THING_GRAPH_ID)
@@ -123,7 +116,7 @@ class AnalysisAreaAndSampleTakingTests(TestCase):
             "sampleDescription": "Test Description",
             "samplingActivityResourceId": str(sampling_activity.pk),
         }
-        response = client.post(reverse("savesamplearea"), create_data)
+        response = self.client.post(reverse("savesamplearea"), create_data)
         self.assertEqual(response.status_code, 200)
 
         # Delete
@@ -150,6 +143,6 @@ class AnalysisAreaAndSampleTakingTests(TestCase):
         }
         delete_data = JSONSerializer().serialize(delete_data)
         content_type = "application/json"
-        response = client.post(reverse("deletesamplearea"), delete_data, content_type=content_type)
+        response = self.client.post(reverse("deletesamplearea"), delete_data, content_type=content_type)
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
As part of reviewing archesproject/arches#9613 I ran the AfS test suite, and found these breaking changes impacted.

We change change nodegroup -> nodegroup_id already in v7.6 without waiting for v8. This will make it easier to develop against either version.

~Setting to DRAFT: there could be more that aren't covered by tests; need to grep the codebase.~

Also add DATABASES to test_settings so that it doesn't attempt to use the core arches test db. Might segregate out this change if this gets fixed in the app templates first.