### PR TITLE
Indicate how to use regex in placeholder

### DIFF
--- a/arches_for_science/templates/views/components/plugins/importer-configuration.htm
+++ b/arches_for_science/templates/views/components/plugins/importer-configuration.htm
@@ -75,7 +75,7 @@
                     <div class="data-delimiter-radio"><input id="delimiter-pipe" type="radio" name="dataDelimiter" value="|" data-bind="checked: dataDelimiterRadio"><label for="delimiter-pipe">{% trans "Pipe" %}</label></div>
                     <div class="data-delimiter-radio"><input id="delimiter-other" type="radio" name="dataDelimiter" value="other" data-bind="checked: dataDelimiterRadio"><label for="delimiter-other">{% trans "Other" %}</label></div>
                 </div>
-                <input type="text" name="delimiterCharacter" data-bind="visible: dataDelimiterRadio()=='other', textInput: dataDelimiter">
+                <input type="text" name="delimiterCharacter" placeholder="String or regex, example: [a-zA-Z]+" data-bind="visible: dataDelimiterRadio()=='other', textInput: dataDelimiter">
                 <div style="display: flex; margin: 5px 0;">
                     <input style="margin: 0px 0px 0px 2px;" type="checkbox" name="includeDelimiter" value="includeDelimiter" data-bind="checked:includeDelimiter">
                     <label style="margin-top: 2px;" for="header-config-none">{% trans "Include Delimiter in Value" %}</label>


### PR DESCRIPTION
Adds indication as to how to use regex to parse columns using a placeholder in importer config's 'other' text input. Testing can be done to confirm example regex is correct using this file:
[alphastringdelim.txt](https://github.com/user-attachments/files/21535793/alphastringdelim.txt)

fixes: #1657
