### PR TITLE
Fix used-before-assignment in ManifestXCanvasView

### DIFF
--- a/arches_for_science/views/manifest_x_canvas.py
+++ b/arches_for_science/views/manifest_x_canvas.py
@@ -1,7 +1,11 @@
+from http import HTTPStatus
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.views.generic import View
-from arches.app.utils.response import JSONResponse
-from arches_for_science.models import ManifestXDigitalResource, CanvasXDigitalResource, ManifestXCanvas
+
+from arches.app.utils.response import JSONErrorResponse, JSONResponse
+from arches_for_science.models import ManifestXDigitalResource, CanvasXDigitalResource
+
 
 class ManifestXCanvasView(View):
     def get(self, request):
@@ -10,13 +14,18 @@ class ManifestXCanvasView(View):
         canvas = request.GET.get("canvas", None)
         if resourceid:
             try:
-                manifest = ManifestXDigitalResource.objects.get(digitalresource=resourceid).manifest
+                link = ManifestXDigitalResource.objects.get(digitalresource=resourceid)
+                manifest = link.manifest
             except ObjectDoesNotExist:
-                canvas = CanvasXDigitalResource.objects.get(digitalresource=resourceid).canvas
+                link = CanvasXDigitalResource.objects.get(digitalresource=resourceid)
+                canvas = link.canvas
+            digital_resource = link.digitalresource
         elif manifest:
             digital_resource = ManifestXDigitalResource.objects.get(manifest=manifest).digitalresource
         elif canvas:
             digital_resource = CanvasXDigitalResource.objects.get(canvas=canvas).digitalresource
+        else:
+            return JSONErrorResponse(status=HTTPStatus.BAD_REQUEST)
 
         result = {"manifest": manifest, "canvas": canvas, "digital_resource": digital_resource}
 


### PR DESCRIPTION
Fix CI failure on [recent pushes](https://github.com/archesproject/arches-for-science/actions/runs/9672816483/job/26685757036)