### PR TITLE
Return thumbnails for manifest image digital resources

### DIFF
--- a/arches_for_science/utils/thumbnail_fetchers/digital_resource_thumbnail_fetcher.py
+++ b/arches_for_science/utils/thumbnail_fetchers/digital_resource_thumbnail_fetcher.py
@@ -2,7 +2,6 @@ from arches.app.utils.search_thumbnail_fetcher_factory import SearchThumbnailFet
 from arches.app.utils.search_thumbnail_fetcher import SearchThumbnailFetcher
 import requests
 from django.utils.translation import get_language
-from django.http import Http404
 
 
 @SearchThumbnailFetcherFactory.register("707cbd78-ca7a-11e9-990b-a4d18cec433a")

--- a/arches_for_science/utils/thumbnail_fetchers/digital_resource_thumbnail_fetcher.py
+++ b/arches_for_science/utils/thumbnail_fetchers/digital_resource_thumbnail_fetcher.py
@@ -2,6 +2,7 @@ from arches.app.utils.search_thumbnail_fetcher_factory import SearchThumbnailFet
 from arches.app.utils.search_thumbnail_fetcher import SearchThumbnailFetcher
 import requests
 from django.utils.translation import get_language
+from django.http import Http404
 
 
 @SearchThumbnailFetcherFactory.register("707cbd78-ca7a-11e9-990b-a4d18cec433a")
@@ -19,16 +20,20 @@ class DigitalResourceThumbnailFetcher(SearchThumbnailFetcher):
             manifest_tile = next((tile for tile in self.resource.tiles if str(tile.nodegroup_id) == MANIFEST_NODEGROUP_ID), None)
             manifest_url = manifest_tile.data[MANIFEST_URL_NODE_ID][get_language()]["value"]
             response = requests.get(manifest_url)
-            response_json = response.json()
-            if "thumbnail" in response_json:
-                image_url = response_json["thumbnail"]["@id"]
-                if retrieve:
-                    response = requests.get(image_url, allow_redirects=True)
-                    response.raw.decode_content = True
-                    if response.ok:
-                        return (response.content, response.headers["Content-Type"])
-                else:
-                    response = requests.head(image_url, allow_redirects=True)
-                    if response.ok:
-                        return ()
+            try:
+                response_json = response.json()
+                if "thumbnail" in response_json:
+                    image_url = response_json["thumbnail"]["@id"]
+            except ValueError as e:
+                image_url = manifest_url.replace("full/full", "full/!200,200")
+
+            if retrieve:
+                response = requests.get(image_url, allow_redirects=True)
+                response.raw.decode_content = True
+                if response.ok:
+                    return (response.content, response.headers["Content-Type"])
+            else:
+                response = requests.head(image_url, allow_redirects=True)
+                if response.ok:
+                    return ()
         return None

--- a/arches_for_science/utils/thumbnail_fetchers/digital_resource_thumbnail_fetcher.py
+++ b/arches_for_science/utils/thumbnail_fetchers/digital_resource_thumbnail_fetcher.py
@@ -23,7 +23,7 @@ class DigitalResourceThumbnailFetcher(SearchThumbnailFetcher):
                 response_json = response.json()
                 if "thumbnail" in response_json:
                     image_url = response_json["thumbnail"]["@id"]
-            except ValueError as e:
+            except ValueError:
                 image_url = manifest_url.replace("full/full", "full/!200,200")
 
             if retrieve:

--- a/releases/2.0.3.md
+++ b/releases/2.0.3.md
@@ -1,0 +1,40 @@
+## Arches for Science 2.0.2 Release Notes
+
+
+### Bug Fixes and Enhancements
+
+- Return thumbnails for manifest image digital resources [#1608](https://github.com/archesproject/arches-for-science/pull/1608)
+
+### Dependency changes:
+
+```
+Python:
+    Upgraded:
+        None
+JavaScript:
+    Upgraded:
+        None
+```
+
+### Breaking Changes
+Due to changes in how projects and apps are configured in the final release of Arches 7.6, there are significant project alterations necessary to migrate from Arches for Science 1.1 to Arches for Science 2.0.
+
+### Upgrading Arches for Science 
+1. Start by upgrading your project to run using [Arches 7.6](https://github.com/archesproject/arches/blob/dev/7.6.x/releases/7.6.0.md#upgrading-arches). 
+
+2. Update arches-for-science in your project's package.json file:
+    ```
+    "arches_for_science": "archesproject/arches-for-science#dev/2.0.x"
+    ```
+
+3. Add arches_for_science to your project's dependencies in your pyproject.toml file:
+    ```
+    "arches_for_science>=2.0.3,<2.1.0"
+    ```
+
+4. Upgrade to Arches for Science 2.0.3
+    ```
+    pip install --upgrade arches_for_science==2.0.3
+    ```
+
+


### PR DESCRIPTION
If a digital resource is an image that belongs to a manifest rather than the manifest itself, it's identifier is a link to the image rather than the UUID of the manifest. The thumbnail fetcher was implemented before images belonging to manifests were represented as digital resources, so the fetcher was not written to handle a link. This PR no allows both a link or a manifest uuid to return a thumbnail image.

Closes #1607