### PR TITLE
Add project and django request logging

### DIFF
--- a/arches_for_science/settings.py
+++ b/arches_for_science/settings.py
@@ -191,7 +191,23 @@ LOGGING = {
         },
         "console": {"level": "WARNING", "class": "logging.StreamHandler", "formatter": "console"},
     },
-    "loggers": {"arches": {"handlers": ["file", "console"], "level": "WARNING", "propagate": True}},
+    "loggers": {
+        "arches": {
+            "handlers": ["file", "console"],
+            "level": "WARNING",
+            "propagate": True,
+        },
+        "arches_for_science": {
+            "handlers": ["file", "console"],
+            "level": "WARNING",
+            "propagate": True,
+        },
+        "django.request": {
+            "handlers": ["file", "console"],
+            "level": "WARNING",
+            "propagate": True,
+        },
+    },
 }
 
 # Rate limit for authentication views


### PR DESCRIPTION
Refs archesproject/arches#11861

AfS logs in a few places, but no loggers were listening (no "arches_for_science" logger configured).

Disco should probably make the same change.