### PR TITLE
Update iiif_manifest model to support the external iiif service, #1626

### DIFF
--- a/arches_for_science/signals.py
+++ b/arches_for_science/signals.py
@@ -11,13 +11,16 @@ def create_digital_resources(sender, instance, created, **kwargs):
     from arches_for_science.utils.digital_resource_for_manifest import digital_resources_for_manifest, digital_resources_for_canvases
 
     digital_resources_for_manifest(instance, created)
-    digital_resources_for_canvases(instance)
+    internal = instance.url.startswith("/manifest/")
+    if internal:
+        digital_resources_for_canvases(instance)
 
 
 @receiver(post_delete, sender=IIIFManifest)
 def delete_manifest_x_canvas(sender, instance, **kwargs):
-    ManifestXCanvas.objects.filter(manifest=instance.manifest["@id"]).delete()
-    ManifestXDigitalResource.objects.filter(manifest=instance.manifest["@id"]).delete()
+    manifest_id = instance.manifest["id"] if "id" in instance.manifest else instance.manifest["@id"]
+    ManifestXCanvas.objects.filter(manifest=manifest_id).delete()
+    ManifestXDigitalResource.objects.filter(manifest=manifest_id).delete()
 
 
 @receiver(post_delete, sender=ResourceXResource)

--- a/arches_for_science/utils/digital_resource_for_manifest.py
+++ b/arches_for_science/utils/digital_resource_for_manifest.py
@@ -169,15 +169,11 @@ def create_manifest_record(manifest_url):
     response = requests.get(manifest_url)
     manifest_data = response.json()
     manifest_values = get_manifest_values(manifest_data)
-    print(manifest_url)
-    print(manifest_data)
-    print(manifest_values)
 
     manifest = IIIFManifest(
         url=manifest_url, manifest=manifest_data, label=manifest_values["label"], description=manifest_values["description"]
     )
     manifest.save()
-    print(f"Manifest created with ID: {manifest.globalid}")
     return manifest.globalid
 
 
@@ -274,7 +270,6 @@ def digital_resources_for_manifest(instance, created):
 
     if created:
         manifest_resource_id = create_digital_resource(instance, "manifest")
-        print("manifest_resource_id", manifest_resource_id)
         create_manifest_x_digitalresource(get_manifest_values(instance.manifest)["manifest_id"], manifest_resource_id)
 
     else:

--- a/arches_for_science/utils/digital_resource_for_manifest.py
+++ b/arches_for_science/utils/digital_resource_for_manifest.py
@@ -15,8 +15,12 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
+import requests
+import uuid
+from urllib.parse import urlparse
 
 from django.utils.translation import get_language, get_language_bidi
+from arches.app.models.models import IIIFManifest
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
 from arches_for_science.models import ManifestXDigitalResource, CanvasXDigitalResource, ManifestXCanvas
