### PR TITLE
Address bugs in sample taking and analysis area steps

### DIFF
--- a/arches_for_science/media/css/project.css
+++ b/arches_for_science/media/css/project.css
@@ -561,6 +561,14 @@
 
 }
 
+.afs-sample-name .ion-asterisk {
+    display: none;
+}
+
+.afs-region-name .ion-asterisk {
+    display: none;
+}
+
 #parts-panel .panel:nth-child(even) a .file-workbench-file{
     background: #fff;
 }

--- a/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
+++ b/arches_for_science/media/js/views/components/workflows/analysis-areas-workflow/analysis-areas-annotation-step.js
@@ -449,6 +449,20 @@ define([
         };
 
         this.saveAnalysisAreaTile = function() {
+            var partIdentifierAssignmentLabelNodeId = '3e541cc6-859b-11ea-97eb-acde48001122';
+            var partIdentifierAssignmentPolygonIdentifierNodeId = "97c30c42-8594-11ea-97eb-acde48001122"
+            const featureCollection = ko.unwrap(self.selectedAnalysisAreaInstance().data[partIdentifierAssignmentPolygonIdentifierNodeId])
+            if (!ko.unwrap(featureCollection?.features)?.length ||  // Area location
+                !ko.unwrap(ko.unwrap(self.selectedAnalysisAreaInstance().data[partIdentifierAssignmentLabelNodeId])?.[arches.activeLanguage]?.value)  // Area name
+            ) {
+                params.pageVm.alert(new params.form.AlertViewModel(
+                    "ep-alert-red",
+                    "Missing Values",
+                    "Sample Location and Sample Name are Required",
+                ));
+                return;    
+            }
+
             var updateAnnotations = function() {
                 return new Promise(function(resolve, _reject) {
                     /* updates selected annotations */ 

--- a/arches_for_science/signals.py
+++ b/arches_for_science/signals.py
@@ -1,6 +1,6 @@
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
-from arches.app.models.models import IIIFManifest, ResourceXResource
+from arches.app.models.models import IIIFManifest, ResourceXResource, TileModel
 from arches.app.models.resource import Resource
 from .models import ManifestXCanvas, ManifestXDigitalResource
 import uuid
@@ -24,7 +24,10 @@ def delete_manifest_x_canvas(sender, instance, **kwargs):
 def ensure_part_tile_is_deleted(sender, instance, **kwargs):
     physical_thing_parts_node_id = uuid.UUID("b240c366-8594-11ea-97eb-acde48001122")
     if instance.nodeid_id == physical_thing_parts_node_id:
-        instance.tileid.delete()
-        resourceid = instance.tileid.resourceinstance_id
-        resource = Resource.objects.get(pk=resourceid)
-        resource.index()
+        try:
+            instance.tileid.delete()
+            resourceid = instance.tileid.resourceinstance_id
+            resource = Resource.objects.get(pk=resourceid)
+            resource.index()
+        except TileModel.DoesNotExist:
+            pass

--- a/arches_for_science/templates/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.htm
+++ b/arches_for_science/templates/views/components/workflows/sample-taking-workflow/sample-taking-sample-location-step.htm
@@ -43,7 +43,7 @@
         <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: '{% trans 'Sample Details' %}'"></h4>
     </div>
     <div class="workbench-card-sidepanel-border"></div>
-    <div class="workbench-card-sidepanel-body" style="overflow-y: hidden">
+    <div class="workbench-card-sidepanel-body">
 
 
 


### PR DESCRIPTION
- Allows user to scroll side panel in sample taking step
- Prevents signal receiver from attempting to delete tiles that do not exist (causing error)
- Prevents user from attempting to save an analysis area without an annotation geometry
- Removes asterisks from analysis and sample taking steps because there is already a 'required' label and the asterisk was obscuring the label