@@ -123,7 +127,7 @@ def add_tiles(
         type_tile.save(transaction_id=transactionid, index=True)
 
     if iiif_type == "canvas":
-        manifest_digital_resource = ManifestXDigitalResource.objects.get(manifest=manifest_data["@id"])
+        manifest_digital_resource = ManifestXDigitalResource.objects.get(manifest=get_manifest_values(manifest_data)["manifest_id"])
         part_of_tile = Tile.get_blank_tile_from_nodegroup_id(nodegroup_id=part_of_manifest_node_id, resourceid=resource_id)
         part_of_tile.data[part_of_manifest_node_id] = [
             {
@@ -135,8 +139,75 @@ def add_tiles(
         ]
         part_of_tile.save(transaction_id=transactionid, index=True)
 
+def get_version_from_manifest(manifest_data):
+    parsed_url = urlparse(manifest_data["@context"])
+    if parsed_url.path.split("/")[3].startswith("3"):
+        return 3
+    elif parsed_url.path.split("/")[3].startswith("2"):
+        return 2
+    else:
+        raise ValueError("Unable to identify version of IIIF presentation api.")
 
-def create_digital_resource(instance, iiif_type, canvas=None):
+
+def get_manifest_values(manifest):
+    version = get_version_from_manifest(manifest)
+    if version == 2:
+        label =  manifest["label"]
+        description = manifest["description"]
+        manifest_id = manifest["@id"]
+    elif version == 3:
+        label =  manifest["label"]["en"][0]
+        description = manifest["description"]
+        manifest_id = manifest["id"]
+
+    return {
+        "label": label,
+        "description": description,
+        "manifest_id": manifest_id
+    }
+
+
+def create_manifest_record(manifest_url):
+    response = requests.get(manifest_url)
+    manifest_data = response.json()
+    manifest_values = get_manifest_values(manifest_data)
+    print(manifest_url)
+    print(manifest_data)
+    print(manifest_values)
+
+    manifest = IIIFManifest(
+        url=manifest_url,
+        manifest=manifest_data,
+        label=manifest_values["label"],
+        description=manifest_values["description"]
+    )
+    manifest.save()
+    print(f"Manifest created with ID: {manifest.globalid}")
+    return manifest.globalid
+
+
+def get_canvas_values(canvas):
+    version = get_version_from_manifest(canvas)
+    if version == 2:
+        label =  canvas["label"]
+        description = canvas["description"]
+        id = canvas["@id"]
+        manifest_id = canvas["@id"]
+    elif version == 3:
+        label =  canvas.label["en"][0]
+        description = canvas["description"]["en"][0]
+        id = ""
+        manifest_id = canvas["id"]
+
+    return {
+        "label": label,
+        "description": description,
+        "id": id,
+        "manifest_id": manifest_id
+    }
+
+
+def create_digital_resource_from_manifest(manifest_data, iiif_type, globalid=None, transactionid=None, canvas=None):
     """Creates the digital resources resource instance representing manifest
     and also creates the manifest_x_canvas record
     """
@@ -145,21 +216,22 @@ def create_digital_resource(instance, iiif_type, canvas=None):
     web_service_valueid = ["e208df66-9e61-498b-8071-3024aa7bed30"]
     digital_resource_graph = "707cbd78-ca7a-11e9-990b-a4d18cec433a"
 
-    manifest_data = instance.manifest
     service = {manifest_data["@context"]: web_service_valueid}  # TODO canvas does not have its own service
     type = iiif_manifest_valueid  # TODO canvas type need to be added
-    transactionid = instance.transactionid
+    transactionid = transactionid if transactionid else uuid.uuid4()
+    globalid = globalid if globalid else uuid.uuid4()
 
     resource = Resource(graph_id=digital_resource_graph)
-    resource.save(transaction_id=instance.transactionid)
+    resource.save(transaction_id=transactionid)
     resource_id = resource.pk
 
     if iiif_type == "manifest":
-        name = manifest_data["label"]
-        statement = manifest_data["description"]
-        id = {str(instance.globalid): internal_id_valueid}
+        manifest_values = get_manifest_values(manifest_data)
+        name = manifest_values["label"]
+        statement = manifest_values["description"]
+        id = {str(globalid): internal_id_valueid}
         service_identifiers = [
-            {manifest_data["@id"]: ["f32d0944-4229-4792-a33c-aadc2b181dc7"]},
+            {manifest_values["manifest_id"]: ["f32d0944-4229-4792-a33c-aadc2b181dc7"]},
         ]
     elif iiif_type == "canvas":
         name = canvas["label"]
@@ -182,12 +254,24 @@ def create_digital_resource(instance, iiif_type, canvas=None):
         manifest_data=manifest_data,
         iiif_type=iiif_type,
     )
+
     return resource_id
+
+
+def create_digital_resource(instance, iiif_type, canvas=None):
+    """Creates the digital resources resource instance representing manifest
+    and also creates the manifest_x_canvas record
+    """
+
+    manifest_data = instance.manifest
+    globalid = instance.globalid
+    transactionid = instance.transactionid
+    return create_digital_resource_from_manifest(manifest_data, iiif_type, globalid, transactionid)
 
 
 def update_manifest_digital_resource(instance):
     manifest_data = instance.manifest
-    manifest_resource_id = ManifestXDigitalResource.objects.get(manifest=manifest_data["@id"]).digitalresource
+    manifest_resource_id = ManifestXDigitalResource.objects.get(manifest=get_manifest_values(manifest_data)["manifest_id"]).digitalresource
     add_tiles(
         manifest_resource_id, name=manifest_data["label"], statement=manifest_data["description"], transactionid=instance.transactionid
     )
@@ -200,14 +284,15 @@ def digital_resources_for_manifest(instance, created):
 
     if created:
         manifest_resource_id = create_digital_resource(instance, "manifest")
-        create_manifest_x_digitalresource(instance.manifest["@id"], manifest_resource_id)
+        print("manifest_resource_id",manifest_resource_id)
+        create_manifest_x_digitalresource(get_manifest_values(instance.manifest)["manifest_id"], manifest_resource_id)
 
     else:
-        if ManifestXDigitalResource.objects.filter(manifest=instance.manifest["@id"]).count() == 1:
+        if ManifestXDigitalResource.objects.filter(manifest=get_manifest_values(instance.manifest)["manifest_id"]).count() == 1:
             update_manifest_digital_resource(instance)
         else:
             manifest_resource_id = create_digital_resource(instance, "manifest")
-            create_manifest_x_digitalresource(instance.manifest["@id"], manifest_resource_id)
+            create_manifest_x_digitalresource(get_manifest_values(instance.manifest)["manifest_id"], manifest_resource_id)
 
 
 def digital_resources_for_canvases(instance):
@@ -221,12 +306,12 @@ def digital_resources_for_canvases(instance):
             create_canvas_x_digitalresource(canvas["images"][0]["resource"]["service"]["@id"], canvas_resource_id)
 
         if not ManifestXCanvas.objects.filter(
-            manifest=manifest_data["@id"], canvas=canvas["images"][0]["resource"]["service"]["@id"]
+            manifest=get_manifest_values(manifest_data)["manifest_id"], canvas=canvas["images"][0]["resource"]["service"]["@id"]
         ).exists():
-            create_manifest_x_canvas(manifest_data["@id"], canvas["images"][0]["resource"]["service"]["@id"])
+            create_manifest_x_canvas(get_manifest_values(manifest_data)["manifest_id"], canvas["images"][0]["resource"]["service"]["@id"])
 
     # remove the canvas record in manifest_x_canvas that was removed from the current manifest
     current_canvases = [canvas["images"][0]["resource"]["service"]["@id"] for canvas in manifest_data["sequences"][0]["canvases"]]
-    for manifest_x_canvas in ManifestXCanvas.objects.filter(manifest=manifest_data["@id"]):
+    for manifest_x_canvas in ManifestXCanvas.objects.filter(manifest=get_manifest_values(manifest_data)["manifest_id"]):
         if manifest_x_canvas.canvas not in current_canvases:
             manifest_x_canvas.delete()

--- a/arches_for_science/utils/digital_resource_for_manifest.py
+++ b/arches_for_science/utils/digital_resource_for_manifest.py
@@ -15,6 +15,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
+
 import requests
 import uuid
 from urllib.parse import urlparse
@@ -139,6 +140,7 @@ def add_tiles(
         ]
         part_of_tile.save(transaction_id=transactionid, index=True)
 
+
 def get_version_from_manifest(manifest_data):
     parsed_url = urlparse(manifest_data["@context"])
     if parsed_url.path.split("/")[3].startswith("3"):
@@ -152,19 +154,15 @@ def get_version_from_manifest(manifest_data):
 def get_manifest_values(manifest):
     version = get_version_from_manifest(manifest)
     if version == 2:
-        label =  manifest["label"]
+        label = manifest["label"]
         description = manifest["description"]
         manifest_id = manifest["@id"]
     elif version == 3:
-        label =  manifest["label"]["en"][0]
+        label = manifest["label"]["en"][0]
         description = manifest["description"]
         manifest_id = manifest["id"]
 
-    return {
-        "label": label,
-        "description": description,
-        "manifest_id": manifest_id
-    }
+    return {"label": label, "description": description, "manifest_id": manifest_id}
 
 
 def create_manifest_record(manifest_url):
@@ -176,10 +174,7 @@ def create_manifest_record(manifest_url):
     print(manifest_values)
 
     manifest = IIIFManifest(
-        url=manifest_url,
-        manifest=manifest_data,
-        label=manifest_values["label"],
-        description=manifest_values["description"]
+        url=manifest_url, manifest=manifest_data, label=manifest_values["label"], description=manifest_values["description"]
     )
     manifest.save()
     print(f"Manifest created with ID: {manifest.globalid}")
@@ -189,22 +184,17 @@ def create_manifest_record(manifest_url):
 def get_canvas_values(canvas):
     version = get_version_from_manifest(canvas)
     if version == 2:
-        label =  canvas["label"]
+        label = canvas["label"]
         description = canvas["description"]
         id = canvas["@id"]
         manifest_id = canvas["@id"]
     elif version == 3:
-        label =  canvas.label["en"][0]
+        label = canvas.label["en"][0]
         description = canvas["description"]["en"][0]
         id = ""
         manifest_id = canvas["id"]
 
-    return {
-        "label": label,
-        "description": description,
-        "id": id,
-        "manifest_id": manifest_id
-    }
+    return {"label": label, "description": description, "id": id, "manifest_id": manifest_id}
 
 
 def create_digital_resource_from_manifest(manifest_data, iiif_type, globalid=None, transactionid=None, canvas=None):
@@ -284,7 +274,7 @@ def digital_resources_for_manifest(instance, created):
 
     if created:
         manifest_resource_id = create_digital_resource(instance, "manifest")
-        print("manifest_resource_id",manifest_resource_id)
+        print("manifest_resource_id", manifest_resource_id)
         create_manifest_x_digitalresource(get_manifest_values(instance.manifest)["manifest_id"], manifest_resource_id)
 
     else:

--- a/arches_for_science/views/manifest_x_canvas.py
+++ b/arches_for_science/views/manifest_x_canvas.py
@@ -1,10 +1,13 @@
 from http import HTTPStatus
+import uuid
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.views.generic import View
 
 from arches.app.utils.response import JSONErrorResponse, JSONResponse
+from arches.app.models.models import IIIFManifest
 from arches_for_science.models import ManifestXDigitalResource, CanvasXDigitalResource
+from arches_for_science.utils.digital_resource_for_manifest import create_manifest_record, create_digital_resource_from_manifest
 
 
 class ManifestXCanvasView(View):
@@ -21,7 +24,10 @@ class ManifestXCanvasView(View):
                 canvas = link.canvas
             digital_resource = link.digitalresource
         elif manifest:
+            if not IIIFManifest.objects.filter(url=manifest).exists():
+                create_manifest_record(manifest)
             digital_resource = ManifestXDigitalResource.objects.get(manifest=manifest).digitalresource
+
         elif canvas:
             digital_resource = CanvasXDigitalResource.objects.get(canvas=canvas).digitalresource
         else:


### PR DESCRIPTION
Update iiif_manifest model behavior to support the external iiif service to fix the issue in the workflows,  #1626
The changes include:

1. Create iiif manifest record, if the manifest is not in the database during workflow (ie. an external iiif service)

2. Update the creation of iiif-menifest digital resource to support presentation v.3
- create the digital resource for the manifest
- but do not create the digital resource for the canvases