### PR TITLE
Migrate to controlled lists

### DIFF
--- a/arches_for_science/pkg/graphs/branches/Attribute Assignment .json
+++ b/arches_for_science/pkg/graphs/branches/Attribute Assignment .json
@@ -16,13 +16,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Attribute Assignment "
@@ -45,13 +45,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -74,13 +74,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration"
@@ -103,13 +103,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan"
@@ -132,13 +132,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Statement"
@@ -161,13 +161,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -190,13 +190,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -219,13 +219,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -248,13 +248,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -277,13 +277,13 @@
                     "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -350,14 +350,11 @@
                 {
                     "card_id": "9e93b5f2-0d77-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -370,19 +367,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93b5f2-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -395,7 +417,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93b5f2-0d77-11ea-b439-acde48001122",
@@ -477,7 +499,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -490,7 +511,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93bb1a-0d77-11ea-b439-acde48001122",
@@ -568,14 +589,37 @@
                     "card_id": "9e93bfac-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -588,7 +632,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93bfac-0d77-11ea-b439-acde48001122",
@@ -654,13 +698,38 @@
                     "card_id": "9e93bfac-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -673,7 +742,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93bfac-0d77-11ea-b439-acde48001122",
@@ -868,7 +937,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -881,7 +949,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93b8f4-0d77-11ea-b439-acde48001122",
@@ -891,7 +959,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Duration",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -904,7 +971,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93c20e-0d77-11ea-b439-acde48001122",
@@ -940,13 +1007,38 @@
                     "card_id": "9e93c20e-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -959,19 +1051,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93c20e-0d77-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -984,7 +1073,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93c20e-0d77-11ea-b439-acde48001122",
@@ -1064,13 +1153,38 @@
                     "card_id": "9e93bdae-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1083,7 +1197,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9e93bdae-0d77-11ea-b439-acde48001122",
@@ -1148,14 +1262,11 @@
                 {
                     "card_id": "9e93bdae-0d77-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1168,7 +1279,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a753d76c-0d77-11ea-b439-acde48001122",
@@ -1178,7 +1289,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1191,7 +1301,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a753d76c-0d77-11ea-b439-acde48001122",
@@ -1219,13 +1329,38 @@
                     "card_id": "a753d76c-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1238,7 +1373,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a753d76c-0d77-11ea-b439-acde48001122",
@@ -1364,13 +1499,38 @@
                     "card_id": "c7f4e2b8-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1383,19 +1543,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c7f4e2b8-0d77-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1408,7 +1565,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c7f4e2b8-0d77-11ea-b439-acde48001122",
@@ -1466,13 +1623,24 @@
                     "card_id": "c7f4e8a8-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1485,7 +1653,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c7f4e8a8-0d77-11ea-b439-acde48001122",
@@ -1543,13 +1711,38 @@
                     "card_id": "c7f4e8a8-0d77-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1562,7 +1755,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6a851378-0d77-11ea-b439-acde48001122",
@@ -1572,7 +1765,6 @@
                             "placeholder"
                         ],
                         "label": "Classification",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1585,7 +1777,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6a851378-0d77-11ea-b439-acde48001122",
@@ -2383,9 +2575,10 @@
                 {
                     "alias": "classification",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2600,9 +2793,10 @@
                 {
                     "alias": "type_n5",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2685,9 +2879,10 @@
                 {
                     "alias": "type_n6",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2765,9 +2960,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2790,9 +2986,10 @@
                 {
                     "alias": "type_n7",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2838,9 +3035,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3010,9 +3208,10 @@
                 {
                     "alias": "type_n8",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3035,9 +3234,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3090,9 +3290,10 @@
                 {
                     "alias": "language_n3",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3161,9 +3362,10 @@
                 {
                     "alias": "language_n6",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3186,10 +3388,10 @@
                 {
                     "alias": "language_n4",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3260,9 +3462,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3425,9 +3628,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3480,9 +3684,10 @@
                 {
                     "alias": "language_n5",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3620,9 +3825,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3668,9 +3874,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3693,9 +3900,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3748,10 +3956,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3852,9 +4060,9 @@
             "publication": {
                 "graph_id": "6a841568-0d77-11ea-b439-acde48001122",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ebb4553e-95b5-11ed-a5e5-a683e74f6c3a",
-                "published_time": "2023-01-16T09:53:29.443"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "73841642-6866-44d1-a035-7b88832a1087",
+                "published_time": "2026-02-06T13:22:11.761"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/branches/Dimension.json
+++ b/arches_for_science/pkg/graphs/branches/Dimension.json
@@ -16,13 +16,13 @@
                     "graph_id": "d9738a38-b24d-11e9-b32c-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -45,13 +45,13 @@
                     "graph_id": "d9738a38-b24d-11e9-b32c-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Dimension"
@@ -74,13 +74,13 @@
                     "graph_id": "d9738a38-b24d-11e9-b32c-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -103,13 +103,13 @@
                     "graph_id": "d9738a38-b24d-11e9-b32c-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -166,7 +166,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -179,7 +178,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d976167a-b24d-11e9-bd8e-a4d18cec433a",
@@ -241,7 +240,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -254,7 +252,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d976167a-b24d-11e9-bd8e-a4d18cec433a",
@@ -363,14 +361,11 @@
                 {
                     "card_id": "42c2bc3d-b250-11e9-a6d5-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -383,7 +378,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "42c2bc3d-b250-11e9-a6d5-a4d18cec433a",
@@ -441,13 +436,38 @@
                     "card_id": "42c2bc3d-b250-11e9-a6d5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -460,7 +480,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ea198e88-073d-11ea-aac2-acde48001122",
@@ -526,13 +546,38 @@
                     "card_id": "ea198e88-073d-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -545,19 +590,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ea198e88-073d-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -570,7 +612,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ea198e88-073d-11ea-aac2-acde48001122",
@@ -628,13 +670,24 @@
                     "card_id": "ea19914e-073d-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -647,7 +700,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ea19914e-073d-11ea-aac2-acde48001122",
@@ -705,13 +758,38 @@
                     "card_id": "ea19914e-073d-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -724,7 +802,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": null,
@@ -1055,9 +1133,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "44295221-1215-4359-a079-234b317f65b7"
+                        "controlledList": "44295221-1215-4359-a079-234b317f65b7",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1156,9 +1235,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1181,9 +1261,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1229,9 +1310,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "c9e838f8-7660-4701-821c-721dac98a10b"
+                        "controlledList": "c9e838f8-7660-4701-821c-721dac98a10b",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1399,9 +1481,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1447,9 +1530,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1472,9 +1556,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1527,10 +1612,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1677,9 +1762,9 @@
             "publication": {
                 "graph_id": "d9738a38-b24d-11e9-b32c-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ec2186ae-95b5-11ed-a5e5-a683e74f6c3a",
-                "published_time": "2023-01-16T09:53:30.159"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "bd1e0215-03f6-411e-9435-1df0d0baaab2",
+                "published_time": "2026-02-06T13:22:15.217"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/branches/Identifier.json
+++ b/arches_for_science/pkg/graphs/branches/Identifier.json
@@ -16,13 +16,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -45,13 +45,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration"
@@ -74,13 +74,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan"
@@ -103,13 +103,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Statement"
@@ -132,13 +132,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -161,13 +161,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -190,13 +190,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier"
@@ -219,13 +219,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -248,13 +248,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -277,13 +277,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -306,13 +306,13 @@
                     "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Assignment"
@@ -392,7 +392,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Identifier",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -405,7 +404,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6d1cd4f3-b250-11e9-a05c-a4d18cec433a",
@@ -484,14 +483,11 @@
                 {
                     "card_id": "63a6130c-0d74-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -504,19 +500,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a6130c-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -529,7 +550,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a6130c-0d74-11ea-b439-acde48001122",
@@ -611,7 +632,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -624,7 +644,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a6180c-0d74-11ea-b439-acde48001122",
@@ -702,14 +722,37 @@
                     "card_id": "63a61c6c-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -722,7 +765,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a61c6c-0d74-11ea-b439-acde48001122",
@@ -788,13 +831,38 @@
                     "card_id": "63a61c6c-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -807,7 +875,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a61c6c-0d74-11ea-b439-acde48001122",
@@ -1002,7 +1070,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1015,7 +1082,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a615f0-0d74-11ea-b439-acde48001122",
@@ -1025,7 +1092,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Duration",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1038,7 +1104,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a61eba-0d74-11ea-b439-acde48001122",
@@ -1074,13 +1140,38 @@
                     "card_id": "63a61eba-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1093,19 +1184,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a61eba-0d74-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1118,7 +1206,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a61eba-0d74-11ea-b439-acde48001122",
@@ -1198,13 +1286,38 @@
                     "card_id": "63a61a8c-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1217,7 +1330,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "63a61a8c-0d74-11ea-b439-acde48001122",
@@ -1282,14 +1395,11 @@
                 {
                     "card_id": "63a61a8c-0d74-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1302,7 +1412,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6d1f7f90-0d74-11ea-b439-acde48001122",
@@ -1312,7 +1422,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1325,7 +1434,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6d1f7f90-0d74-11ea-b439-acde48001122",
@@ -1353,13 +1462,38 @@
                     "card_id": "6d1f7f90-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1372,7 +1506,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6d1f7f90-0d74-11ea-b439-acde48001122",
@@ -1498,13 +1632,38 @@
                     "card_id": "77fa8b76-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1517,19 +1676,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "77fa8b76-0d74-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1542,7 +1698,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "77fa8b76-0d74-11ea-b439-acde48001122",
@@ -1600,13 +1756,24 @@
                     "card_id": "77fa8dce-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1619,7 +1786,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "77fa8dce-0d74-11ea-b439-acde48001122",
@@ -1677,13 +1844,38 @@
                     "card_id": "77fa8dce-0d74-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1696,7 +1888,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bd2245d6-0d74-11ea-b439-acde48001122",
@@ -1736,7 +1928,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Assignment",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1749,7 +1940,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bd2245d6-0d74-11ea-b439-acde48001122",
@@ -2712,9 +2903,10 @@
                 {
                     "alias": "type_n5",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2797,9 +2989,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2877,9 +3070,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2902,9 +3096,10 @@
                 {
                     "alias": "type_n6",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2950,9 +3145,10 @@
                 {
                     "alias": "language_n5",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3122,9 +3318,10 @@
                 {
                     "alias": "type_n7",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3147,9 +3344,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3202,9 +3400,10 @@
                 {
                     "alias": "language_n6",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3273,9 +3472,10 @@
                 {
                     "alias": "language_n4",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3298,10 +3498,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3372,9 +3572,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3560,9 +3761,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3615,9 +3817,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3755,9 +3958,10 @@
                 {
                     "alias": "type_n8",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3803,9 +4007,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3828,9 +4033,10 @@
                 {
                     "alias": "type_n9",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3883,10 +4089,10 @@
                 {
                     "alias": "language_n3",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4054,9 +4260,10 @@
                 {
                     "alias": "classification",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4079,9 +4286,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4168,9 +4376,9 @@
             "publication": {
                 "graph_id": "6d18e659-b250-11e9-8855-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ec9f0110-95b5-11ed-a5e5-a683e74f6c3a",
-                "published_time": "2023-01-16T09:53:30.981"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "2dbed7e5-ec98-4fcd-b1ec-bf033319a46e",
+                "published_time": "2026-02-06T13:22:25.541"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/branches/Monetary Amount.json
+++ b/arches_for_science/pkg/graphs/branches/Monetary Amount.json
@@ -16,13 +16,13 @@
                     "graph_id": "74fa1707-b251-11e9-b46d-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Monetary Amount"
@@ -207,9 +207,10 @@
                 {
                     "alias": "currency",
                     "config": {
-                        "rdmCollection": "9fe65e48-540c-4401-836d-947eb1878677"
+                        "controlledList": "9fe65e48-540c-4401-836d-947eb1878677",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -232,9 +233,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "696fd77f-0181-4d00-9372-b395b2fde9b3"
+                        "controlledList": "696fd77f-0181-4d00-9372-b395b2fde9b3",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -335,9 +337,9 @@
             "publication": {
                 "graph_id": "74fa1707-b251-11e9-b46d-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ec4651c8-95b5-11ed-a5e5-a683e74f6c3a",
-                "published_time": "2023-01-16T09:53:30.400"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "6868ffb9-75b5-4595-8009-dedbf3bd84b8",
+                "published_time": "2026-02-06T13:22:16.595"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/branches/Name.json
+++ b/arches_for_science/pkg/graphs/branches/Name.json
@@ -16,13 +16,13 @@
                     "graph_id": "146b5654-b24f-11e9-937a-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -42,7 +42,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -55,7 +54,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "146f621e-b24f-11e9-9b44-a4d18cec433a",
@@ -83,13 +82,38 @@
                     "card_id": "146f621e-b24f-11e9-9b44-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -102,7 +126,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "146f621e-b24f-11e9-9b44-a4d18cec433a",
@@ -318,9 +342,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -343,9 +368,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -400,9 +426,9 @@
             "publication": {
                 "graph_id": "146b5654-b24f-11e9-937a-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ec124572-95b5-11ed-a5e5-a683e74f6c3a",
-                "published_time": "2023-01-16T09:53:30.059"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "c9fcb2bf-892f-471a-b2dd-f9029d9a67b7",
+                "published_time": "2026-02-06T13:22:13.144"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/branches/Statement.json
+++ b/arches_for_science/pkg/graphs/branches/Statement.json
@@ -16,13 +16,13 @@
                     "graph_id": "a22ee0c5-b25a-11e9-b97e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -45,13 +45,13 @@
                     "graph_id": "a22ee0c5-b25a-11e9-b97e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -97,13 +97,24 @@
                     "card_id": "a2314c9c-b25a-11e9-bca2-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -116,7 +127,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a2314c9c-b25a-11e9-bca2-a4d18cec433a",
@@ -174,13 +185,38 @@
                     "card_id": "a2314c9c-b25a-11e9-bca2-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -193,7 +229,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e61194d1-b25a-11e9-95be-a4d18cec433a",
@@ -259,13 +295,38 @@
                     "card_id": "e61194d1-b25a-11e9-95be-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -278,19 +339,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e61194d1-b25a-11e9-95be-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -303,7 +361,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e61194d1-b25a-11e9-95be-a4d18cec433a",
@@ -525,9 +583,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -573,10 +632,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -652,9 +711,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -730,9 +790,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -780,9 +841,9 @@
             "publication": {
                 "graph_id": "a22ee0c5-b25a-11e9-b97e-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ec8a1b2e-95b5-11ed-a5e5-a683e74f6c3a",
-                "published_time": "2023-01-16T09:53:30.844"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "c85511f6-1067-4e63-95ed-5790e07b562f",
+                "published_time": "2026-02-06T13:22:23.100"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/branches/TimeSpan.json
+++ b/arches_for_science/pkg/graphs/branches/TimeSpan.json
@@ -16,13 +16,13 @@
                     "graph_id": "6da55a8c-b24d-11e9-835d-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -45,13 +45,13 @@
                     "graph_id": "6da55a8c-b24d-11e9-835d-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration"
@@ -74,13 +74,13 @@
                     "graph_id": "6da55a8c-b24d-11e9-835d-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan"
@@ -103,13 +103,13 @@
                     "graph_id": "6da55a8c-b24d-11e9-835d-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -132,13 +132,13 @@
                     "graph_id": "6da55a8c-b24d-11e9-835d-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Statement"
@@ -161,13 +161,13 @@
                     "graph_id": "6da55a8c-b24d-11e9-835d-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -205,14 +205,37 @@
                     "card_id": "85fce045-b25b-11e9-9ebf-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -225,7 +248,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "85fce045-b25b-11e9-9ebf-a4d18cec433a",
@@ -291,13 +314,38 @@
                     "card_id": "85fce045-b25b-11e9-9ebf-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -310,7 +358,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ebeba582-b251-11e9-8efa-a4d18cec433a",
@@ -346,13 +394,38 @@
                     "card_id": "ebeba582-b251-11e9-8efa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -365,19 +438,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ebeba582-b251-11e9-8efa-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -390,7 +460,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ebeba582-b251-11e9-8efa-a4d18cec433a",
@@ -447,14 +517,11 @@
                 {
                     "card_id": "85fce647-b25b-11e9-93c6-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -467,7 +534,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "85fce647-b25b-11e9-93c6-a4d18cec433a",
@@ -495,13 +562,38 @@
                     "card_id": "85fce647-b25b-11e9-93c6-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -514,7 +606,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "85fce647-b25b-11e9-93c6-a4d18cec433a",
@@ -747,7 +839,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -760,7 +851,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0054506e-b252-11e9-a330-a4d18cec433a",
@@ -770,7 +861,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Duration",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -783,7 +873,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6da7c6b5-b24d-11e9-a2a5-a4d18cec433a",
@@ -835,7 +925,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -848,7 +937,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6da7c6b5-b24d-11e9-a2a5-a4d18cec433a",
@@ -977,14 +1066,11 @@
                 {
                     "card_id": "00544c91-b252-11e9-97b9-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -997,7 +1083,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "00544c91-b252-11e9-97b9-a4d18cec433a",
@@ -1033,13 +1119,38 @@
                     "card_id": "00544c91-b252-11e9-97b9-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1052,7 +1163,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": null,
@@ -1619,9 +1730,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1644,9 +1756,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1752,9 +1865,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1823,9 +1937,10 @@
                 {
                     "alias": "type_n5",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1942,10 +2057,10 @@
                 {
                     "alias": "language_n3",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -1968,9 +2083,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2069,9 +2185,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2147,9 +2264,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2220,9 +2338,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2394,9 +2513,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2419,9 +2539,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2469,9 +2590,9 @@
             "publication": {
                 "graph_id": "6da55a8c-b24d-11e9-835d-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ec54e5b2-95b5-11ed-a5e5-a683e74f6c3a",
-                "published_time": "2023-01-16T09:53:30.495"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "ecab47b6-e4e7-4807-a57a-62c676ce69f9",
+                "published_time": "2026-02-06T13:22:18.910"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/branches/__Activity_Template.json
+++ b/arches_for_science/pkg/graphs/branches/__Activity_Template.json
@@ -16,13 +16,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration"
@@ -45,13 +45,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -74,13 +74,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Duration"
@@ -103,13 +103,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan"
@@ -132,13 +132,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "__Activity_Template"
@@ -161,13 +161,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -190,13 +190,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -219,13 +219,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier"
@@ -248,13 +248,13 @@
                     "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -426,13 +426,38 @@
                     "card_id": "861ed87d-d284-11e9-851c-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Statement Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -445,7 +470,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ec0ba-d284-11e9-8200-a4d18cec433a",
@@ -518,13 +543,38 @@
                     "card_id": "861ec4f3-d284-11e9-b0d0-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -537,19 +587,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ec98f-d284-11e9-99be-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -562,7 +609,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ed191-d284-11e9-a0a7-a4d18cec433a",
@@ -638,7 +685,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -651,7 +697,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ed191-d284-11e9-a0a7-a4d18cec433a",
@@ -678,14 +724,11 @@
                 {
                     "card_id": "861ec4f3-d284-11e9-b0d0-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -698,20 +741,43 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ed87d-d284-11e9-851c-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -724,7 +790,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ec0ba-d284-11e9-8200-a4d18cec433a",
@@ -734,7 +800,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -747,7 +812,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ec0ba-d284-11e9-8200-a4d18cec433a",
@@ -937,13 +1002,24 @@
                     "card_id": "861ed517-d284-11e9-8985-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -956,7 +1032,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ed191-d284-11e9-a0a7-a4d18cec433a",
@@ -1099,7 +1175,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Activity",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1112,7 +1187,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ed191-d284-11e9-a0a7-a4d18cec433a",
@@ -1144,7 +1219,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Identifier",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1157,7 +1231,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ec0ba-d284-11e9-8200-a4d18cec433a",
@@ -1304,13 +1378,38 @@
                     "card_id": "861ed517-d284-11e9-8985-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1323,7 +1422,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ec0ba-d284-11e9-8200-a4d18cec433a",
@@ -1435,7 +1534,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1448,19 +1546,44 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ec98f-d284-11e9-99be-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1473,7 +1596,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ed191-d284-11e9-a0a7-a4d18cec433a",
@@ -1483,7 +1606,6 @@
                             "placeholder"
                         ],
                         "label": "Particular Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1496,7 +1618,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "861ed191-d284-11e9-a0a7-a4d18cec433a",
@@ -2463,9 +2585,10 @@
                 {
                     "alias": "language_n4",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2488,9 +2611,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2543,9 +2667,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2656,9 +2781,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2734,9 +2860,10 @@
                 {
                     "alias": "type_n5",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2916,9 +3043,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3310,9 +3438,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3335,10 +3464,10 @@
                 {
                     "alias": "language_n3",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3361,9 +3490,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3409,9 +3539,10 @@
                 {
                     "alias": "technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3480,9 +3611,10 @@
                 {
                     "alias": "type_n7",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3505,9 +3637,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3560,9 +3693,10 @@
                 {
                     "alias": "type_n6",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3631,9 +3765,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3778,9 +3913,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3803,9 +3939,10 @@
                 {
                     "alias": "type_n8",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3855,9 +3992,9 @@
             "publication": {
                 "graph_id": "861eb630-d284-11e9-a958-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ecf889d8-95b5-11ed-a5e5-a683e74f6c3a",
-                "published_time": "2023-01-16T09:53:31.568"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "701a8838-0924-45bc-97b2-6c2135892009",
+                "published_time": "2026-02-06T13:22:21.522"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Collection or Set.json
+++ b/arches_for_science/pkg/graphs/resource_models/Collection or Set.json
@@ -815,14 +815,37 @@
                     "card_id": "11b58ecc-d354-11e9-a84f-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -835,7 +858,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11b58ecc-d354-11e9-a84f-a4d18cec433a",
@@ -983,13 +1006,38 @@
                     "card_id": "11b58ecc-d354-11e9-a84f-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1002,7 +1050,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11b58ac7-d354-11e9-88f9-a4d18cec433a",
@@ -1030,13 +1078,38 @@
                     "card_id": "11b58ac7-d354-11e9-88f9-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1049,19 +1122,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11b58ac7-d354-11e9-88f9-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1074,7 +1144,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a5571c82-b2e2-11e9-932e-a4d18cec433a",
@@ -1114,7 +1184,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1127,7 +1196,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59765223-c450-11e9-b4da-a4d18cec433a",
@@ -1163,13 +1232,38 @@
                     "card_id": "59765223-c450-11e9-b4da-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1182,7 +1276,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59765223-c450-11e9-b4da-a4d18cec433a",
@@ -1240,13 +1334,24 @@
                     "card_id": "59765223-c450-11e9-b4da-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1259,7 +1364,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "52aa1963-c450-11e9-b89e-a4d18cec433a",
@@ -1295,13 +1400,24 @@
                     "card_id": "52aa1963-c450-11e9-b89e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1314,7 +1430,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "52aa1963-c450-11e9-b89e-a4d18cec433a",
@@ -1372,13 +1488,38 @@
                     "card_id": "52aa1963-c450-11e9-b89e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1391,7 +1532,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "31aaf2a4-8e2f-11eb-a9c4-faffc265b501",
@@ -1423,7 +1564,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1436,7 +1576,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f7c73-c451-11e9-af4b-a4d18cec433a",
@@ -1471,14 +1611,11 @@
                 {
                     "card_id": "466f7c73-c451-11e9-af4b-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1491,19 +1628,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f7c73-c451-11e9-af4b-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1516,7 +1678,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f7c73-c451-11e9-af4b-a4d18cec433a",
@@ -1634,13 +1796,38 @@
                     "card_id": "56c7a80c-c450-11e9-9ec4-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1653,20 +1840,43 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "56c7a80c-c450-11e9-9ec4-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "7d08d556-b831-4a7b-8a47-2068db0db6e6",
+                                        "language_id": "en",
+                                        "list_item_id": "b441941d-8d0d-4db3-9a99-cd28886d500a",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "e24a3dd7-06bb-4238-a161-81ab6c582574",
+                                        "language_id": "en",
+                                        "list_item_id": "1e9d7790-e9fa-4971-a37c-0ee8ba4db798",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1679,7 +1889,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59762bf0-c450-11e9-a049-a4d18cec433a",
@@ -1719,7 +1929,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1732,7 +1941,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59762bf0-c450-11e9-a049-a4d18cec433a",
@@ -1880,7 +2089,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1893,7 +2101,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4f9298d9-9116-11ec-a428-ad03e9261309",
@@ -2138,7 +2346,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2151,7 +2358,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f879e-c451-11e9-8c69-a4d18cec433a",
@@ -2183,7 +2390,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2196,7 +2402,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59763442-c450-11e9-b995-a4d18cec433a",
@@ -2299,7 +2505,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2312,7 +2517,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59763442-c450-11e9-b995-a4d18cec433a",
@@ -2391,13 +2596,24 @@
                     "card_id": "466f8b54-c451-11e9-9dac-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2410,19 +2626,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f8b54-c451-11e9-9dac-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2435,7 +2676,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f8b54-c451-11e9-9dac-a4d18cec433a",
@@ -2500,14 +2741,11 @@
                 {
                     "card_id": "597641f8-c450-11e9-9f5a-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2520,19 +2758,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "597641f8-c450-11e9-9f5a-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2545,7 +2808,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "597641f8-c450-11e9-9f5a-a4d18cec433a",
@@ -2654,14 +2917,11 @@
                 {
                     "card_id": "56c7a438-c450-11e9-97d9-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2674,19 +2934,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "56c7a438-c450-11e9-97d9-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2699,7 +2984,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "56c7a438-c450-11e9-97d9-a4d18cec433a",
@@ -2735,13 +3020,38 @@
                     "card_id": "466f8f80-c451-11e9-a943-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2754,19 +3064,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f8f80-c451-11e9-a943-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2779,7 +3086,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f8f80-c451-11e9-a943-a4d18cec433a",
@@ -2901,7 +3208,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2914,7 +3220,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f782e-c451-11e9-8fc2-a4d18cec433a",
@@ -3072,7 +3378,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3085,7 +3390,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59762538-c450-11e9-98ab-a4d18cec433a",
@@ -3125,7 +3430,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3138,7 +3442,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59762538-c450-11e9-98ab-a4d18cec433a",
@@ -3185,7 +3489,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3198,7 +3501,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5620d3cc-c450-11e9-942f-a4d18cec433a",
@@ -3290,7 +3593,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3303,7 +3605,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59764b61-c450-11e9-8100-a4d18cec433a",
@@ -3500,14 +3802,11 @@
                 {
                     "card_id": "59763b85-c450-11e9-b05f-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3520,19 +3819,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59763b85-c450-11e9-b05f-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3545,7 +3869,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "59763b85-c450-11e9-b05f-a4d18cec433a",
@@ -3629,7 +3953,6 @@
                             "placeholder"
                         ],
                         "label": "Curation Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3642,7 +3965,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f83f3-c451-11e9-92bb-a4d18cec433a",
@@ -3722,13 +4045,24 @@
                     "card_id": "466f83f3-c451-11e9-92bb-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "461bf80b-bf25-47a1-b757-2dbefb157aa4"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "484bd1f7-042c-4d29-9763-b705811a3792",
+                                        "language_id": "en",
+                                        "list_item_id": "f3725a5c-4f37-4142-b252-86bdd125988a",
+                                        "value": "curating",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "74760cd2-f255-474c-87d5-2e1c5394d11e",
+                                "uri": "http://vocab.getty.edu/aat/300054277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Curation Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3741,7 +4075,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f83f3-c451-11e9-92bb-a4d18cec433a",
@@ -3910,7 +4244,6 @@
                             "placeholder"
                         ],
                         "label": "Timespan of Curation Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3923,7 +4256,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "466f8030-c451-11e9-be86-a4d18cec433a",
@@ -3998,7 +4331,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4011,7 +4343,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d64f7cf5-d352-11e9-9b12-a4d18cec433a",
@@ -4099,14 +4431,37 @@
                     "card_id": "d64f7cf5-d352-11e9-9b12-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4119,19 +4474,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d64f7cf5-d352-11e9-9b12-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4144,7 +4524,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d64f7882-d352-11e9-a309-a4d18cec433a",
@@ -4231,14 +4611,11 @@
                 {
                     "card_id": "d64f7882-d352-11e9-a309-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4251,7 +4628,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d64f7882-d352-11e9-a309-a4d18cec433a",
@@ -4261,7 +4638,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4274,7 +4650,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": "rgba(5,114,102,0.8)",
@@ -6202,10 +6578,10 @@
                 {
                     "alias": "curation_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6228,9 +6604,10 @@
                 {
                     "alias": "curation_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6253,9 +6630,10 @@
                 {
                     "alias": "curation_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6381,9 +6759,10 @@
                 {
                     "alias": "curation_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6509,9 +6888,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6572,9 +6952,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "3534ed28-8baa-40f0-a4c2-97e23870cdb3"
+                        "controlledList": "3534ed28-8baa-40f0-a4c2-97e23870cdb3",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6852,9 +7233,10 @@
                 {
                     "alias": "curation_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7005,9 +7387,10 @@
                 {
                     "alias": "curation_technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7030,9 +7413,10 @@
                 {
                     "alias": "curation_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7158,9 +7542,10 @@
                 {
                     "alias": "curation_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7183,9 +7568,10 @@
                 {
                     "alias": "curation_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7245,9 +7631,10 @@
                 {
                     "alias": "curation_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7270,9 +7657,10 @@
                 {
                     "alias": "curation_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7368,9 +7756,10 @@
                 {
                     "alias": "curation_type",
                     "config": {
-                        "rdmCollection": "74760cd2-f255-474c-87d5-2e1c5394d11e"
+                        "controlledList": "74760cd2-f255-474c-87d5-2e1c5394d11e",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7490,9 +7879,10 @@
                 {
                     "alias": "curation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7540,9 +7930,10 @@
                 {
                     "alias": "curation_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7565,9 +7956,10 @@
                 {
                     "alias": "curation_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7928,9 +8320,10 @@
                 {
                     "alias": "curation_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8108,9 +8501,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8293,9 +8687,10 @@
                 {
                     "alias": "name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8378,9 +8773,10 @@
                 {
                     "alias": "name_type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8451,9 +8847,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "044b55b3-bd2b-4c66-bb92-f60d6a563e54"
+                        "controlledList": "044b55b3-bd2b-4c66-bb92-f60d6a563e54",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8605,10 +9002,10 @@
                 {
                     "alias": "statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8631,9 +9028,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8656,9 +9054,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "f44f7240-35c5-49e8-a0e3-2ffe308f0862"
+                        "controlledList": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8750,9 +9149,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9030,9 +9430,10 @@
                 {
                     "alias": "created_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9135,9 +9536,10 @@
                 {
                     "alias": "created_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9185,9 +9587,10 @@
                 {
                     "alias": "created_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9303,9 +9706,10 @@
                 {
                     "alias": "created_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9351,9 +9755,10 @@
                 {
                     "alias": "created_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9501,9 +9906,10 @@
                 {
                     "alias": "created_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9526,9 +9932,10 @@
                 {
                     "alias": "created_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9703,9 +10110,10 @@
                 {
                     "alias": "created_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9728,9 +10136,10 @@
                 {
                     "alias": "created_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9979,9 +10388,10 @@
                 {
                     "alias": "created_type",
                     "config": {
-                        "rdmCollection": "cde31c5b-8ab2-4fbe-9b55-11eed1d478f7"
+                        "controlledList": "cde31c5b-8ab2-4fbe-9b55-11eed1d478f7",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10073,9 +10483,10 @@
                 {
                     "alias": "created_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10323,10 +10734,10 @@
                 {
                     "alias": "created_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10349,9 +10760,10 @@
                 {
                     "alias": "created_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10374,9 +10786,10 @@
                 {
                     "alias": "created_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10505,9 +10918,10 @@
                 {
                     "alias": "created_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10651,9 +11065,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -10678,9 +11093,9 @@
             "publication": {
                 "graph_id": "1b210ef3-b25c-11e9-a037-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "7f1c3182-382a-11f0-806e-020539808477",
-                "published_time": "2025-05-23T16:06:02.082"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "a8c851af-a7cb-4e19-9c6a-673c3a48a1e7",
+                "published_time": "2026-02-06T12:58:36.265"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Digital Resources.json
+++ b/arches_for_science/pkg/graphs/resource_models/Digital Resources.json
@@ -1166,13 +1166,38 @@
                     "card_id": "ef5c1bfd-ca7a-11e9-b1ee-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1185,19 +1210,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ef5c1bfd-ca7a-11e9-b1ee-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1210,7 +1232,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ef5c1bfd-ca7a-11e9-b1ee-a4d18cec433a",
@@ -1302,7 +1324,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1315,7 +1336,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5a1f7a6e-ca7c-11e9-a6e5-a4d18cec433a",
@@ -1373,13 +1394,38 @@
                     "card_id": "5a1f7a6e-ca7c-11e9-a6e5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1392,7 +1438,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5a1f7a6e-ca7c-11e9-a6e5-a4d18cec433a",
@@ -1427,14 +1473,11 @@
                 {
                     "card_id": "5a1f7a6e-ca7c-11e9-a6e5-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1447,7 +1490,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "23fa6d5c-9474-11ea-ae26-3af9d3b32b71",
@@ -1501,7 +1544,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1514,19 +1556,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "17fc5ac2-79a5-11ea-8ae2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1539,7 +1606,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "17fc5ac2-79a5-11ea-8ae2-acde48001122",
@@ -1672,7 +1739,6 @@
                             "placeholder"
                         ],
                         "label": "Timespan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1685,7 +1751,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de952354-ca7a-11e9-9557-a4d18cec433a",
@@ -1790,7 +1856,6 @@
                             "placeholder"
                         ],
                         "label": "File Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1803,7 +1868,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "7c4a758f-d380-11e9-9a7b-a4d18cec433a",
@@ -1869,13 +1934,38 @@
                     "card_id": "de951187-ca7a-11e9-8b5e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1888,19 +1978,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de951187-ca7a-11e9-8b5e-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1913,7 +2000,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de951187-ca7a-11e9-8b5e-a4d18cec433a",
@@ -2093,7 +2180,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2106,7 +2192,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de951e6b-ca7a-11e9-bd04-a4d18cec433a",
@@ -2116,7 +2202,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2129,7 +2214,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de951e6b-ca7a-11e9-bd04-a4d18cec433a",
@@ -2257,7 +2342,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2270,7 +2354,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de951a4f-ca7a-11e9-96b9-a4d18cec433a",
@@ -2317,7 +2401,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2330,7 +2413,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de951a4f-ca7a-11e9-96b9-a4d18cec433a",
@@ -2470,13 +2553,38 @@
                     "card_id": "d2fdb538-ca7a-11e9-9afd-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2489,7 +2597,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d2fdb538-ca7a-11e9-9afd-a4d18cec433a",
@@ -2547,13 +2655,24 @@
                     "card_id": "d2fdb538-ca7a-11e9-9afd-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2566,7 +2685,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d81614a3-ca7a-11e9-a611-a4d18cec433a",
@@ -2702,7 +2821,6 @@
                             "placeholder"
                         ],
                         "label": "Dimension Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2715,7 +2833,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d81614a3-ca7a-11e9-a611-a4d18cec433a",
@@ -2762,7 +2880,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2775,7 +2892,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5736d617-9117-11ec-a428-ad03e9261309",
@@ -2871,7 +2988,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2884,7 +3000,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5736d617-9117-11ec-a428-ad03e9261309",
@@ -3066,14 +3182,37 @@
                     "card_id": "da1faf1c-ca7a-11e9-8946-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "3a6a31fb-be19-41ed-ad4a-cdfb0b70dced",
+                                        "language_id": "en",
+                                        "list_item_id": "3789dcf2-e752-4a70-8507-8c3ca1e3804c",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5ea4b9fe-5b06-478b-aaf1-9a33d13ed8c0",
+                                        "language_id": "en",
+                                        "list_item_id": "59e115f2-0d6e-4bfb-81b2-794b9c74da97",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3086,19 +3225,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "da1faf1c-ca7a-11e9-8946-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3111,7 +3275,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de952770-ca7a-11e9-a5ac-a4d18cec433a",
@@ -3139,13 +3303,38 @@
                     "card_id": "de952770-ca7a-11e9-a5ac-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3158,7 +3347,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de952770-ca7a-11e9-a5ac-a4d18cec433a",
@@ -3193,14 +3382,11 @@
                 {
                     "card_id": "de952770-ca7a-11e9-a5ac-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3213,7 +3399,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de952770-ca7a-11e9-a5ac-a4d18cec433a",
@@ -3308,14 +3494,11 @@
                 {
                     "card_id": "d8160d0f-ca7a-11e9-ab1c-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3328,7 +3511,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d8160d0f-ca7a-11e9-ab1c-a4d18cec433a",
@@ -3356,13 +3539,38 @@
                     "card_id": "d8160d0f-ca7a-11e9-ab1c-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3375,7 +3583,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8c515561-9117-11ec-a428-ad03e9261309",
@@ -3407,7 +3615,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3420,19 +3627,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "da1faa4f-ca7a-11e9-8223-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3445,7 +3649,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "da1faa4f-ca7a-11e9-8223-a4d18cec433a",
@@ -3473,13 +3677,38 @@
                     "card_id": "da1faa4f-ca7a-11e9-8223-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3492,7 +3721,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "da1faa4f-ca7a-11e9-8223-a4d18cec433a",
@@ -3577,13 +3806,24 @@
                     "card_id": "de950bf0-ca7a-11e9-8e72-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3596,7 +3836,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de950bf0-ca7a-11e9-8e72-a4d18cec433a",
@@ -3684,13 +3924,38 @@
                     "card_id": "de950bf0-ca7a-11e9-8e72-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3703,7 +3968,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "db05bdc2-ca7a-11e9-90c4-a4d18cec433a",
@@ -3795,7 +4060,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3808,7 +4072,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ba46115a-78ed-11ea-a33b-acde48001122",
@@ -3848,7 +4112,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3861,7 +4124,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "52c997f5-ca7c-11e9-b7e0-a4d18cec433a",
@@ -3926,14 +4189,11 @@
                 {
                     "card_id": "52c997f5-ca7c-11e9-b7e0-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3946,7 +4206,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "52c997f5-ca7c-11e9-b7e0-a4d18cec433a",
@@ -3974,13 +4234,38 @@
                     "card_id": "52c997f5-ca7c-11e9-b7e0-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3993,7 +4278,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1e1a694-9473-11ea-ae26-3af9d3b32b71",
@@ -4028,14 +4313,11 @@
                 {
                     "card_id": "c1e1a694-9473-11ea-ae26-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4048,19 +4330,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1e1a694-9473-11ea-ae26-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4073,7 +4380,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1e1a446-9473-11ea-ae26-3af9d3b32b71",
@@ -4157,7 +4464,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4170,7 +4476,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1e1a446-9473-11ea-ae26-3af9d3b32b71",
@@ -4217,7 +4523,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Setting",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4230,7 +4535,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1e1a8d8-9473-11ea-ae26-3af9d3b32b71",
@@ -4296,13 +4601,38 @@
                     "card_id": "c1e1a8d8-9473-11ea-ae26-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4315,19 +4645,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1e1a8d8-9473-11ea-ae26-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4340,7 +4667,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1e1a8d8-9473-11ea-ae26-3af9d3b32b71",
@@ -4398,13 +4725,24 @@
                     "card_id": "c1e1aaf4-9473-11ea-ae26-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4417,19 +4755,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1e1aaf4-9473-11ea-ae26-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4442,7 +4805,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "56f8e5c0-ca7c-11e9-822e-a4d18cec433a",
@@ -4482,7 +4845,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4495,7 +4857,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "56f8e5c0-ca7c-11e9-822e-a4d18cec433a",
@@ -4583,13 +4945,38 @@
                     "card_id": "ca226ec0-78ed-11ea-a33b-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4602,19 +4989,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ca226ec0-78ed-11ea-a33b-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4627,7 +5011,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ca227140-78ed-11ea-a33b-acde48001122",
@@ -4663,14 +5047,37 @@
                     "card_id": "ca227140-78ed-11ea-a33b-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "2eef4771-830c-494d-9283-3348a383dfd6"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "3a6a31fb-be19-41ed-ad4a-cdfb0b70dced",
+                                        "language_id": "en",
+                                        "list_item_id": "3789dcf2-e752-4a70-8507-8c3ca1e3804c",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "999d8b43-3072-4c22-8462-002528101351",
+                                        "language_id": "en",
+                                        "list_item_id": "5d26c70d-774b-4403-9c54-c81fe776eabe",
+                                        "value": "interpretation",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9",
+                                "uri": "http://vocab.getty.edu/aat/300226183"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4683,19 +5090,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ca227140-78ed-11ea-a33b-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4708,7 +5140,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de9515b5-ca7a-11e9-954b-a4d18cec433a",
@@ -4770,7 +5202,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4783,7 +5214,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "de9515b5-ca7a-11e9-954b-a4d18cec433a",
@@ -4871,13 +5302,38 @@
                     "card_id": "ef5c20d7-ca7a-11e9-8aff-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4890,7 +5346,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ef5c20d7-ca7a-11e9-8aff-a4d18cec433a",
@@ -4948,14 +5404,37 @@
                     "card_id": "ef5c20d7-ca7a-11e9-8aff-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4968,7 +5447,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "29c969cf-ca7c-11e9-876d-a4d18cec433a",
@@ -5008,7 +5487,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Service Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5021,7 +5499,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "29c969cf-ca7c-11e9-876d-a4d18cec433a",
@@ -5087,13 +5565,24 @@
                     "card_id": "5a1f80d7-ca7c-11e9-b5c1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5106,7 +5595,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5a1f80d7-ca7c-11e9-b5c1-a4d18cec433a",
@@ -5164,13 +5653,38 @@
                     "card_id": "5a1f80d7-ca7c-11e9-b5c1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5183,7 +5697,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": "rgba(87,142,169,0.75)",
@@ -7419,9 +7933,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "8dc4c1ac-aae5-41f6-817b-9ee5fef855fe"
+                        "controlledList": "8dc4c1ac-aae5-41f6-817b-9ee5fef855fe",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": true,
                     "fieldname": "type",
@@ -7467,9 +7982,10 @@
                 {
                     "alias": "file_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7492,9 +8008,10 @@
                 {
                     "alias": "file_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7625,9 +8142,10 @@
                 {
                     "alias": "file_type",
                     "config": {
-                        "rdmCollection": "5da484cb-7537-43be-91cb-dc28c4369efb"
+                        "controlledList": "5da484cb-7537-43be-91cb-dc28c4369efb",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7707,9 +8225,10 @@
                 {
                     "alias": "service_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7789,9 +8308,10 @@
                 {
                     "alias": "service_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7860,9 +8380,10 @@
                 {
                     "alias": "service_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8097,9 +8618,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8305,10 +8827,10 @@
                 {
                     "alias": "service_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8331,9 +8853,10 @@
                 {
                     "alias": "service_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8356,9 +8879,10 @@
                 {
                     "alias": "service_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8484,9 +9008,10 @@
                 {
                     "alias": "service_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8566,9 +9091,10 @@
                 {
                     "alias": "service_type",
                     "config": {
-                        "rdmCollection": "1230c0d7-ed5b-4f97-b54d-74bda170c7e3"
+                        "controlledList": "1230c0d7-ed5b-4f97-b54d-74bda170c7e3",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8782,9 +9308,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -8913,9 +9440,10 @@
                 {
                     "alias": "file_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9053,9 +9581,10 @@
                 {
                     "alias": "file_creation_procedure_dimension_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9101,9 +9630,10 @@
                 {
                     "alias": "file_creation_procedure_dimension_type",
                     "config": {
-                        "rdmCollection": "c9e838f8-7660-4701-821c-721dac98a10b"
+                        "controlledList": "c9e838f8-7660-4701-821c-721dac98a10b",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9206,9 +9736,10 @@
                 {
                     "alias": "file_creation_procedure_dimension_unit",
                     "config": {
-                        "rdmCollection": "44295221-1215-4359-a079-234b317f65b7"
+                        "controlledList": "44295221-1215-4359-a079-234b317f65b7",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9277,9 +9808,10 @@
                 {
                     "alias": "file_creation_procedure_dimension_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9325,9 +9857,10 @@
                 {
                     "alias": "file_creation_procedure_dimension_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9350,9 +9883,10 @@
                 {
                     "alias": "file_creation_procedure_dimension_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9375,9 +9909,10 @@
                 {
                     "alias": "file_creation_procedure_dimension_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9400,10 +9935,10 @@
                 {
                     "alias": "file_creation_procedure_dimension_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9495,9 +10030,10 @@
                 {
                     "alias": "file_statement_type",
                     "config": {
-                        "rdmCollection": "5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"
+                        "controlledList": "5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9520,9 +10056,10 @@
                 {
                     "alias": "file_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9545,9 +10082,10 @@
                 {
                     "alias": "file_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9570,10 +10108,10 @@
                 {
                     "alias": "file_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9711,9 +10249,10 @@
                 {
                     "alias": "name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9796,9 +10335,10 @@
                 {
                     "alias": "name_type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9938,9 +10478,10 @@
                 {
                     "alias": "dimension_type",
                     "config": {
-                        "rdmCollection": "c2788105-d184-4192-b19f-7d504f43d7b0"
+                        "controlledList": "c2788105-d184-4192-b19f-7d504f43d7b0",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9963,9 +10504,10 @@
                 {
                     "alias": "dimension_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10034,9 +10576,10 @@
                 {
                     "alias": "dimension_unit",
                     "config": {
-                        "rdmCollection": "9faa2596-258f-4a2f-a482-d07cb1e4126e"
+                        "controlledList": "9faa2596-258f-4a2f-a482-d07cb1e4126e",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10176,9 +10719,10 @@
                 {
                     "alias": "dimension_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10247,10 +10791,10 @@
                 {
                     "alias": "statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10273,9 +10817,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10298,9 +10843,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"
+                        "controlledList": "5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10429,9 +10975,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10534,9 +11081,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10803,9 +11351,10 @@
                 {
                     "alias": "creation_type",
                     "config": {
-                        "rdmCollection": "38867773-6543-4a98-90cc-dc1c7bec3340"
+                        "controlledList": "38867773-6543-4a98-90cc-dc1c7bec3340",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10828,9 +11377,10 @@
                 {
                     "alias": "creation_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10853,9 +11403,10 @@
                 {
                     "alias": "creation_technique",
                     "config": {
-                        "rdmCollection": "641c4612-732b-48c3-b958-3af2c5c3f647"
+                        "controlledList": "641c4612-732b-48c3-b958-3af2c5c3f647",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11239,9 +11790,10 @@
                 {
                     "alias": "creation_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11369,9 +11921,10 @@
                 {
                     "alias": "creation_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11500,9 +12053,10 @@
                 {
                     "alias": "creation_type_n1",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11571,9 +12125,10 @@
                 {
                     "alias": "creation_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11704,9 +12259,10 @@
                 {
                     "alias": "creation_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11752,9 +12308,10 @@
                 {
                     "alias": "creation_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11942,9 +12499,10 @@
                 {
                     "alias": "creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12001,9 +12559,10 @@
                 {
                     "alias": "creation_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12049,9 +12608,10 @@
                 {
                     "alias": "creation_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12203,10 +12763,10 @@
                 {
                     "alias": "creation_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12229,9 +12789,10 @@
                 {
                     "alias": "creation_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12254,9 +12815,10 @@
                 {
                     "alias": "creation_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12382,9 +12944,10 @@
                 {
                     "alias": "creation_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12466,9 +13029,9 @@
             "publication": {
                 "graph_id": "707cbd78-ca7a-11e9-990b-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "fc5b6458-382d-11f0-b11a-020539808477",
-                "published_time": "2025-05-23T16:31:00.701"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "4287dff0-0b88-4a8d-ad4b-c210d8679558",
+                "published_time": "2026-02-06T12:59:51.708"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Group.json
+++ b/arches_for_science/pkg/graphs/resource_models/Group.json
@@ -1192,14 +1192,11 @@
                 {
                     "card_id": "d3a55182-c061-11e9-992f-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1212,19 +1209,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a55182-c061-11e9-992f-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1237,7 +1259,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a55182-c061-11e9-992f-a4d18cec433a",
@@ -1299,7 +1321,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1312,7 +1333,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a4f570-c061-11e9-9b3e-a4d18cec433a",
@@ -1352,7 +1373,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1365,7 +1385,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a4f570-c061-11e9-9b3e-a4d18cec433a",
@@ -1449,7 +1469,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1462,7 +1481,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d559e-d284-11e9-a348-a4d18cec433a",
@@ -1472,7 +1491,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1485,7 +1503,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d559e-d284-11e9-a348-a4d18cec433a",
@@ -1555,7 +1573,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1568,7 +1585,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d559e-d284-11e9-a348-a4d18cec433a",
@@ -1677,14 +1694,11 @@
                 {
                     "card_id": "54948d8c-c05e-11e9-88db-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1697,19 +1711,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "54948d8c-c05e-11e9-88db-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1722,7 +1761,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f5f42-c05e-11e9-af92-a4d18cec433a",
@@ -1732,7 +1771,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1745,7 +1783,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f5f42-c05e-11e9-af92-a4d18cec433a",
@@ -1807,7 +1845,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1820,7 +1857,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f5f42-c05e-11e9-af92-a4d18cec433a",
@@ -1860,7 +1897,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1873,7 +1909,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f6563-c05e-11e9-b5a5-a4d18cec433a",
@@ -1965,7 +2001,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1978,7 +2013,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f57c0-c05e-11e9-a3ed-a4d18cec433a",
@@ -2018,7 +2053,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2031,7 +2065,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f57c0-c05e-11e9-a3ed-a4d18cec433a",
@@ -2119,13 +2153,38 @@
                     "card_id": "ec344c80-c061-11e9-bd85-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2138,7 +2197,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ec344c80-c061-11e9-bd85-a4d18cec433a",
@@ -2166,14 +2225,37 @@
                     "card_id": "ec344c80-c061-11e9-bd85-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2186,7 +2268,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ec344c80-c061-11e9-bd85-a4d18cec433a",
@@ -2304,13 +2386,24 @@
                     "card_id": "d3a54b07-c061-11e9-b4ac-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2323,19 +2416,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a54b07-c061-11e9-b4ac-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2348,7 +2466,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a54b07-c061-11e9-b4ac-a4d18cec433a",
@@ -2436,13 +2554,38 @@
                     "card_id": "ec34485c-c061-11e9-b52d-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2455,19 +2598,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ec34485c-c061-11e9-b52d-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2480,7 +2620,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ec34485c-c061-11e9-b52d-a4d18cec433a",
@@ -2542,7 +2682,6 @@
                             "placeholder"
                         ],
                         "label": "Professional Activity Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2555,7 +2694,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a52100-c061-11e9-b4e0-a4d18cec433a",
@@ -2631,7 +2770,6 @@
                             "placeholder"
                         ],
                         "label": "Professional Activity Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2644,7 +2782,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a52100-c061-11e9-b4e0-a4d18cec433a",
@@ -2758,7 +2896,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2771,7 +2908,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "32db9354-c05e-11e9-8d0a-a4d18cec433a",
@@ -2807,13 +2944,38 @@
                     "card_id": "32db9354-c05e-11e9-8d0a-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2826,7 +2988,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "32db9354-c05e-11e9-8d0a-a4d18cec433a",
@@ -2883,14 +3045,11 @@
                 {
                     "card_id": "32db9354-c05e-11e9-8d0a-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2903,7 +3062,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d4a2e-d284-11e9-b729-a4d18cec433a",
@@ -2999,13 +3158,24 @@
                     "card_id": "ae7d4a2e-d284-11e9-b729-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3018,7 +3188,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d4678-d284-11e9-b9fd-a4d18cec433a",
@@ -3058,7 +3228,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3071,7 +3240,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d3f3d-d284-11e9-868d-a4d18cec433a",
@@ -3125,7 +3294,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3138,7 +3306,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d59cc-d284-11e9-b0f2-a4d18cec433a",
@@ -3178,7 +3346,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3191,7 +3358,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d59cc-d284-11e9-b0f2-a4d18cec433a",
@@ -3277,14 +3444,37 @@
                     "card_id": "ae7d4678-d284-11e9-b9fd-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3297,7 +3487,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d526e-d284-11e9-8849-a4d18cec433a",
@@ -3414,13 +3604,38 @@
                     "card_id": "ae7d4a2e-d284-11e9-b729-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3433,7 +3648,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d59cc-d284-11e9-b0f2-a4d18cec433a",
@@ -3443,7 +3658,6 @@
                             "placeholder"
                         ],
                         "label": "Dissolution Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3456,7 +3670,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d4de3-d284-11e9-8264-a4d18cec433a",
@@ -3535,13 +3749,38 @@
                     "card_id": "ae7d5d33-d284-11e9-988d-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3554,7 +3793,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d4a2e-d284-11e9-b729-a4d18cec433a",
@@ -3638,7 +3877,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3651,19 +3889,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d5d33-d284-11e9-988d-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3676,7 +3911,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d4de3-d284-11e9-8264-a4d18cec433a",
@@ -3748,14 +3983,11 @@
                 {
                     "card_id": "ae7d3aca-d284-11e9-8b98-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3768,7 +4000,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d59cc-d284-11e9-b0f2-a4d18cec433a",
@@ -3840,13 +4072,38 @@
                     "card_id": "ae7d3aca-d284-11e9-8b98-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3859,7 +4116,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d3f3d-d284-11e9-868d-a4d18cec433a",
@@ -3916,13 +4173,38 @@
                     "card_id": "ae7d4678-d284-11e9-b9fd-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3935,7 +4217,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ae7d4de3-d284-11e9-8264-a4d18cec433a",
@@ -4012,7 +4294,6 @@
                             "placeholder"
                         ],
                         "label": "Formation Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4025,7 +4306,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f6987-c05e-11e9-9e36-a4d18cec433a",
@@ -4257,7 +4538,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4270,7 +4550,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a4e44a-c061-11e9-b1af-a4d18cec433a",
@@ -4324,7 +4604,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4337,7 +4616,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a5048c-c061-11e9-aba3-a4d18cec433a",
@@ -4347,7 +4626,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4360,7 +4638,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a5048c-c061-11e9-aba3-a4d18cec433a",
@@ -4527,7 +4805,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4540,7 +4817,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f5b6e-c05e-11e9-b597-a4d18cec433a",
@@ -4725,7 +5002,6 @@
                             "placeholder"
                         ],
                         "label": "Contact Point Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4738,7 +5014,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "12707d3d-c05e-11e9-9866-a4d18cec433a",
@@ -4766,13 +5042,38 @@
                     "card_id": "12707d3d-c05e-11e9-9866-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4785,7 +5086,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "12707d3d-c05e-11e9-9866-a4d18cec433a",
@@ -4821,13 +5122,24 @@
                     "card_id": "12707d3d-c05e-11e9-9866-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4840,7 +5152,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "12707d3d-c05e-11e9-9866-a4d18cec433a",
@@ -4966,7 +5278,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4979,7 +5290,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e95988e1-9117-11ec-a428-ad03e9261309",
@@ -5083,7 +5394,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5096,7 +5406,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "280206c0-c05e-11e9-9cc4-a4d18cec433a",
@@ -5314,7 +5624,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5327,7 +5636,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d3a52aa3-c061-11e9-8486-a4d18cec433a",
@@ -5374,7 +5683,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5387,7 +5695,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f6cee-c05e-11e9-82fa-a4d18cec433a",
@@ -5423,13 +5731,24 @@
                     "card_id": "3b5f6cee-c05e-11e9-82fa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5442,7 +5761,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f6cee-c05e-11e9-82fa-a4d18cec433a",
@@ -5500,13 +5819,38 @@
                     "card_id": "3b5f6cee-c05e-11e9-82fa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5519,7 +5863,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "54949228-c05e-11e9-ba58-a4d18cec433a",
@@ -5555,13 +5899,38 @@
                     "card_id": "54949228-c05e-11e9-ba58-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5574,20 +5943,43 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "54949228-c05e-11e9-ba58-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5600,7 +5992,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "54949228-c05e-11e9-ba58-a4d18cec433a",
@@ -5658,13 +6050,38 @@
                     "card_id": "32db9714-c05e-11e9-8b31-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5677,20 +6094,43 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "32db9714-c05e-11e9-8b31-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "7d08d556-b831-4a7b-8a47-2068db0db6e6",
+                                        "language_id": "en",
+                                        "list_item_id": "b441941d-8d0d-4db3-9a99-cd28886d500a",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "e24a3dd7-06bb-4238-a161-81ab6c582574",
+                                        "language_id": "en",
+                                        "list_item_id": "1e9d7790-e9fa-4971-a37c-0ee8ba4db798",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5703,7 +6143,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "32db9714-c05e-11e9-8b31-a4d18cec433a",
@@ -5869,7 +6309,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5882,7 +6321,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3b5f534c-c05e-11e9-aae3-a4d18cec433a",
@@ -5959,7 +6398,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5972,7 +6410,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": "rgba(231,111,81,0.75)",
@@ -8608,9 +9046,10 @@
                 {
                     "alias": "name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8693,9 +9132,10 @@
                 {
                     "alias": "name_type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8849,9 +9289,10 @@
                 {
                     "alias": "contact_point_type",
                     "config": {
-                        "rdmCollection": "92d3e507-9d66-4122-9cd6-36430cf36e3c"
+                        "controlledList": "92d3e507-9d66-4122-9cd6-36430cf36e3c",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -8897,9 +9338,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9051,10 +9493,10 @@
                 {
                     "alias": "statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9077,9 +9519,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9102,9 +9545,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "f44f7240-35c5-49e8-a0e3-2ffe308f0862"
+                        "controlledList": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9196,9 +9640,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9476,9 +9921,10 @@
                 {
                     "alias": "formation_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9581,9 +10027,10 @@
                 {
                     "alias": "formation_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9631,9 +10078,10 @@
                 {
                     "alias": "formation_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9749,9 +10197,10 @@
                 {
                     "alias": "formation_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9797,9 +10246,10 @@
                 {
                     "alias": "formation_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9947,9 +10397,10 @@
                 {
                     "alias": "formation_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9972,9 +10423,10 @@
                 {
                     "alias": "formation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10149,9 +10601,10 @@
                 {
                     "alias": "formation_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10174,9 +10627,10 @@
                 {
                     "alias": "formation_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10433,9 +10887,10 @@
                 {
                     "alias": "formation_type",
                     "config": {
-                        "rdmCollection": "cde31c5b-8ab2-4fbe-9b55-11eed1d478f7"
+                        "controlledList": "cde31c5b-8ab2-4fbe-9b55-11eed1d478f7",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10527,9 +10982,10 @@
                 {
                     "alias": "formation_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10717,10 +11173,10 @@
                 {
                     "alias": "formation_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10743,9 +11199,10 @@
                 {
                     "alias": "formation_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10768,9 +11225,10 @@
                 {
                     "alias": "formation_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10896,9 +11354,10 @@
                 {
                     "alias": "formation_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11001,9 +11460,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "093ddd50-2a48-4d20-8b46-344ade2af30c"
+                        "controlledList": "093ddd50-2a48-4d20-8b46-344ade2af30c",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11049,9 +11509,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -11367,9 +11828,10 @@
                 {
                     "alias": "dissolution_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11426,9 +11888,10 @@
                 {
                     "alias": "dissolution_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11451,9 +11914,10 @@
                 {
                     "alias": "dissolution_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11476,9 +11940,10 @@
                 {
                     "alias": "dissolution_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11673,9 +12138,10 @@
                 {
                     "alias": "dissolution_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11698,9 +12164,10 @@
                 {
                     "alias": "dissolution_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11760,9 +12227,10 @@
                 {
                     "alias": "dissolution_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11865,9 +12333,10 @@
                 {
                     "alias": "dissolution_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12055,9 +12524,10 @@
                 {
                     "alias": "dissolution_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12139,9 +12609,10 @@
                 {
                     "alias": "dissolution_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12326,9 +12797,10 @@
                 {
                     "alias": "dissolution_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12351,10 +12823,10 @@
                 {
                     "alias": "dissolution_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12446,9 +12918,10 @@
                 {
                     "alias": "dissolution_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12508,9 +12981,10 @@
                 {
                     "alias": "dissolution_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12533,9 +13007,10 @@
                 {
                     "alias": "dissolution_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12619,9 +13094,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -12996,9 +13472,10 @@
                 {
                     "alias": "professional_activity_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13149,9 +13626,10 @@
                 {
                     "alias": "professional_activity_technique",
                     "config": {
-                        "rdmCollection": "b27ffefc-18a1-468f-8923-87530b6f5943"
+                        "controlledList": "b27ffefc-18a1-468f-8923-87530b6f5943",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13174,9 +13652,10 @@
                 {
                     "alias": "professional_activity_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13256,9 +13735,10 @@
                 {
                     "alias": "professional_activity_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13281,9 +13761,10 @@
                 {
                     "alias": "professional_activity_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13343,9 +13824,10 @@
                 {
                     "alias": "professional_activity_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13368,9 +13850,10 @@
                 {
                     "alias": "professional_activity_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13466,9 +13949,10 @@
                 {
                     "alias": "professional_activity_type",
                     "config": {
-                        "rdmCollection": "b3d6e036-e788-4c85-a1f0-3aa35f0a82f2"
+                        "controlledList": "b3d6e036-e788-4c85-a1f0-3aa35f0a82f2",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13588,9 +14072,10 @@
                 {
                     "alias": "professional_activity_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13638,9 +14123,10 @@
                 {
                     "alias": "professional_activity_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13663,9 +14149,10 @@
                 {
                     "alias": "professional_activity_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14034,9 +14521,10 @@
                 {
                     "alias": "professional_activity_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14214,9 +14702,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14422,10 +14911,10 @@
                 {
                     "alias": "professional_activity_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14448,9 +14937,10 @@
                 {
                     "alias": "professional_activity_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14473,9 +14963,10 @@
                 {
                     "alias": "professional_activity_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14601,9 +15092,10 @@
                 {
                     "alias": "professional_activity_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14685,9 +15177,9 @@
             "publication": {
                 "graph_id": "07883c9e-b25c-11e9-975a-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "4444d2ae-382e-11f0-a8f5-020539808477",
-                "published_time": "2025-05-23T16:33:01.349"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "92e66e7b-e83d-47ca-977c-703d55ce05c7",
+                "published_time": "2026-02-06T12:59:40.726"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Instrument.json
+++ b/arches_for_science/pkg/graphs/resource_models/Instrument.json
@@ -723,7 +723,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -736,7 +735,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "45a0fc33-9118-11ec-a428-ad03e9261309",
@@ -832,7 +831,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -845,7 +843,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "45a0fc33-9118-11ec-a428-ad03e9261309",
@@ -975,13 +973,38 @@
                     "card_id": "b6cabf4c-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -994,7 +1017,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6cabf4c-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1021,14 +1044,11 @@
                 {
                     "card_id": "b6cabf4c-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1041,7 +1061,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6cabf4c-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1099,13 +1119,24 @@
                     "card_id": "b6c89c62-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1118,7 +1149,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c89c62-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1154,13 +1185,38 @@
                     "card_id": "b6c89c62-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1173,7 +1229,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c89c62-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1273,7 +1329,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1286,7 +1341,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c81f62-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1344,13 +1399,38 @@
                     "card_id": "b6c8ba3a-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1363,7 +1443,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c8ba3a-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1429,13 +1509,24 @@
                     "card_id": "b6c8ba3a-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1448,7 +1539,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c8ba3a-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1539,7 +1630,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1552,7 +1642,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6ca37fc-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1592,7 +1682,6 @@
                             "placeholder"
                         ],
                         "label": "Dimension Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1605,7 +1694,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6ca37fc-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1789,13 +1878,38 @@
                     "card_id": "b6ca6a56-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1808,19 +1922,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6ca6a56-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1833,7 +1944,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c9f8e6-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1843,7 +1954,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1856,7 +1966,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c9ae36-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1925,7 +2035,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1938,7 +2047,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c9d852-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2015,7 +2124,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2028,7 +2136,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c9d852-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2092,14 +2200,11 @@
                 {
                     "card_id": "b6ca5b1a-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2112,7 +2217,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6ca5b1a-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2178,13 +2283,38 @@
                     "card_id": "b6ca5b1a-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2197,7 +2327,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6ca5b1a-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2251,7 +2381,6 @@
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2264,7 +2393,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c8e9d8-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2274,7 +2403,6 @@
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2287,7 +2415,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c8e9d8-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2353,14 +2481,37 @@
                     "card_id": "b6ca98c8-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "c7c453d4-eac8-458c-9dfa-95a93e975555",
+                                        "language_id": "en",
+                                        "list_item_id": "b2f45594-6c10-49d7-a4b7-24e5ca839838",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "074dca4c-a3d3-4521-835d-f1fa1a9c775b",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "2218563c-c2ce-400f-85d7-445c12140953",
+                                        "language_id": "en",
+                                        "list_item_id": "9a51d30b-48e8-4f94-9344-cd2bb1d4b33a",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "074dca4c-a3d3-4521-835d-f1fa1a9c775b",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2373,19 +2524,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6ca98c8-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2398,7 +2574,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6ca98c8-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2498,7 +2674,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2511,7 +2686,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c8d196-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2600,14 +2775,11 @@
                 {
                     "card_id": "b6c8e262-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2620,19 +2792,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c8e262-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2645,7 +2842,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c8e262-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2785,13 +2982,38 @@
                     "card_id": "b6c844ce-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2804,19 +3026,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c844ce-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2829,7 +3048,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c844ce-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2913,7 +3132,6 @@
                             "placeholder"
                         ],
                         "label": "Production Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2926,7 +3144,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c8974e-99f6-11ea-a9b7-3af9d3b32b71",
@@ -3062,7 +3280,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3075,7 +3292,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b6c86d32-99f6-11ea-a9b7-3af9d3b32b71",
@@ -3159,7 +3376,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3172,7 +3388,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bd3fb786-cdca-11eb-a29f-024e0d439fdb",
@@ -4668,9 +4884,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -4825,9 +5042,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5337,9 +5555,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "05ad2322-38c4-434f-95ec-4f9f297515eb"
+                        "controlledList": "05ad2322-38c4-434f-95ec-4f9f297515eb",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": true,
                     "fieldname": "type",
@@ -5592,9 +5811,10 @@
                 {
                     "alias": "name_language_",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5663,9 +5883,10 @@
                 {
                     "alias": "dimension_name_type_",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5863,9 +6084,10 @@
                 {
                     "alias": "dimension_name_language_",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5888,9 +6110,10 @@
                 {
                     "alias": "production_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5936,9 +6159,10 @@
                 {
                     "alias": "production_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6021,9 +6245,10 @@
                 {
                     "alias": "production_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6046,9 +6271,10 @@
                 {
                     "alias": "production_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6139,9 +6365,10 @@
                 {
                     "alias": "production_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6164,9 +6391,10 @@
                 {
                     "alias": "production_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6269,10 +6497,10 @@
                 {
                     "alias": "production_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6318,9 +6546,10 @@
                 {
                     "alias": "production_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6366,9 +6595,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6607,9 +6837,10 @@
                 {
                     "alias": "production_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6632,9 +6863,10 @@
                 {
                     "alias": "production_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6680,9 +6912,10 @@
                 {
                     "alias": "production_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6742,9 +6975,10 @@
                 {
                     "alias": "name_type_",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6767,9 +7001,10 @@
                 {
                     "alias": "dimension_unit",
                     "config": {
-                        "rdmCollection": "44295221-1215-4359-a079-234b317f65b7"
+                        "controlledList": "44295221-1215-4359-a079-234b317f65b7",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6888,10 +7123,10 @@
                 {
                     "alias": "statement_language_",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6914,9 +7149,10 @@
                 {
                     "alias": "dimension_type_",
                     "config": {
-                        "rdmCollection": "c9e838f8-7660-4701-821c-721dac98a10b"
+                        "controlledList": "c9e838f8-7660-4701-821c-721dac98a10b",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6962,9 +7198,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6987,9 +7224,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7115,9 +7353,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "074dca4c-a3d3-4521-835d-f1fa1a9c775b"
+                        "controlledList": "074dca4c-a3d3-4521-835d-f1fa1a9c775b",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7140,9 +7379,10 @@
                 {
                     "alias": "production_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7165,9 +7405,10 @@
                 {
                     "alias": "production_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7514,9 +7755,10 @@
                 {
                     "alias": "production_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7539,9 +7781,10 @@
                 {
                     "alias": "production_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -7646,9 +7889,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -7711,9 +7955,9 @@
             "publication": {
                 "graph_id": "b6c819b8-99f6-11ea-a9b7-3af9d3b32b71",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "8bad062c-382e-11f0-9128-020539808477",
-                "published_time": "2025-05-23T16:35:01.150"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "1a079ff5-5793-44b9-97fb-279d91e784ba",
+                "published_time": "2026-02-06T12:58:30.571"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Modification.json
+++ b/arches_for_science/pkg/graphs/resource_models/Modification.json
@@ -728,14 +728,11 @@
                 {
                     "card_id": "a95ccd8a-c456-11e9-bfc1-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -748,7 +745,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95ccd8a-c456-11e9-bfc1-a4d18cec433a",
@@ -806,13 +803,38 @@
                     "card_id": "a95ccd8a-c456-11e9-bfc1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -825,7 +847,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ad9f4cc5-c456-11e9-827e-a4d18cec433a",
@@ -860,14 +882,11 @@
                 {
                     "card_id": "ad9f4cc5-c456-11e9-827e-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -880,7 +899,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ad9f4cc5-c456-11e9-827e-a4d18cec433a",
@@ -938,13 +957,38 @@
                     "card_id": "ad9f4cc5-c456-11e9-827e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -957,7 +1001,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "acac7397-c456-11e9-bf35-a4d18cec433a",
@@ -1019,7 +1063,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1032,7 +1075,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "acac7397-c456-11e9-bf35-a4d18cec433a",
@@ -1183,7 +1226,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1196,7 +1238,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95cc678-c456-11e9-a11b-a4d18cec433a",
@@ -1206,7 +1248,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1219,7 +1260,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95cc678-c456-11e9-a11b-a4d18cec433a",
@@ -1395,7 +1436,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1408,7 +1448,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95cbbb0-c456-11e9-a51e-a4d18cec433a",
@@ -1465,14 +1505,11 @@
                 {
                     "card_id": "a95cbbb0-c456-11e9-a51e-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1485,19 +1522,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95cbbb0-c456-11e9-a51e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1510,7 +1572,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95cbbb0-c456-11e9-a51e-a4d18cec433a",
@@ -1550,7 +1612,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1563,7 +1624,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "12423b33-c457-11e9-8099-a4d18cec433a",
@@ -1673,13 +1734,38 @@
                     "card_id": "a74af499-c456-11e9-93e5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1692,19 +1778,30 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a74af499-c456-11e9-93e5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1717,19 +1814,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ad9f5154-c456-11e9-9c59-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1742,20 +1864,43 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ad9f5154-c456-11e9-9c59-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "86254aea-e890-462a-8dff-6c9e8b8f19e2",
+                                        "language_id": "en",
+                                        "list_item_id": "75e01ae4-4659-4d3b-85a5-4d7386fd9c29",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "495fe7b2-5580-4489-8a66-fd50aea1c266",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "85b8af80-733d-47a5-8ca9-00e9695fbb88",
+                                        "language_id": "en",
+                                        "list_item_id": "6f9434ce-8758-4b83-bfe9-d80ca9bf888e",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "495fe7b2-5580-4489-8a66-fd50aea1c266",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1768,7 +1913,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ad9f5154-c456-11e9-9c59-a4d18cec433a",
@@ -1904,7 +2049,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1917,7 +2061,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cb4086de-c45a-11e9-82a1-a4d18cec433a",
@@ -2057,7 +2201,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2070,7 +2213,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8eaf0555-9118-11ec-a428-ad03e9261309",
@@ -2248,7 +2391,6 @@
                             "placeholder"
                         ],
                         "label": "Modification Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2261,7 +2403,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "dc7d1bb0-c45a-11e9-a8b1-a4d18cec433a",
@@ -2319,13 +2461,38 @@
                     "card_id": "a95cc357-c456-11e9-95c6-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2338,7 +2505,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95cc357-c456-11e9-95c6-a4d18cec433a",
@@ -2365,14 +2532,11 @@
                 {
                     "card_id": "a95cc357-c456-11e9-95c6-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2385,7 +2549,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95cc357-c456-11e9-95c6-a4d18cec433a",
@@ -2503,14 +2667,37 @@
                     "card_id": "a95cbf7a-c456-11e9-bc43-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2523,19 +2710,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a95cbf7a-c456-11e9-bc43-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2548,7 +2760,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "f0da2726-8e2f-11eb-a9c4-faffc265b501",
@@ -2580,7 +2792,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2593,7 +2804,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": "rgba(17,54,122,0.75)",
@@ -3956,9 +4167,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "a9e75b55-78b9-46a6-8cb2-aee3f5b5003e"
+                        "controlledList": "a9e75b55-78b9-46a6-8cb2-aee3f5b5003e",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4042,9 +4254,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -4245,9 +4458,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4467,9 +4681,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4552,9 +4767,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4857,9 +5073,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4916,9 +5133,10 @@
                 {
                     "alias": "type_n5",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4941,9 +5159,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5000,9 +5219,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5050,9 +5270,10 @@
                 {
                     "alias": "language_n3",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5132,9 +5353,10 @@
                 {
                     "alias": "language_n4",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5203,9 +5425,10 @@
                 {
                     "alias": "type_n10",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5344,9 +5567,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5417,9 +5641,10 @@
                 {
                     "alias": "type_n6",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5488,9 +5713,10 @@
                 {
                     "alias": "type_n7",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5536,10 +5762,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5608,9 +5834,10 @@
                 {
                     "alias": "type_n8",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5762,10 +5989,10 @@
                 {
                     "alias": "language_n5",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5788,9 +6015,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5813,9 +6041,10 @@
                 {
                     "alias": "type_n9",
                     "config": {
-                        "rdmCollection": "495fe7b2-5580-4489-8a66-fd50aea1c266"
+                        "controlledList": "495fe7b2-5580-4489-8a66-fd50aea1c266",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5907,9 +6136,10 @@
                 {
                     "alias": "language_n6",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6170,9 +6400,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6233,9 +6464,10 @@
                 {
                     "alias": "technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6260,9 +6492,9 @@
             "publication": {
                 "graph_id": "5bece219-c456-11e9-8dcd-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "ed42f006-382e-11f0-9f22-020539808477",
-                "published_time": "2025-05-23T16:37:44.872"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "5f20eea1-f758-45df-8541-62155a38fc52",
+                "published_time": "2026-02-06T12:59:44.957"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Observation.json
+++ b/arches_for_science/pkg/graphs/resource_models/Observation.json
@@ -810,14 +810,37 @@
                     "card_id": "89f063fd-c457-11e9-8120-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -830,19 +853,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f063fd-c457-11e9-8120-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -855,7 +903,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0a56b67b-9119-11ec-a428-ad03e9261309",
@@ -887,7 +935,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -900,7 +947,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0ae14b68-8e30-11eb-a9c4-faffc265b501",
@@ -932,7 +979,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -945,19 +991,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f07240-c457-11e9-b9eb-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -970,7 +1041,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f07240-c457-11e9-b9eb-a4d18cec433a",
@@ -1005,14 +1076,11 @@
                 {
                     "card_id": "89f07240-c457-11e9-b9eb-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1025,7 +1093,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f07240-c457-11e9-b9eb-a4d18cec433a",
@@ -1169,7 +1237,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1182,7 +1249,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f067e3-c457-11e9-95c9-a4d18cec433a",
@@ -1240,13 +1307,38 @@
                     "card_id": "89f067e3-c457-11e9-95c9-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1259,19 +1351,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f067e3-c457-11e9-95c9-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1284,7 +1373,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f067e3-c457-11e9-95c9-a4d18cec433a",
@@ -1432,7 +1521,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1445,7 +1533,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "3d26cb77-9119-11ec-a428-ad03e9261309",
@@ -1550,7 +1638,7 @@
                         ],
                         "label": "Select digital resource(s)",
                         "placeholder": {
-                            "en": null
+                            "en": ""
                         }
                     },
                     "id": "5d03d4d0-7845-11ea-a33b-acde48001122",
@@ -1571,7 +1659,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1584,7 +1671,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "51426161-c458-11e9-acd8-a4d18cec433a",
@@ -1663,14 +1750,11 @@
                 {
                     "card_id": "89f0600a-c457-11e9-aa64-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1683,19 +1767,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f0600a-c457-11e9-aa64-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1708,7 +1817,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f0600a-c457-11e9-aa64-a4d18cec433a",
@@ -1888,7 +1997,6 @@
                             "placeholder"
                         ],
                         "label": "Analytical Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1901,7 +2009,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2121ed87-d383-11e9-8a2d-a4d18cec433a",
@@ -1959,13 +2067,38 @@
                     "card_id": "87e3dee8-c457-11e9-9e0e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1978,19 +2111,30 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "87e3dee8-c457-11e9-9e0e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2003,7 +2147,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "87e3dee8-c457-11e9-9e0e-a4d18cec433a",
@@ -2061,14 +2205,37 @@
                     "card_id": "8ec31138-c457-11e9-a987-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "86254aea-e890-462a-8dff-6c9e8b8f19e2",
+                                        "language_id": "en",
+                                        "list_item_id": "75e01ae4-4659-4d3b-85a5-4d7386fd9c29",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "495fe7b2-5580-4489-8a66-fd50aea1c266",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "85b8af80-733d-47a5-8ca9-00e9695fbb88",
+                                        "language_id": "en",
+                                        "list_item_id": "6f9434ce-8758-4b83-bfe9-d80ca9bf888e",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "495fe7b2-5580-4489-8a66-fd50aea1c266",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2081,19 +2248,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8ec31138-c457-11e9-a987-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2106,7 +2298,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8ec31138-c457-11e9-a987-a4d18cec433a",
@@ -2269,7 +2461,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2282,7 +2473,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f06f00-c457-11e9-b138-a4d18cec433a",
@@ -2369,13 +2560,38 @@
                     "card_id": "8ec306dc-c457-11e9-aa23-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2388,19 +2604,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8ec306dc-c457-11e9-aa23-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2413,7 +2626,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8ec306dc-c457-11e9-aa23-a4d18cec433a",
@@ -2512,7 +2725,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2525,7 +2737,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "89f06b0f-c457-11e9-b64e-a4d18cec433a",
@@ -2631,7 +2843,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2644,7 +2855,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": "rgba(131,160,214,0.75)",
@@ -3862,9 +4073,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -3910,9 +4122,10 @@
                 {
                     "alias": "digital_reference_digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -4178,9 +4391,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4461,9 +4675,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "0ca18480-f5f2-41b2-b177-857726e5ecd7"
+                        "controlledList": "0ca18480-f5f2-41b2-b177-857726e5ecd7",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class.\nSee: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4509,9 +4724,10 @@
                 {
                     "alias": "name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4594,9 +4810,10 @@
                 {
                     "alias": "name_type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4899,9 +5116,10 @@
                 {
                     "alias": "timespan_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4958,9 +5176,10 @@
                 {
                     "alias": "timespan_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4983,9 +5202,10 @@
                 {
                     "alias": "timespan_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5042,9 +5262,10 @@
                 {
                     "alias": "timespan_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5092,9 +5313,10 @@
                 {
                     "alias": "timespan_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5174,9 +5396,10 @@
                 {
                     "alias": "timespan_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5245,9 +5468,10 @@
                 {
                     "alias": "timespan_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5386,9 +5610,10 @@
                 {
                     "alias": "timespan_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5459,9 +5684,10 @@
                 {
                     "alias": "timespan_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5530,9 +5756,10 @@
                 {
                     "alias": "timespan_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5578,10 +5805,10 @@
                 {
                     "alias": "timespan_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5673,10 +5900,10 @@
                 {
                     "alias": "statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5699,9 +5926,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5724,9 +5952,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "495fe7b2-5580-4489-8a66-fd50aea1c266"
+                        "controlledList": "495fe7b2-5580-4489-8a66-fd50aea1c266",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5818,9 +6047,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5925,9 +6155,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6116,9 +6347,10 @@
                 {
                     "alias": "technique",
                     "config": {
-                        "rdmCollection": "3a8e8388-0bb9-42f2-bc77-fc5a1c640589"
+                        "controlledList": "3a8e8388-0bb9-42f2-bc77-fc5a1c640589",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6253,9 +6485,9 @@
             "publication": {
                 "graph_id": "615b11ee-c457-11e9-910c-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "5febbaf8-382f-11f0-b47e-020539808477",
-                "published_time": "2025-05-23T16:40:57.238"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "4e25443f-4e1f-41f1-bc11-9fead8ae009c",
+                "published_time": "2026-02-06T12:58:47.591"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Period.json
+++ b/arches_for_science/pkg/graphs/resource_models/Period.json
@@ -16,13 +16,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Type of Period"
@@ -45,13 +45,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Duration of TimeSpan"
@@ -74,13 +74,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about TimeSpan"
@@ -103,13 +103,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for TimeSpan"
@@ -132,13 +132,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration of TimeSpan"
@@ -161,13 +161,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan of Period"
@@ -190,13 +190,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement about TimeSpan"
@@ -217,13 +217,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Digital Reference to Period"
@@ -246,13 +246,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Period"
@@ -275,13 +275,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier of Period"
@@ -304,13 +304,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement"
@@ -333,13 +333,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about Period"
@@ -362,13 +362,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "External URI for Period"
@@ -391,13 +391,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Internal Label for Period"
@@ -420,13 +420,13 @@
                     "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Parent Period"
@@ -488,7 +488,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -501,7 +500,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4ba66-c072-11e9-8c79-a4d18cec433a",
@@ -630,14 +629,11 @@
                 {
                     "card_id": "4db4b32e-c072-11e9-9e10-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -650,7 +646,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4b32e-c072-11e9-9e10-a4d18cec433a",
@@ -686,13 +682,38 @@
                     "card_id": "4db4b32e-c072-11e9-9e10-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -705,7 +726,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4f1ec80a-8e30-11eb-a9c4-faffc265b501",
@@ -737,7 +758,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -750,19 +770,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4bd99-c072-11e9-af2d-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -775,7 +792,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4bd99-c072-11e9-af2d-a4d18cec433a",
@@ -833,13 +850,38 @@
                     "card_id": "4db4bd99-c072-11e9-af2d-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -852,7 +894,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4bd99-c072-11e9-af2d-a4d18cec433a",
@@ -922,7 +964,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -935,19 +976,44 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "50dc6e3a-c072-11e9-922e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -960,19 +1026,30 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "50dc6e3a-c072-11e9-922e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -985,7 +1062,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "50dc6e3a-c072-11e9-922e-a4d18cec433a",
@@ -1151,7 +1228,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1164,7 +1240,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4b69c-c072-11e9-87cf-a4d18cec433a",
@@ -1211,7 +1287,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1224,7 +1299,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4b69c-c072-11e9-87cf-a4d18cec433a",
@@ -1364,14 +1439,37 @@
                     "card_id": "4db4af4c-c072-11e9-81fa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1384,19 +1482,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4af4c-c072-11e9-81fa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1409,7 +1532,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "529441c7-c072-11e9-b3e8-a4d18cec433a",
@@ -1471,7 +1594,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1484,7 +1606,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "529441c7-c072-11e9-b3e8-a4d18cec433a",
@@ -1601,14 +1723,11 @@
                 {
                     "card_id": "4db4ab02-c072-11e9-9658-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1621,19 +1740,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4db4ab02-c072-11e9-9658-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1646,19 +1790,44 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "53887d57-c072-11e9-acb1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1671,7 +1840,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "53887d57-c072-11e9-acb1-a4d18cec433a",
@@ -1729,14 +1898,37 @@
                     "card_id": "53887d57-c072-11e9-acb1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1749,7 +1941,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "53887d57-c072-11e9-acb1-a4d18cec433a",
@@ -1785,13 +1977,38 @@
                     "card_id": "53886eb0-c072-11e9-92b4-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1804,19 +2021,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "53886eb0-c072-11e9-92b4-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1829,7 +2043,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "53886eb0-c072-11e9-92b4-a4d18cec433a",
@@ -2811,9 +3025,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3091,9 +3306,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3150,9 +3366,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3175,9 +3392,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3234,9 +3452,10 @@
                 {
                     "alias": "language_n4",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3284,9 +3503,10 @@
                 {
                     "alias": "language_n3",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3366,9 +3586,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3437,9 +3658,10 @@
                 {
                     "alias": "type_n9",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3578,9 +3800,10 @@
                 {
                     "alias": "type_n8",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3651,9 +3874,10 @@
                 {
                     "alias": "type_n7",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3722,9 +3946,10 @@
                 {
                     "alias": "type_n5",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3770,10 +3995,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3842,9 +4067,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -3925,9 +4151,10 @@
                 {
                     "alias": "language_n6",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4007,9 +4234,10 @@
                 {
                     "alias": "type_n10",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4078,9 +4306,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4252,10 +4481,10 @@
                 {
                     "alias": "language_n5",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4278,9 +4507,10 @@
                 {
                     "alias": "type_n6",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4303,9 +4533,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4431,9 +4662,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4592,7 +4824,13 @@
                 }
             ],
             "ontology_id": "0b1f5462-faa7-11e9-8f09-3af9d3b32b71",
-            "publication": null,
+            "publication": {
+                "graph_id": "52c40a30-b25c-11e9-92cf-a4d18cec433a",
+                "most_recent_edit_id": null,
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "f598ad6a-6246-486f-97ab-7898c32107bb",
+                "published_time": "2026-02-06T12:58:39.632"
+            },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],
             "resource_instance_lifecycle": {

--- a/arches_for_science/pkg/graphs/resource_models/Person.json
+++ b/arches_for_science/pkg/graphs/resource_models/Person.json
@@ -1283,17 +1283,10 @@
                     "component_id": "2f9054d8-de57-45cd-8a9c-58bbb1619030",
                     "config": {
                         "groupedCardIds": [
-                            "741dc68f-bfb4-11e9-a26a-a4d18cec433a",
-                            "9f1559b0-bfb4-11e9-aa80-a4d18cec433a"
+                            "7a6672fa-43f0-458e-b1a9-b3b1ce739c17",
+                            "dcdb4c79-7257-4e4e-86de-d4e3a7032918"
                         ],
-                        "sortedWidgetIds": [
-                            "83cf1bdc-bfb4-11e9-8f51-a4d18cec433a",
-                            "732f489c-c05b-11e9-8d3d-a4d18cec433a",
-                            "741d3687-bfb4-11e9-bcc1-a4d18cec433a",
-                            "87ef338a-c05b-11e9-974e-a4d18cec433a",
-                            "9f14d3b3-bfb4-11e9-a539-a4d18cec433a",
-                            "5a41d4b0-c05b-11e9-a6c5-a4d18cec433a"
-                        ]
+                        "sortedWidgetIds": []
                     },
                     "constraints": [],
                     "cssclass": null,
@@ -2238,13 +2231,24 @@
                     "card_id": "08dc92ca-d287-11e9-b814-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2257,7 +2261,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dca6b5-d287-11e9-ad13-a4d18cec433a",
@@ -2319,7 +2323,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2332,7 +2335,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dc892e-d287-11e9-a699-a4d18cec433a",
@@ -2386,7 +2389,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2399,7 +2401,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dca6b5-d287-11e9-ad13-a4d18cec433a",
@@ -2439,7 +2441,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2452,7 +2453,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dca6b5-d287-11e9-ad13-a4d18cec433a",
@@ -2538,14 +2539,37 @@
                     "card_id": "08dc8e19-d287-11e9-9e0f-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2558,7 +2582,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dc9d35-d287-11e9-be13-a4d18cec433a",
@@ -2675,13 +2699,38 @@
                     "card_id": "08dc92ca-d287-11e9-b814-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2694,7 +2743,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dca6b5-d287-11e9-ad13-a4d18cec433a",
@@ -2704,7 +2753,6 @@
                             "placeholder"
                         ],
                         "label": "Professional Activity Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2717,7 +2765,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dc978c-d287-11e9-add4-a4d18cec433a",
@@ -2796,13 +2844,38 @@
                     "card_id": "08dcab14-d287-11e9-b9ee-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2815,7 +2888,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dc92ca-d287-11e9-b814-a4d18cec433a",
@@ -2899,7 +2972,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2912,19 +2984,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dcab14-d287-11e9-b9ee-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2937,7 +3006,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dc978c-d287-11e9-add4-a4d18cec433a",
@@ -3009,14 +3078,11 @@
                 {
                     "card_id": "08dc8351-d287-11e9-8277-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3029,7 +3095,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dca6b5-d287-11e9-ad13-a4d18cec433a",
@@ -3101,13 +3167,38 @@
                     "card_id": "08dc8351-d287-11e9-8277-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3120,7 +3211,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dc892e-d287-11e9-a699-a4d18cec433a",
@@ -3177,13 +3268,38 @@
                     "card_id": "08dc8e19-d287-11e9-9e0f-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3196,7 +3312,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dc978c-d287-11e9-add4-a4d18cec433a",
@@ -3243,7 +3359,6 @@
                             "placeholder"
                         ],
                         "label": "Particular Professional Activity Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3256,7 +3371,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dcab14-d287-11e9-b9ee-a4d18cec433a",
@@ -3326,7 +3441,6 @@
                             "placeholder"
                         ],
                         "label": "Contact Information Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3339,7 +3453,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "eaeb2f78-bfb3-11e9-a80a-a4d18cec433a",
@@ -3508,14 +3622,11 @@
                 {
                     "card_id": "110f9699-d289-11e9-9eb5-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3528,7 +3639,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fb087-d289-11e9-aec4-a4d18cec433a",
@@ -3590,7 +3701,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3603,7 +3713,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110f8cb5-d289-11e9-9b79-a4d18cec433a",
@@ -3657,7 +3767,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3670,7 +3779,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fb087-d289-11e9-aec4-a4d18cec433a",
@@ -3710,7 +3819,6 @@
                             "placeholder"
                         ],
                         "label": "unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3723,7 +3831,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fb087-d289-11e9-aec4-a4d18cec433a",
@@ -3809,13 +3917,24 @@
                     "card_id": "110f91d4-d289-11e9-830e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3828,7 +3947,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fa3b8-d289-11e9-a538-a4d18cec433a",
@@ -3945,13 +4064,38 @@
                     "card_id": "110f9699-d289-11e9-9eb5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3964,7 +4108,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fb087-d289-11e9-aec4-a4d18cec433a",
@@ -3974,7 +4118,6 @@
                             "placeholder"
                         ],
                         "label": "Group Leaving Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3987,7 +4130,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110f9b8c-d289-11e9-9160-a4d18cec433a",
@@ -4066,13 +4209,38 @@
                     "card_id": "110fb74a-d289-11e9-9baa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4085,7 +4253,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110f9699-d289-11e9-9eb5-a4d18cec433a",
@@ -4169,7 +4337,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4182,19 +4349,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fb74a-d289-11e9-9baa-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4207,7 +4371,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110f9b8c-d289-11e9-9160-a4d18cec433a",
@@ -4279,14 +4443,11 @@
                 {
                     "card_id": "110f8721-d289-11e9-bbc2-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4299,7 +4460,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fb087-d289-11e9-aec4-a4d18cec433a",
@@ -4371,13 +4532,38 @@
                     "card_id": "110f8721-d289-11e9-bbc2-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4390,7 +4576,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110f8cb5-d289-11e9-9b79-a4d18cec433a",
@@ -4447,13 +4633,38 @@
                     "card_id": "110f91d4-d289-11e9-830e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4466,7 +4677,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110f9b8c-d289-11e9-9160-a4d18cec433a",
@@ -4513,7 +4724,6 @@
                             "placeholder"
                         ],
                         "label": "Group Leaving Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4526,7 +4736,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fb74a-d289-11e9-9baa-a4d18cec433a",
@@ -4592,13 +4802,38 @@
                     "card_id": "c93b1f5e-d286-11e9-84f1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4611,19 +4846,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b1f5e-d286-11e9-84f1-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4636,7 +4868,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b1f5e-d286-11e9-84f1-a4d18cec433a",
@@ -4724,14 +4956,37 @@
                     "card_id": "2a9fef0a-bfb2-11e9-b297-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "267bd5ac-5a85-472a-a427-80cb502b3a44",
+                                        "language_id": "en",
+                                        "list_item_id": "1059072b-a459-42f4-9b3c-feda8a87d702",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "52c977b9-3ee6-415c-ad88-70e01c72fd38",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "10aa4066-2ab3-477a-8e5e-5bc652d29b3c",
+                                        "language_id": "en",
+                                        "list_item_id": "bb65e31f-c9b0-49b9-b474-c8eb4a899886",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "52c977b9-3ee6-415c-ad88-70e01c72fd38",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4744,19 +4999,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2a9fef0a-bfb2-11e9-b297-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4769,7 +5049,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2a9fef0a-bfb2-11e9-b297-a4d18cec433a",
@@ -4895,13 +5175,24 @@
                     "card_id": "2d53426b-d286-11e9-be43-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4914,7 +5205,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d533dcf-d286-11e9-9bee-a4d18cec433a",
@@ -4954,7 +5245,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4967,7 +5257,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d53391e-d286-11e9-a9e3-a4d18cec433a",
@@ -4999,7 +5289,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5012,7 +5301,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d53566b-d286-11e9-8075-a4d18cec433a",
@@ -5052,7 +5341,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5065,7 +5353,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d53566b-d286-11e9-8075-a4d18cec433a",
@@ -5151,14 +5439,37 @@
                     "card_id": "2d533dcf-d286-11e9-9bee-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5171,7 +5482,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d534d02-d286-11e9-8cea-a4d18cec433a",
@@ -5288,13 +5599,38 @@
                     "card_id": "2d53426b-d286-11e9-be43-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5307,7 +5643,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d53566b-d286-11e9-8075-a4d18cec433a",
@@ -5317,7 +5653,6 @@
                             "placeholder"
                         ],
                         "label": "Birth Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5330,7 +5665,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d534738-d286-11e9-a04b-a4d18cec433a",
@@ -5409,13 +5744,38 @@
                     "card_id": "2d535ab8-d286-11e9-885e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5428,7 +5788,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d53426b-d286-11e9-be43-a4d18cec433a",
@@ -5512,7 +5872,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5525,19 +5884,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d535ab8-d286-11e9-885e-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5550,7 +5906,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d534738-d286-11e9-a04b-a4d18cec433a",
@@ -5622,14 +5978,11 @@
                 {
                     "card_id": "2d533394-d286-11e9-8f98-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5642,7 +5995,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d53566b-d286-11e9-8075-a4d18cec433a",
@@ -5714,13 +6067,38 @@
                     "card_id": "2d533394-d286-11e9-8f98-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5733,7 +6111,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d53391e-d286-11e9-a9e3-a4d18cec433a",
@@ -5790,13 +6168,38 @@
                     "card_id": "2d533dcf-d286-11e9-9bee-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5809,7 +6212,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d534738-d286-11e9-a04b-a4d18cec433a",
@@ -5960,7 +6363,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5973,7 +6375,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d4b5097-bfb2-11e9-8a03-a4d18cec433a",
@@ -6035,7 +6437,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6048,7 +6449,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b302f942-b31f-11e9-a483-a4d18cec433a",
@@ -6106,13 +6507,38 @@
                     "card_id": "08dca15c-d287-11e9-8e71-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6125,7 +6551,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dca15c-d287-11e9-8e71-a4d18cec433a",
@@ -6152,14 +6578,11 @@
                 {
                     "card_id": "08dca15c-d287-11e9-8e71-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6172,7 +6595,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "08dca15c-d287-11e9-8e71-a4d18cec433a",
@@ -6242,7 +6665,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6255,7 +6677,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d4168-0d78-11ea-b439-acde48001122",
@@ -6428,7 +6850,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6441,20 +6862,43 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d469a-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6467,7 +6911,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d469a-0d78-11ea-b439-acde48001122",
@@ -6533,13 +6977,38 @@
                     "card_id": "753d469a-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6552,7 +7021,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d469a-0d78-11ea-b439-acde48001122",
@@ -6584,7 +7053,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6597,7 +7065,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d34c0-0d78-11ea-b439-acde48001122",
@@ -6739,13 +7207,38 @@
                     "card_id": "753d377c-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6758,7 +7251,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d377c-0d78-11ea-b439-acde48001122",
@@ -6823,14 +7316,11 @@
                 {
                     "card_id": "753d377c-0d78-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6843,7 +7333,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d3a24-0d78-11ea-b439-acde48001122",
@@ -6935,7 +7425,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6948,19 +7437,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d3a24-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6973,7 +7487,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d3f4c-0d78-11ea-b439-acde48001122",
@@ -7039,13 +7553,38 @@
                     "card_id": "753d3f4c-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7058,19 +7597,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d3f4c-0d78-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7083,7 +7619,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d3f4c-0d78-11ea-b439-acde48001122",
@@ -7141,13 +7677,24 @@
                     "card_id": "753d3cd6-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7160,7 +7707,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d3cd6-0d78-11ea-b439-acde48001122",
@@ -7218,13 +7765,38 @@
                     "card_id": "753d3cd6-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7237,7 +7809,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d3240-0d78-11ea-b439-acde48001122",
@@ -7299,7 +7871,6 @@
                             "placeholder"
                         ],
                         "label": "Data Assignment Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7312,7 +7883,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d49c4-0d78-11ea-b439-acde48001122",
@@ -7348,13 +7919,38 @@
                     "card_id": "753d49c4-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7367,19 +7963,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d49c4-0d78-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7392,7 +7985,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d49c4-0d78-11ea-b439-acde48001122",
@@ -7472,13 +8065,38 @@
                     "card_id": "753d44c4-0d78-11ea-b439-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7491,7 +8109,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "753d44c4-0d78-11ea-b439-acde48001122",
@@ -7556,14 +8174,11 @@
                 {
                     "card_id": "753d44c4-0d78-11ea-b439-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7576,7 +8191,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "83cfa99c-bfb4-11e9-bbb1-a4d18cec433a",
@@ -7586,7 +8201,6 @@
                             "placeholder"
                         ],
                         "label": "Gender",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7599,17 +8213,16 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "83cfa99c-bfb4-11e9-bbb1-a4d18cec433a",
                     "config": {
-                        "defaultValue": "7c1adac4-5031-4af0-a9c6-2473e3fd6e08",
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Meta Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7622,7 +8235,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "87e3310f-9119-11ec-a428-ad03e9261309",
@@ -7654,7 +8267,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7667,17 +8279,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "741dc68f-bfb4-11e9-a26a-a4d18cec433a",
                     "config": {
-                        "defaultValue": "c50786c7-6ec0-4809-8cc4-c8dbad061a8a",
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Meta Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7690,7 +8301,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "741dc68f-bfb4-11e9-a26a-a4d18cec433a",
@@ -7700,7 +8311,6 @@
                             "placeholder"
                         ],
                         "label": "Nationality",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7713,7 +8323,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1ed5548c-bfb2-11e9-9731-a4d18cec433a",
@@ -7801,13 +8411,24 @@
                     "card_id": "1ed5548c-bfb2-11e9-9731-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "828a2e14-8976-4d99-96d0-aeb1bd4223cc"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "af9caab3-a07b-4c57-9965-52e8914b2d2f",
+                                        "language_id": "en",
+                                        "list_item_id": "c54f3642-9f8d-475d-8c6d-b82fc4b5b853",
+                                        "value": "full names (personal names)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "36169008-3624-4589-98f8-47653f6db663",
+                                "uri": "http://vocab.getty.edu/aat/300404688"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7820,19 +8441,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1ed5548c-bfb2-11e9-9731-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7845,7 +8491,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9f1559b0-bfb4-11e9-aa80-a4d18cec433a",
@@ -7855,7 +8501,6 @@
                             "placeholder"
                         ],
                         "label": "Ethnicity",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7868,7 +8513,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9f1559b0-bfb4-11e9-aa80-a4d18cec433a",
@@ -7878,7 +8523,6 @@
                             "placeholder"
                         ],
                         "label": "Meta Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7891,7 +8535,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1ed54dca-bfb2-11e9-b256-a4d18cec433a",
@@ -7961,7 +8605,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7974,7 +8617,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1ed54dca-bfb2-11e9-b256-a4d18cec433a",
@@ -8002,13 +8645,38 @@
                     "card_id": "1ed54dca-bfb2-11e9-b256-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8021,7 +8689,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8638b78-d288-11e9-a59a-a4d18cec433a",
@@ -8139,13 +8807,24 @@
                     "card_id": "c93b1091-d286-11e9-9bfc-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8158,7 +8837,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b0bf5-d286-11e9-aecb-a4d18cec433a",
@@ -8198,7 +8877,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8211,7 +8889,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b070a-d286-11e9-9e60-a4d18cec433a",
@@ -8243,7 +8921,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8256,7 +8933,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b24e1-d286-11e9-929e-a4d18cec433a",
@@ -8296,7 +8973,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8309,7 +8985,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b24e1-d286-11e9-929e-a4d18cec433a",
@@ -8395,14 +9071,37 @@
                     "card_id": "c93b0bf5-d286-11e9-aecb-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8415,7 +9114,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b1b33-d286-11e9-87d5-a4d18cec433a",
@@ -8532,13 +9231,38 @@
                     "card_id": "c93b1091-d286-11e9-9bfc-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8551,7 +9275,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b24e1-d286-11e9-929e-a4d18cec433a",
@@ -8561,7 +9285,6 @@
                             "placeholder"
                         ],
                         "label": "Death Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8574,7 +9297,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b1561-d286-11e9-8d0d-a4d18cec433a",
@@ -8653,13 +9376,38 @@
                     "card_id": "c93b2942-d286-11e9-9487-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8672,7 +9420,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b1091-d286-11e9-9bfc-a4d18cec433a",
@@ -8756,7 +9504,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8769,19 +9516,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b2942-d286-11e9-9487-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8794,7 +9538,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b1561-d286-11e9-8d0d-a4d18cec433a",
@@ -8866,14 +9610,11 @@
                 {
                     "card_id": "c93b017d-d286-11e9-9164-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8886,7 +9627,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b24e1-d286-11e9-929e-a4d18cec433a",
@@ -8958,13 +9699,38 @@
                     "card_id": "c93b017d-d286-11e9-9164-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8977,7 +9743,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b070a-d286-11e9-9e60-a4d18cec433a",
@@ -9034,13 +9800,38 @@
                     "card_id": "c93b0bf5-d286-11e9-aecb-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9053,7 +9844,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c93b1561-d286-11e9-8d0d-a4d18cec433a",
@@ -9216,7 +10007,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9229,7 +10019,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cce52bf5-9119-11ec-a428-ad03e9261309",
@@ -9389,13 +10179,38 @@
                     "card_id": "2d535126-d286-11e9-abfa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9408,19 +10223,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d535126-d286-11e9-abfa-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9433,7 +10245,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2d535126-d286-11e9-abfa-a4d18cec433a",
@@ -9595,13 +10407,38 @@
                     "card_id": "e86385d7-d288-11e9-94bd-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9614,19 +10451,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e86385d7-d288-11e9-94bd-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9639,7 +10473,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fa907-d289-11e9-9d6d-a4d18cec433a",
@@ -9697,13 +10531,38 @@
                     "card_id": "110fa907-d289-11e9-9d6d-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9716,7 +10575,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "110fa907-d289-11e9-9d6d-a4d18cec433a",
@@ -9751,14 +10610,11 @@
                 {
                     "card_id": "110fa907-d289-11e9-9d6d-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9771,7 +10627,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8637926-d288-11e9-bfc4-a4d18cec433a",
@@ -9889,13 +10745,24 @@
                     "card_id": "e8637926-d288-11e9-bfc4-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9908,7 +10775,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8638b78-d288-11e9-a59a-a4d18cec433a",
@@ -9970,7 +10837,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9983,7 +10849,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8637142-d288-11e9-baf9-a4d18cec433a",
@@ -10037,7 +10903,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10050,7 +10915,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8638b78-d288-11e9-a59a-a4d18cec433a",
@@ -10090,7 +10955,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10103,7 +10967,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8638b78-d288-11e9-a59a-a4d18cec433a",
@@ -10189,14 +11053,37 @@
                     "card_id": "e8637551-d288-11e9-9c97-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10209,7 +11096,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8638202-d288-11e9-a364-a4d18cec433a",
@@ -10326,13 +11213,38 @@
                     "card_id": "e8637926-d288-11e9-bfc4-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10345,7 +11257,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8638b78-d288-11e9-a59a-a4d18cec433a",
@@ -10355,7 +11267,6 @@
                             "placeholder"
                         ],
                         "label": "Group Role",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10368,7 +11279,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8637d2b-d288-11e9-b365-a4d18cec433a",
@@ -10447,13 +11358,38 @@
                     "card_id": "e863942e-d288-11e9-b6b6-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10466,7 +11402,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8637926-d288-11e9-bfc4-a4d18cec433a",
@@ -10550,7 +11486,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10563,19 +11498,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e863942e-d288-11e9-b6b6-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10588,7 +11520,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8637d2b-d288-11e9-b365-a4d18cec433a",
@@ -10660,14 +11592,11 @@
                 {
                     "card_id": "e8636c68-d288-11e9-8433-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10680,7 +11609,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8638b78-d288-11e9-a59a-a4d18cec433a",
@@ -10752,13 +11681,38 @@
                     "card_id": "e8636c68-d288-11e9-8433-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10771,7 +11725,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8637142-d288-11e9-baf9-a4d18cec433a",
@@ -10828,13 +11782,38 @@
                     "card_id": "e8637551-d288-11e9-9c97-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10847,7 +11826,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e8637d2b-d288-11e9-b365-a4d18cec433a",
@@ -10894,7 +11873,6 @@
                             "placeholder"
                         ],
                         "label": "Group Joining Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10907,7 +11885,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e863942e-d288-11e9-b6b6-a4d18cec433a",
@@ -10973,13 +11951,38 @@
                     "card_id": "2a9fe566-bfb2-11e9-bf45-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10992,7 +11995,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2a9fe566-bfb2-11e9-bf45-a4d18cec433a",
@@ -11027,14 +12030,11 @@
                 {
                     "card_id": "2a9fe566-bfb2-11e9-bf45-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11047,7 +12047,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2a9fe566-bfb2-11e9-bf45-a4d18cec433a",
@@ -16058,9 +17058,10 @@
                 {
                     "alias": "profession_activity_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16117,9 +17118,10 @@
                 {
                     "alias": "profession_activity_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16142,9 +17144,10 @@
                 {
                     "alias": "profession_activity_technique",
                     "config": {
-                        "rdmCollection": "c372cf0b-f0f4-4730-a97d-c892dfbefcd7"
+                        "controlledList": "c372cf0b-f0f4-4730-a97d-c892dfbefcd7",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16167,9 +17170,10 @@
                 {
                     "alias": "profession_activity_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16192,9 +17196,10 @@
                 {
                     "alias": "profession_activity_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16529,9 +17534,10 @@
                 {
                     "alias": "profession_activity_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16554,9 +17560,10 @@
                 {
                     "alias": "profession_activity_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16616,9 +17623,10 @@
                 {
                     "alias": "profession_activity_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16721,9 +17729,10 @@
                 {
                     "alias": "profession_activity_type",
                     "config": {
-                        "rdmCollection": "db261e02-be27-4a99-b9c1-875375103a1d"
+                        "controlledList": "db261e02-be27-4a99-b9c1-875375103a1d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16911,9 +17920,10 @@
                 {
                     "alias": "profession_activity_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16995,9 +18005,10 @@
                 {
                     "alias": "profession_activity_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17182,9 +18193,10 @@
                 {
                     "alias": "profession_activity_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17207,10 +18219,10 @@
                 {
                     "alias": "profession_activity_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17339,9 +18351,10 @@
                 {
                     "alias": "profession_activity_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17401,9 +18414,10 @@
                 {
                     "alias": "profession_activity_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17426,9 +18440,10 @@
                 {
                     "alias": "profession_activity_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17706,9 +18721,10 @@
                 {
                     "alias": "left_group_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17765,9 +18781,10 @@
                 {
                     "alias": "left_group_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17790,9 +18807,10 @@
                 {
                     "alias": "left_group_technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17815,9 +18833,10 @@
                 {
                     "alias": "left_group_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17840,9 +18859,10 @@
                 {
                     "alias": "left_group_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18177,9 +19197,10 @@
                 {
                     "alias": "left_group_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18202,9 +19223,10 @@
                 {
                     "alias": "left_group_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18264,9 +19286,10 @@
                 {
                     "alias": "left_group_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18369,9 +19392,10 @@
                 {
                     "alias": "left_group_type",
                     "config": {
-                        "rdmCollection": "07e8d7a0-551f-4200-8c71-8a03e1f02d36"
+                        "controlledList": "07e8d7a0-551f-4200-8c71-8a03e1f02d36",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18559,9 +19583,10 @@
                 {
                     "alias": "left_group_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18643,9 +19668,10 @@
                 {
                     "alias": "left_group_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18830,9 +19856,10 @@
                 {
                     "alias": "left_group_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18855,10 +19882,10 @@
                 {
                     "alias": "left_group_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18987,9 +20014,10 @@
                 {
                     "alias": "left_group_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19049,9 +20077,10 @@
                 {
                     "alias": "left_group_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19074,9 +20103,10 @@
                 {
                     "alias": "left_group_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19145,9 +20175,10 @@
                 {
                     "alias": "name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19276,9 +20307,10 @@
                 {
                     "alias": "name_part_type",
                     "config": {
-                        "rdmCollection": "b5dfd5e3-779d-4b94-8552-c539e352fd68"
+                        "controlledList": "b5dfd5e3-779d-4b94-8552-c539e352fd68",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19326,9 +20358,10 @@
                 {
                     "alias": "name_type",
                     "config": {
-                        "rdmCollection": "36169008-3624-4589-98f8-47653f6db663"
+                        "controlledList": "36169008-3624-4589-98f8-47653f6db663",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19351,9 +20384,10 @@
                 {
                     "alias": "name_part_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19456,10 +20490,10 @@
                 {
                     "alias": "statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19482,9 +20516,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19507,9 +20542,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "52c977b9-3ee6-415c-ad88-70e01c72fd38"
+                        "controlledList": "52c977b9-3ee6-415c-ad88-70e01c72fd38",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19601,9 +20637,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19708,9 +20745,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "5d1f9674-3dbb-4da2-b107-c878eff13d5d"
+                        "controlledList": "5d1f9674-3dbb-4da2-b107-c878eff13d5d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20071,9 +21109,10 @@
                 {
                     "alias": "birth_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20130,9 +21169,10 @@
                 {
                     "alias": "birth_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20155,9 +21195,10 @@
                 {
                     "alias": "birth_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20180,9 +21221,10 @@
                 {
                     "alias": "birth_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20377,9 +21419,10 @@
                 {
                     "alias": "birth_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20402,9 +21445,10 @@
                 {
                     "alias": "birth_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20464,9 +21508,10 @@
                 {
                     "alias": "birth_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20569,9 +21614,10 @@
                 {
                     "alias": "birth_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20759,9 +21805,10 @@
                 {
                     "alias": "birth_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20843,9 +21890,10 @@
                 {
                     "alias": "birth_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21030,9 +22078,10 @@
                 {
                     "alias": "birth_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21055,10 +22104,10 @@
                 {
                     "alias": "birth_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21150,9 +22199,10 @@
                 {
                     "alias": "birth_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21212,9 +22262,10 @@
                 {
                     "alias": "birth_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21237,9 +22288,10 @@
                 {
                     "alias": "birth_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21262,9 +22314,10 @@
                 {
                     "alias": "ethnicity_meta_type",
                     "config": {
-                        "rdmCollection": "4d7dd282-959e-4bef-9b14-dc37a6470f7e"
+                        "controlledList": "4d7dd282-959e-4bef-9b14-dc37a6470f7e",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21310,9 +22363,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -21373,9 +22427,10 @@
                 {
                     "alias": "gender_meta_type",
                     "config": {
-                        "rdmCollection": "5a9349ec-e6fa-4e19-9343-058749886697"
+                        "controlledList": "5a9349ec-e6fa-4e19-9343-058749886697",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21398,10 +22453,10 @@
                 {
                     "alias": "nationality",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"
+                        "controlledList": "ff5ed7bd-4b75-42a3-8361-ddfc1edc2875",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21677,9 +22732,10 @@
                 {
                     "alias": "identifier_attribute_assignment__classification",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21813,9 +22869,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21932,9 +22989,10 @@
                 {
                     "alias": "identifier_attribute_assignment__name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22060,10 +23118,10 @@
                 {
                     "alias": "identifier_attribute_assignment__language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22166,9 +23224,10 @@
                 {
                     "alias": "identifier_attribute_assignment__name_type_n1",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22191,9 +23250,10 @@
                 {
                     "alias": "identifier_attribute_assignment__name_language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22239,9 +23299,10 @@
                 {
                     "alias": "identifier_attribute_assignment__type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22321,9 +23382,10 @@
                 {
                     "alias": "identifier_attribute_assignment__name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22346,9 +23408,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22439,9 +23502,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22523,9 +23587,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22548,9 +23613,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22573,9 +23639,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22749,9 +23816,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22774,9 +23842,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22833,9 +23902,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22904,9 +23974,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22929,10 +24000,10 @@
                 {
                     "alias": "identifier_attribute_assignment__timespan_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22978,10 +24049,10 @@
                 {
                     "alias": "gender",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "5a9349ec-e6fa-4e19-9343-058749886697"
+                        "controlledList": "5a9349ec-e6fa-4e19-9343-058749886697",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23065,9 +24136,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -23090,9 +24162,10 @@
                 {
                     "alias": "nationality_meta_type",
                     "config": {
-                        "rdmCollection": "ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"
+                        "controlledList": "ff5ed7bd-4b75-42a3-8361-ddfc1edc2875",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23152,10 +24225,10 @@
                 {
                     "alias": "ethnicity",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "4d7dd282-959e-4bef-9b14-dc37a6470f7e"
+                        "controlledList": "4d7dd282-959e-4bef-9b14-dc37a6470f7e",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23493,9 +24566,10 @@
                 {
                     "alias": "death_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23552,9 +24626,10 @@
                 {
                     "alias": "death_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23577,9 +24652,10 @@
                 {
                     "alias": "death_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23602,9 +24678,10 @@
                 {
                     "alias": "death_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23799,9 +24876,10 @@
                 {
                     "alias": "death_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23824,9 +24902,10 @@
                 {
                     "alias": "death_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23886,9 +24965,10 @@
                 {
                     "alias": "death_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23991,9 +25071,10 @@
                 {
                     "alias": "death_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24181,9 +25262,10 @@
                 {
                     "alias": "death_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24265,9 +25347,10 @@
                 {
                     "alias": "death_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24452,9 +25535,10 @@
                 {
                     "alias": "death_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24477,10 +25561,10 @@
                 {
                     "alias": "death_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24572,9 +25656,10 @@
                 {
                     "alias": "death_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24634,9 +25719,10 @@
                 {
                     "alias": "death_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24659,9 +25745,10 @@
                 {
                     "alias": "death_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24816,9 +25903,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25233,9 +26321,10 @@
                 {
                     "alias": "joined_group_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25292,9 +26381,10 @@
                 {
                     "alias": "joined_group_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25317,9 +26407,10 @@
                 {
                     "alias": "joined_group_technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25342,9 +26433,10 @@
                 {
                     "alias": "joined_group_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25367,9 +26459,10 @@
                 {
                     "alias": "joined_group_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25704,9 +26797,10 @@
                 {
                     "alias": "joined_group_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25729,9 +26823,10 @@
                 {
                     "alias": "joined_group_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25791,9 +26886,10 @@
                 {
                     "alias": "joined_group_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25896,9 +26992,10 @@
                 {
                     "alias": "joined_group_type",
                     "config": {
-                        "rdmCollection": "07e8d7a0-551f-4200-8c71-8a03e1f02d36"
+                        "controlledList": "07e8d7a0-551f-4200-8c71-8a03e1f02d36",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26086,9 +27183,10 @@
                 {
                     "alias": "joined_group_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26170,9 +27268,10 @@
                 {
                     "alias": "joined_group_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26357,9 +27456,10 @@
                 {
                     "alias": "joined_group_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26382,10 +27482,10 @@
                 {
                     "alias": "joined_group_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26514,9 +27614,10 @@
                 {
                     "alias": "joined_group_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26576,9 +27677,10 @@
                 {
                     "alias": "joined_group_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26601,9 +27703,10 @@
                 {
                     "alias": "joined_group_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26649,9 +27752,10 @@
                 {
                     "alias": "contact_point_type",
                     "config": {
-                        "rdmCollection": "92d3e507-9d66-4122-9cd6-36430cf36e3c"
+                        "controlledList": "92d3e507-9d66-4122-9cd6-36430cf36e3c",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26805,9 +27909,9 @@
             "publication": {
                 "graph_id": "f71f7b9c-b25b-11e9-901e-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": "Deduplicated card_x_node_x_widgets",
-                "publicationid": "8b0f8b49-fadd-4e8d-b570-87cfc1c5e4df",
-                "published_time": "2026-01-29T18:17:38.774"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "cae52ef9-5853-4f7c-b9f9-53d9c11dc6c8",
+                "published_time": "2026-02-06T12:59:18.163"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Physical Thing.json
+++ b/arches_for_science/pkg/graphs/resource_models/Physical Thing.json
@@ -2236,7 +2236,6 @@
                             "placeholder"
                         ],
                         "label": "Destruction Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2249,7 +2248,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc6516dc-b497-11e9-bfe6-a4d18cec433a",
@@ -2470,7 +2469,6 @@
                             "placeholder"
                         ],
                         "label": "Dimension Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2483,7 +2481,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc1561a6-b497-11e9-8cba-a4d18cec433a",
@@ -2515,7 +2513,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2528,7 +2525,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc1561a6-b497-11e9-8cba-a4d18cec433a",
@@ -2667,14 +2664,11 @@
                 {
                     "card_id": "b11f1fb8-d2bc-11e9-ac48-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2687,7 +2681,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f1fb8-d2bc-11e9-ac48-a4d18cec433a",
@@ -2723,13 +2717,38 @@
                     "card_id": "b11f1fb8-d2bc-11e9-ac48-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2742,7 +2761,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f1fb8-d2bc-11e9-ac48-a4d18cec433a",
@@ -2774,7 +2793,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2787,7 +2805,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a1490223-d2bd-11e9-bcd5-a4d18cec433a",
@@ -2844,14 +2862,11 @@
                 {
                     "card_id": "a1490223-d2bd-11e9-bcd5-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2864,7 +2879,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a1490223-d2bd-11e9-bcd5-a4d18cec433a",
@@ -2900,13 +2915,38 @@
                     "card_id": "a1490223-d2bd-11e9-bcd5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2919,7 +2959,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "2eeb8e08-0fe4-4d24-8f70-dbfb044abbaf",
@@ -2951,7 +2991,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2964,7 +3003,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cbfa42e1-b31d-11e9-8eaf-a4d18cec433a",
@@ -2974,7 +3013,6 @@
                             "placeholder"
                         ],
                         "label": "material_data_assignment_statement_type_metatype",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2987,7 +3025,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "7ae624dc-bee9-11e9-9ea2-a4d18cec433a",
@@ -3045,13 +3083,38 @@
                     "card_id": "7ae624dc-bee9-11e9-9ea2-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3064,7 +3127,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "7ae624dc-bee9-11e9-9ea2-a4d18cec433a",
@@ -3100,14 +3163,37 @@
                     "card_id": "7ae624dc-bee9-11e9-9ea2-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3120,7 +3206,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc153c78-b497-11e9-bde1-a4d18cec433a",
@@ -3155,14 +3241,11 @@
                 {
                     "card_id": "cc153c78-b497-11e9-bde1-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3175,7 +3258,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc153c78-b497-11e9-bde1-a4d18cec433a",
@@ -3203,13 +3286,38 @@
                     "card_id": "cc153c78-b497-11e9-bde1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3222,7 +3330,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc153c78-b497-11e9-bde1-a4d18cec433a",
@@ -3355,7 +3463,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3368,7 +3475,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc64fcee-b497-11e9-ad3c-a4d18cec433a",
@@ -3441,7 +3548,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3454,7 +3560,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "29ebd099-47e8-11f0-b94f-020539808477",
@@ -3562,13 +3668,38 @@
                     "card_id": "29ebd7da-47e8-11f0-974c-020539808477",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3581,19 +3712,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "29ebd7da-47e8-11f0-974c-020539808477",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3606,7 +3734,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "29ebd7da-47e8-11f0-974c-020539808477",
@@ -3668,7 +3796,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3681,7 +3808,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "7ae61cf8-bee9-11e9-a88a-a4d18cec433a",
@@ -3773,7 +3900,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3786,7 +3912,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1952aeb3-b498-11e9-9f84-a4d18cec433a",
@@ -3822,13 +3948,38 @@
                     "card_id": "1952aeb3-b498-11e9-9f84-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3841,19 +3992,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1952aeb3-b498-11e9-9f84-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3866,7 +4014,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1952aeb3-b498-11e9-9f84-a4d18cec433a",
@@ -4036,13 +4184,24 @@
                     "card_id": "cc1548d9-b497-11e9-aa4e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4055,19 +4214,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc1548d9-b497-11e9-aa4e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4080,7 +4264,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc64f791-b497-11e9-9de5-a4d18cec433a",
@@ -4149,7 +4333,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4162,7 +4345,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc64f791-b497-11e9-9de5-a4d18cec433a",
@@ -4239,7 +4422,6 @@
                             "placeholder"
                         ],
                         "label": "Unit ",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4252,7 +4434,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc64f791-b497-11e9-9de5-a4d18cec433a",
@@ -4437,13 +4619,24 @@
                     "card_id": "57f23257-d2bd-11e9-a916-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4456,7 +4649,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f2563d-d2bd-11e9-bf24-a4d18cec433a",
@@ -4518,7 +4711,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4531,7 +4723,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f22b14-d2bd-11e9-ad9a-a4d18cec433a",
@@ -4585,7 +4777,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4598,7 +4789,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f2563d-d2bd-11e9-bf24-a4d18cec433a",
@@ -4638,7 +4829,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4651,7 +4841,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f2563d-d2bd-11e9-bf24-a4d18cec433a",
@@ -4737,14 +4927,37 @@
                     "card_id": "57f22ed4-d2bd-11e9-b7fe-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4757,7 +4970,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f244f0-d2bd-11e9-b4a6-a4d18cec433a",
@@ -4874,13 +5087,38 @@
                     "card_id": "57f23257-d2bd-11e9-a916-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4893,7 +5131,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f2563d-d2bd-11e9-bf24-a4d18cec433a",
@@ -4903,7 +5141,6 @@
                             "placeholder"
                         ],
                         "label": "Addition Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4916,7 +5153,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f23b7d-d2bd-11e9-8372-a4d18cec433a",
@@ -4995,13 +5232,38 @@
                     "card_id": "57f26051-d2bd-11e9-8965-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5014,7 +5276,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f23257-d2bd-11e9-a916-a4d18cec433a",
@@ -5098,7 +5360,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5111,19 +5372,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f26051-d2bd-11e9-8965-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5136,7 +5394,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f23b7d-d2bd-11e9-8372-a4d18cec433a",
@@ -5208,14 +5466,11 @@
                 {
                     "card_id": "57f226b5-d2bd-11e9-a80a-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5228,7 +5483,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f2563d-d2bd-11e9-bf24-a4d18cec433a",
@@ -5300,13 +5555,38 @@
                     "card_id": "57f226b5-d2bd-11e9-a80a-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5319,7 +5599,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f22b14-d2bd-11e9-ad9a-a4d18cec433a",
@@ -5376,13 +5656,38 @@
                     "card_id": "57f22ed4-d2bd-11e9-b7fe-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5395,7 +5700,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f23b7d-d2bd-11e9-8372-a4d18cec433a",
@@ -5442,7 +5747,6 @@
                             "placeholder"
                         ],
                         "label": "Addition Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5455,7 +5759,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f26051-d2bd-11e9-8965-a4d18cec433a",
@@ -5517,7 +5821,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5530,7 +5833,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f23e6-d2bc-11e9-9216-a4d18cec433a",
@@ -5599,7 +5902,6 @@
                             "placeholder"
                         ],
                         "label": "Dimension Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5612,7 +5914,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b7f907a-b498-11e9-bfa6-a4d18cec433a",
@@ -5748,7 +6050,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5761,7 +6062,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f23e6-d2bc-11e9-9216-a4d18cec433a",
@@ -5819,13 +6120,24 @@
                     "card_id": "b9c1d233-b497-11e9-b375-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5838,7 +6150,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b9c1d233-b497-11e9-b375-a4d18cec433a",
@@ -5896,13 +6208,38 @@
                     "card_id": "b9c1d233-b497-11e9-b375-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5915,7 +6252,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "488170d4-8ac0-11ec-ae5b-ff450758ecce",
@@ -5968,7 +6305,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5981,7 +6317,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "488170d4-8ac0-11ec-ae5b-ff450758ecce",
@@ -6205,14 +6541,11 @@
                 {
                     "card_id": "fc651a23-b497-11e9-b8ad-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6225,19 +6558,44 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc651a23-b497-11e9-b8ad-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6250,7 +6608,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc651a23-b497-11e9-b8ad-a4d18cec433a",
@@ -6312,7 +6670,6 @@
                             "placeholder"
                         ],
                         "label": "material_data_assignment_classification",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6325,7 +6682,7 @@
                     "sortorder": 9,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "23c01c21-b31e-11e9-96f3-a4d18cec433a",
@@ -6383,13 +6740,24 @@
                     "card_id": "fc6506e1-b497-11e9-be23-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6402,7 +6770,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc6506e1-b497-11e9-be23-a4d18cec433a",
@@ -6460,13 +6828,38 @@
                     "card_id": "fc6506e1-b497-11e9-be23-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6479,7 +6872,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cbfa42e1-b31d-11e9-8eaf-a4d18cec433a",
@@ -6566,15 +6959,11 @@
                 {
                     "card_id": "1952cc75-b498-11e9-bd30-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6587,19 +6976,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1952cc75-b498-11e9-bd30-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6612,7 +7026,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c1d4445-bee9-11e9-85e8-a4d18cec433a",
@@ -6674,7 +7088,6 @@
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6687,7 +7100,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c1d4445-bee9-11e9-85e8-a4d18cec433a",
@@ -6697,7 +7110,6 @@
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6710,7 +7122,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c1d4445-bee9-11e9-85e8-a4d18cec433a",
@@ -6893,14 +7305,11 @@
                 {
                     "card_id": "fc6512c2-b497-11e9-85b2-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6913,19 +7322,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc6512c2-b497-11e9-85b2-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6938,7 +7372,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc6512c2-b497-11e9-85b2-a4d18cec433a",
@@ -7082,7 +7516,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7095,7 +7528,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a148efd1-d2bd-11e9-ac42-a4d18cec433a",
@@ -7213,13 +7646,24 @@
                     "card_id": "a148efd1-d2bd-11e9-ac42-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7232,7 +7676,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a149095e-d2bd-11e9-b3ca-a4d18cec433a",
@@ -7294,7 +7738,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7307,7 +7750,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a148e623-d2bd-11e9-99fb-a4d18cec433a",
@@ -7361,7 +7804,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7374,7 +7816,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a149095e-d2bd-11e9-b3ca-a4d18cec433a",
@@ -7414,7 +7856,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7427,7 +7868,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a149095e-d2bd-11e9-b3ca-a4d18cec433a",
@@ -7513,14 +7954,37 @@
                     "card_id": "a148eb17-d2bd-11e9-994b-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7533,7 +7997,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a148fc5c-d2bd-11e9-803d-a4d18cec433a",
@@ -7650,13 +8114,38 @@
                     "card_id": "a148efd1-d2bd-11e9-ac42-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7669,7 +8158,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a149095e-d2bd-11e9-b3ca-a4d18cec433a",
@@ -7679,7 +8168,6 @@
                             "placeholder"
                         ],
                         "label": "Removal Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7692,7 +8180,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a148f4dc-d2bd-11e9-a0c7-a4d18cec433a",
@@ -7771,13 +8259,38 @@
                     "card_id": "a1490f6b-d2bd-11e9-a3d1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7790,7 +8303,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a148efd1-d2bd-11e9-ac42-a4d18cec433a",
@@ -7874,7 +8387,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7887,19 +8399,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a1490f6b-d2bd-11e9-a3d1-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7912,7 +8421,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a148f4dc-d2bd-11e9-a0c7-a4d18cec433a",
@@ -7984,14 +8493,11 @@
                 {
                     "card_id": "a148e00a-d2bd-11e9-9ac8-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8004,7 +8510,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a149095e-d2bd-11e9-b3ca-a4d18cec433a",
@@ -8076,13 +8582,38 @@
                     "card_id": "a148e00a-d2bd-11e9-9ac8-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8095,7 +8626,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a148e623-d2bd-11e9-99fb-a4d18cec433a",
@@ -8152,13 +8683,38 @@
                     "card_id": "a148eb17-d2bd-11e9-994b-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8171,7 +8727,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a148f4dc-d2bd-11e9-a0c7-a4d18cec433a",
@@ -8218,7 +8774,6 @@
                             "placeholder"
                         ],
                         "label": "Removal Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8231,7 +8786,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a1490f6b-d2bd-11e9-a3d1-a4d18cec433a",
@@ -8349,13 +8904,38 @@
                     "card_id": "6c1d3c23-bee9-11e9-bf9e-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8368,19 +8948,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c1d3c23-bee9-11e9-bf9e-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8393,7 +8970,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b0096b9c-b31d-11e9-80fc-a4d18cec433a",
@@ -8492,7 +9069,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8505,7 +9081,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc158c3a-b497-11e9-9a45-a4d18cec433a",
@@ -8611,7 +9187,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8624,7 +9199,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cbfa42e1-b31d-11e9-8eaf-a4d18cec433a",
@@ -8634,952 +9209,6 @@
                             "placeholder"
                         ],
                         "label": "Chemical Elements",
-                        "options": [
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "2b91123c-3263-48a5-8abf-55a9a6234665",
-                                "id": "910ce59c-d5e0-4670-8998-d5192bb00ebc",
-                                "sortorder": "",
-                                "text": "Actinium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "66d75c7b-cafc-4740-87ab-1d9ce3f755ea",
-                                "id": "f91dafc9-57f2-4b7d-8fb2-c801681bd7e7",
-                                "sortorder": "",
-                                "text": "Aluminum"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "edd7c6a0-1eb8-4114-b33c-83b125b77caf",
-                                "id": "b8eb31df-a6e7-4faf-bed0-05da30cd465d",
-                                "sortorder": "",
-                                "text": "Americium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "e6db9f29-4a2f-4393-97d2-0e9435ccff69",
-                                "id": "f5a947d3-6fe6-4614-9a8c-81ab1f7fcb16",
-                                "sortorder": "",
-                                "text": "Antimony"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "af775082-8a3d-464a-9f03-a8d9b6b26f10",
-                                "id": "b9561b4b-9b8e-4065-b1a4-8c94b65371c8",
-                                "sortorder": "",
-                                "text": "Argon"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "339e769f-4259-450c-8572-903858343869",
-                                "id": "6d46224f-9f06-4bfd-9e58-1ff9fc8d7a85",
-                                "sortorder": "",
-                                "text": "Arsenic"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "bff5f7c9-b4e5-4fd7-8a3b-5b2d77aad099",
-                                "id": "89ca109d-5f37-472f-8b4c-811f7db202bf",
-                                "sortorder": "",
-                                "text": "Astatine"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "d70d092d-eb98-42fe-a153-a88732e5745b",
-                                "id": "fc8310d1-eb30-491a-8e3d-6ca6f9de8440",
-                                "sortorder": "",
-                                "text": "Barium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "aea93315-18f4-4ee5-9a13-549f27e88c1e",
-                                "id": "070e4162-b7c3-4258-90a8-e01c3fbad36b",
-                                "sortorder": "",
-                                "text": "Berkelium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "ba723d66-715f-49f3-b3d2-40c9f20510f1",
-                                "id": "a427eb5e-126c-44e3-aa04-fc86fbc3b274",
-                                "sortorder": "",
-                                "text": "Beryllium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "fd2e3734-ce0c-45ce-9498-f542d482cad4",
-                                "id": "9d29739d-96c3-4271-a7a1-54cd7257135f",
-                                "sortorder": "",
-                                "text": "Bismuth"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "787614aa-a6b5-467d-8fc8-40aeea66a2d5",
-                                "id": "cfdefb96-28ea-4f2e-b02d-d929d09054b0",
-                                "sortorder": "",
-                                "text": "Bohrium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "45843dac-a726-435b-bc77-f3132c328e63",
-                                "id": "1b4976d1-afb8-4490-a0a0-8c0fcc651a12",
-                                "sortorder": "",
-                                "text": "Boron"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "85c8889f-d85f-41e4-8e3c-69644d98bee9",
-                                "id": "1d20d6e3-f44d-4a78-8821-06c79cf2bcb3",
-                                "sortorder": "",
-                                "text": "Bromine"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "90d6139d-46e4-46ca-8d92-a339a8092056",
-                                "id": "e561514e-f370-4d84-b984-6683e8ab5a33",
-                                "sortorder": "",
-                                "text": "Cadmium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "3b5b53d3-bc3b-4b94-bbce-b435cbb8d210",
-                                "id": "9f2f0a18-1ca3-415e-bb03-fe96720f8a18",
-                                "sortorder": "",
-                                "text": "Calcium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "cf140f56-6a2b-4cfd-9cae-ddc2af1d74a2",
-                                "id": "a02cf2b1-14aa-4d93-8949-cae9cbdc278a",
-                                "sortorder": "",
-                                "text": "Californium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "c64d26d1-d0b5-4a9a-9286-4942b915925d",
-                                "id": "85e6b4ee-31ec-4720-a910-992f8901f135",
-                                "sortorder": "",
-                                "text": "Carbon"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "7ebce11e-ee7e-475a-a36e-2b38f7d1d984",
-                                "id": "296354ec-2b7c-4af9-84e6-2a3b710be094",
-                                "sortorder": "",
-                                "text": "Cerium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "50525207-905f-4e65-a816-9f024dfc67f7",
-                                "id": "e12b08ee-84f6-4216-82a0-1956ee2dd229",
-                                "sortorder": "",
-                                "text": "Cesium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "4895c70f-fb12-4412-84d5-86abe742cb30",
-                                "id": "c2f753ab-b2cc-493f-9e25-7431178fef87",
-                                "sortorder": "",
-                                "text": "Chlorine"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "6c77fa92-dd5d-4a95-8ce9-55f9a0aead45",
-                                "id": "502249b3-e0c9-40e5-ad86-a30df0f003f4",
-                                "sortorder": "",
-                                "text": "Chromium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "1c5ba628-5ab6-4ee7-946a-a4bdefee0919",
-                                "id": "e093afc6-3a44-4118-aa7d-d78c440100a1",
-                                "sortorder": "",
-                                "text": "Cobalt"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "2480537d-2dee-4ebe-8dad-fec0c8bb04a4",
-                                "id": "7133cf2b-24a1-4394-8c21-4a98d5f2265f",
-                                "sortorder": "",
-                                "text": "Copernicium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "8e08ccab-5aea-4d44-9b89-9e0834aa8390",
-                                "id": "067eacff-db7c-4462-a80b-948210993cbb",
-                                "sortorder": "",
-                                "text": "Copper"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f162c061-09a7-4338-8564-84e531bad5e5",
-                                "id": "c21ab25f-fa4d-40f3-9378-09e3edf951e9",
-                                "sortorder": "",
-                                "text": "Curium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "c939adea-2e59-461e-b3a9-73fd0ac2636f",
-                                "id": "0e971386-e633-4e70-afa3-920377914df1",
-                                "sortorder": "",
-                                "text": "Darmstadtium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "12868967-09d9-4ffa-8127-6103936bd27f",
-                                "id": "686f767f-4c12-41bf-b801-f0de20da6236",
-                                "sortorder": "",
-                                "text": "Dubnium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "a4011080-0aed-4320-a2c9-cd3fe7eb25e9",
-                                "id": "ddace229-f326-45a3-81f3-af0b4ac45ef6",
-                                "sortorder": "",
-                                "text": "Dysprosium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "7d34406f-fa99-4613-a4e7-5bf6ff8322c8",
-                                "id": "65a36172-d15e-4be3-8376-206710d0ab23",
-                                "sortorder": "",
-                                "text": "Einsteinium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "c77f3f92-ee00-4875-a404-50a8a9ea7dc1",
-                                "id": "b57f0e1c-d191-46c7-9383-06fb6f79b965",
-                                "sortorder": "",
-                                "text": "Erbium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "b404f414-7aef-403b-a04d-300b2df8a884",
-                                "id": "34a31d03-5603-401e-9961-bce0b750a9c9",
-                                "sortorder": "",
-                                "text": "Europium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "d7352ca3-5f0d-4c55-95f5-59eb4a8e65aa",
-                                "id": "860238eb-92da-4a24-a084-8c08eddcce7d",
-                                "sortorder": "",
-                                "text": "Fermium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "fa1e1e2e-0d45-4453-b874-8a459715685d",
-                                "id": "7b0c3f74-f2bb-445a-8683-497a28dd37d7",
-                                "sortorder": "",
-                                "text": "Flerovium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "e8d1a9bd-045a-4c96-9f9a-20944737ee83",
-                                "id": "99ca84de-a662-4a8f-bb1e-05f998f7b585",
-                                "sortorder": "",
-                                "text": "Fluorine"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "a00d55b2-147d-4a50-a233-f330120ab4d1",
-                                "id": "550e4ec0-161f-4c87-9aa8-f2792f4c39ea",
-                                "sortorder": "",
-                                "text": "Francium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "760e3a5a-3401-43d2-90ef-1a2b97182131",
-                                "id": "aede5e96-ab99-46cc-b7ba-61494cd4aa07",
-                                "sortorder": "",
-                                "text": "Gadolinium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f7cd5a85-2b8d-42ec-9566-57a59af9c8c8",
-                                "id": "3193635c-407f-4718-bbd8-baff3d3054b4",
-                                "sortorder": "",
-                                "text": "Gallium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "d3760ea8-324f-479c-b8ea-7b1b05fcb7c1",
-                                "id": "8b480d2d-e6a9-441d-bd56-01b79f70f105",
-                                "sortorder": "",
-                                "text": "Germanium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "b500136b-4b36-4db2-85b4-fdb6cce13f51",
-                                "id": "629d3436-d1e6-4f18-b190-3ba543e7b177",
-                                "sortorder": "",
-                                "text": "Gold"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "581612f5-e396-4859-9d37-39591c91834d",
-                                "id": "a1e98576-df4f-46da-a0b2-a836e308ff89",
-                                "sortorder": "",
-                                "text": "Hafnium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "fbdb5700-5af7-4bab-babb-94e57bfb7fda",
-                                "id": "2ed5b06a-0623-43bb-8cce-ee43c2716bc2",
-                                "sortorder": "",
-                                "text": "Hassium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "10a215ed-a80c-4974-82a0-68766141b434",
-                                "id": "70a25897-c967-4a36-8534-720589d3c2a4",
-                                "sortorder": "",
-                                "text": "Helium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "076cbfad-bfce-4096-894b-04467470fbc8",
-                                "id": "3d026326-e17f-4fae-924f-606c6ff3b29c",
-                                "sortorder": "",
-                                "text": "Holmium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "d16b4b14-4c86-47de-9647-495833687298",
-                                "id": "b47acbcb-14b9-45d4-a6e6-a09dd62dcaac",
-                                "sortorder": "",
-                                "text": "Hydrogen"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "2f54357f-8552-406a-b702-3dc31e24b788",
-                                "id": "867edfc0-f7b3-44da-b121-982e5dcf8c7d",
-                                "sortorder": "",
-                                "text": "Indium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "29ee707a-0b99-4286-bfc1-c0268a72b9ca",
-                                "id": "0a8c01af-7601-4996-bc59-7f4e0003cde3",
-                                "sortorder": "",
-                                "text": "Iodine"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "3fe53655-f35b-45cd-8aea-153181da165c",
-                                "id": "7f77f960-a35d-416e-9677-00118ae0affd",
-                                "sortorder": "",
-                                "text": "Iridium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "0ede5787-434b-4bf2-94d3-ac5ba80465b5",
-                                "id": "afd6fe33-b5df-41ee-a020-8f4970c4587e",
-                                "sortorder": "",
-                                "text": "Iron"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "60a15f0c-7dc7-4fbd-817a-4d827ff58c97",
-                                "id": "dc882473-58ca-4db5-9b52-344e349be296",
-                                "sortorder": "",
-                                "text": "Krypton"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "52454dff-1c2b-4e39-9c1b-0879993cf08f",
-                                "id": "cba93ac8-be39-4edd-ab41-b2be4ca921a1",
-                                "sortorder": "",
-                                "text": "Lanthanum"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "299de067-b416-4778-b01c-a8efbb51d36b",
-                                "id": "1399edf2-d1ba-465d-8fe8-9ccd38595375",
-                                "sortorder": "",
-                                "text": "Lawrencium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "0fdc503e-e2d5-4bff-b351-56d83d79e702",
-                                "id": "b8521d83-5017-4e3d-ba89-91bf0bb7a409",
-                                "sortorder": "",
-                                "text": "Lead"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "0a14e5d4-2bde-46ad-9eed-e888bab1e53b",
-                                "id": "42c02d9c-7d81-4cf9-8d31-c97755698dff",
-                                "sortorder": "",
-                                "text": "Lithium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "6bf01a01-4055-417a-b814-5a8051125697",
-                                "id": "7a462a7a-388c-467f-8011-bbf291378c8b",
-                                "sortorder": "",
-                                "text": "Livermorium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "5cae4306-ddf1-4e43-9e77-95e867c497d3",
-                                "id": "91eeda4e-b953-48e9-a114-d72839372e65",
-                                "sortorder": "",
-                                "text": "Lutetium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f6c7105e-fa1d-4da4-9c11-0fc3cb06c8f0",
-                                "id": "48329483-05f7-47ae-bfc6-04c0ecf29d1d",
-                                "sortorder": "",
-                                "text": "Magnesium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "5f443efa-08fa-41bf-9bad-b829e8083429",
-                                "id": "8d22cb6a-4dff-4bf6-9445-5fa40105c59e",
-                                "sortorder": "",
-                                "text": "Manganese"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "96e707d2-c133-4f2b-ab79-311d4345657b",
-                                "id": "da8e3fd4-5dc6-4632-8203-6e0b1d5b3a36",
-                                "sortorder": "",
-                                "text": "Meitnerium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "1d62fff7-c49d-4f8e-9f0d-32a9ff063a90",
-                                "id": "7ef49549-61c2-4102-a909-bb114eca55e0",
-                                "sortorder": "",
-                                "text": "Mendelevium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f04947ea-ae1d-4e63-9245-dfab10303e23",
-                                "id": "3d0f1756-973f-4b71-8e97-ce4e978f4ef7",
-                                "sortorder": "",
-                                "text": "Mercury"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "8f00a23b-fd48-43e9-8ec2-59a60a7957c6",
-                                "id": "5a399985-ee4c-4cb2-b9eb-928151a2a1d4",
-                                "sortorder": "",
-                                "text": "Molybdenum"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "98e0163b-7e26-4d1b-9b2e-1c5f289b5ea0",
-                                "id": "61605ce8-514f-4a8c-928b-6ea154192ab5",
-                                "sortorder": "",
-                                "text": "Moscovium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "6186c844-0f95-4c21-926e-87347b45df8a",
-                                "id": "9e018465-a5c3-419d-8819-7bf7570d5086",
-                                "sortorder": "",
-                                "text": "Neodymium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "dad241d2-175c-4319-bcf9-c1ba70bda7e6",
-                                "id": "41fb44c0-8d12-48e3-b08b-032aa5ba2c47",
-                                "sortorder": "",
-                                "text": "Neon"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "fb28c2e9-7a94-4dc2-af72-7d1a076fe176",
-                                "id": "228e27d5-6f8b-4903-b62f-bcb1baf12418",
-                                "sortorder": "",
-                                "text": "Neptunium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "e21920ed-72ee-4e63-a9c4-98e0fd2c6811",
-                                "id": "e02c19c3-88c6-429b-b725-713659ed76f1",
-                                "sortorder": "",
-                                "text": "Nickel"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "b32661b5-dba0-4de6-908c-d0104e3b3f94",
-                                "id": "a2efb7b9-0264-4fb3-8d27-785101dffa3c",
-                                "sortorder": "",
-                                "text": "Nihonium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "fe1fdf56-9669-401e-824c-0ff7368bdcaa",
-                                "id": "bb412446-d660-4750-8fc7-386bf2f62d87",
-                                "sortorder": "",
-                                "text": "Niobium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "798ecc23-2f34-4e13-94b4-b5a0831a2f3a",
-                                "id": "bcf3573d-a281-4620-99a4-f307a5576e26",
-                                "sortorder": "",
-                                "text": "Nitrogen"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "0b6d8038-8207-4a1a-900b-bf0fc55aca79",
-                                "id": "17b984fd-be39-49bd-89a3-e7a4b4ad07db",
-                                "sortorder": "",
-                                "text": "Nobelium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "21200099-3708-41ce-b16b-3c81e0a4f8a0",
-                                "id": "67889650-163f-428c-94b9-d8c321a4832e",
-                                "sortorder": "",
-                                "text": "Oganesson"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "03099493-552a-44be-8421-ab327fae6874",
-                                "id": "57173d37-fcec-412c-9316-4985805eaf5d",
-                                "sortorder": "",
-                                "text": "Osmium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "94d5c83b-a55b-4d87-80cd-bfad1c9e717c",
-                                "id": "76e57b3f-be10-4b48-9453-fc7406525746",
-                                "sortorder": "",
-                                "text": "Oxygen"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "2f29e8ea-4d05-4995-8682-8ef84584a1a5",
-                                "id": "7245f822-ffed-4696-9ce1-2f432b885e5e",
-                                "sortorder": "",
-                                "text": "Palladium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "bbaee296-3eb4-44c9-8bc9-ecaadca00e01",
-                                "id": "8c694322-367b-4966-9ab9-6fe2e2613246",
-                                "sortorder": "",
-                                "text": "Phosphorus"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "d5d44b26-05f9-4145-aa3a-0512fb5c4acf",
-                                "id": "7e38ab19-7820-4d7f-899e-a28b3c95c1b7",
-                                "sortorder": "",
-                                "text": "Platinum"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "ab02482d-e9e0-49ad-aac9-20d51ac99c15",
-                                "id": "0d2320bb-6415-4328-80a6-821f40cd6f41",
-                                "sortorder": "",
-                                "text": "Plutonium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f95fd4f0-31e5-42ff-b8b0-5fe5fea34c65",
-                                "id": "8f12827a-cd27-476c-8fe3-e93f57d02bb9",
-                                "sortorder": "",
-                                "text": "Polonium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "2ff81125-8e3f-43fc-a92a-75baed7639e3",
-                                "id": "a98ae006-b38a-4821-83c1-f419876e2318",
-                                "sortorder": "",
-                                "text": "Potassium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "78525076-60d1-4e00-8cf1-6ca9f3a3f02e",
-                                "id": "6f6fcd03-294e-458a-8deb-d094ad6c9633",
-                                "sortorder": "",
-                                "text": "Praseodymium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "3efa527c-32e6-4a2a-84aa-b018ce0742f2",
-                                "id": "6aaf76e5-f4d6-4509-8d28-e82fb0685b50",
-                                "sortorder": "",
-                                "text": "Promethium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "882336f3-a87d-4902-bb36-437f67a529fb",
-                                "id": "dc744b3a-f8d3-4c9a-8fdb-6c2ac3aa383a",
-                                "sortorder": "",
-                                "text": "Protactinium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f0b690bb-9e27-433b-a614-87e32fc9e87b",
-                                "id": "7d8b96b5-48a3-4f59-bc5c-d7c9ad445674",
-                                "sortorder": "",
-                                "text": "Radium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "4476323a-0bdc-4931-a22d-1a857c7257a4",
-                                "id": "b5d48326-b93c-4597-a022-264bddd2d9d8",
-                                "sortorder": "",
-                                "text": "Radon"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "16cf5efc-6549-42e9-b306-6f30cb430103",
-                                "id": "9ce52e35-6f77-4513-8355-30720f9b9c4c",
-                                "sortorder": "",
-                                "text": "Rhenium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "2e51a0c5-67a5-4be3-b2a9-6241b671cc1f",
-                                "id": "de58967b-116d-4831-a9cf-2bd709c2d0f9",
-                                "sortorder": "",
-                                "text": "Rhodium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "7f0239ab-5241-44e2-b295-537e51a80c52",
-                                "id": "5f3e3be8-3859-4de3-9fc0-7934758b1012",
-                                "sortorder": "",
-                                "text": "Roentgenium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f51d6b90-1bd4-425d-91a9-04c2bb9f0164",
-                                "id": "9eec2416-2a7c-4986-b3d3-b4199962a69b",
-                                "sortorder": "",
-                                "text": "Rubidium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "b134d2a0-532a-42d5-b124-5a1710e39d65",
-                                "id": "0f34908d-a8b4-4a1f-bcf1-c218038eeef9",
-                                "sortorder": "",
-                                "text": "Ruthenium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "4b4478ab-03e4-40b4-9cdc-e1a5c63f5aa8",
-                                "id": "a9d067dc-e1e5-469c-9232-e2e610d029b0",
-                                "sortorder": "",
-                                "text": "Rutherfordium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "ad04f159-3d1f-4508-b820-870eebbc40e4",
-                                "id": "6e88ab42-f056-4ed5-95a9-4fa27629e28b",
-                                "sortorder": "",
-                                "text": "Samarium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f8cc9721-cbab-4d76-a588-4a76c220687d",
-                                "id": "a95f7f2b-ce50-4131-bdaa-1905cbedee45",
-                                "sortorder": "",
-                                "text": "Scandium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "64fec2d2-89dd-43e8-985d-3b380ad69186",
-                                "id": "7163f716-e51d-4e81-9705-b00adedb2bd9",
-                                "sortorder": "",
-                                "text": "Seaborgium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "b8dced33-c032-4dfc-a72d-1df8bb185760",
-                                "id": "de53f7e7-4277-4ab7-9554-0698e30666b0",
-                                "sortorder": "",
-                                "text": "Selenium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "8c1595e4-6f8e-434c-9f65-e1c3589c3f72",
-                                "id": "8c85fcac-41f4-460e-aa46-e407947b459f",
-                                "sortorder": "",
-                                "text": "Silicon"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "b1f6d85d-9ea2-4156-a3ca-e2a0965c0937",
-                                "id": "d623bd41-54eb-4edc-8041-e470777be933",
-                                "sortorder": "",
-                                "text": "Silver"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "8b7bd8bb-b228-4d0d-91a8-038f202d9f51",
-                                "id": "01315ca1-582a-4cf8-984f-f1c0d9291f48",
-                                "sortorder": "",
-                                "text": "Sodium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "58b2a731-e2f9-4925-b950-c4e0a908821d",
-                                "id": "65738819-6fa6-46b6-82f9-51852d0db535",
-                                "sortorder": "",
-                                "text": "Strontium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "6da257a3-a82f-48a4-b4f0-7276131b0c4e",
-                                "id": "9a3d82ec-5c5a-48fd-af32-406522ee7c61",
-                                "sortorder": "",
-                                "text": "Sulfur"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "dd16dc11-132f-4d9a-96ed-9072f322257e",
-                                "id": "1bb64bbe-bf52-4f14-a144-15af532cd374",
-                                "sortorder": "",
-                                "text": "Tantalum"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "abf7d596-9e36-4bbe-8b7c-f2b40fd5697b",
-                                "id": "c7cd5949-23d2-44d6-baaf-ae7a3f06a705",
-                                "sortorder": "",
-                                "text": "Technetium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "d529cea0-16fb-4c03-85e2-eb37bd499fc0",
-                                "id": "8ea950e3-72fd-493c-920b-72b0aac5276a",
-                                "sortorder": "",
-                                "text": "Tellurium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "15d1dcd4-054f-44ab-b64e-75e659513d80",
-                                "id": "dfa3b642-5fa7-4736-9d98-ef6e96413b26",
-                                "sortorder": "",
-                                "text": "Tennessine"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "911f6feb-7c1c-4d67-a86d-333e70aa77b5",
-                                "id": "6af0ad8f-cce1-4897-b9b8-d71c82147eff",
-                                "sortorder": "",
-                                "text": "Terbium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "840026ad-a4ee-42ef-850f-6b7d83162961",
-                                "id": "08ac4016-0c5c-4857-9cce-47a5c88637a6",
-                                "sortorder": "",
-                                "text": "Thallium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "1df55246-26a7-4670-aa2b-efde7aff9fa6",
-                                "id": "d4845a22-97e1-4b60-ac5d-74bdf8a7504c",
-                                "sortorder": "",
-                                "text": "Thorium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "12aa5cea-0f98-4b10-8084-24795fe07813",
-                                "id": "9d555a0f-2cb1-4b18-8c3a-4716281d2187",
-                                "sortorder": "",
-                                "text": "Thulium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "07352117-9e9a-485e-a042-a3df8c7d1d6a",
-                                "id": "c8b14291-6eb2-4a8b-a5df-0aad74404656",
-                                "sortorder": "",
-                                "text": "Tin"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "3437adbb-97df-463a-b1c6-65ffaaf28414",
-                                "id": "7ef706ab-9a95-4d67-a805-1f4029856ee4",
-                                "sortorder": "",
-                                "text": "Titanium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "1441b79e-fed7-4a36-acc5-bb1b60d1976d",
-                                "id": "02b7d2fa-01a1-436f-880a-cd1207a9bbb1",
-                                "sortorder": "",
-                                "text": "Uranium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "ff3918b4-ebf5-407b-9d9e-951532a6e55f",
-                                "id": "f2b04911-e012-4708-83e1-8596107a2cc1",
-                                "sortorder": "",
-                                "text": "Vanadium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "4f364fad-a1ab-4956-a36e-204ed8bb2ca0",
-                                "id": "c8214d85-baec-4456-b1e0-f431e16721e0",
-                                "sortorder": "",
-                                "text": "Wolfram"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "b1eb4eb1-a848-45cb-8e8b-dbc6d33b51cb",
-                                "id": "51c52dd8-ab33-4828-85c7-ba7545f4e055",
-                                "sortorder": "",
-                                "text": "Xenon"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "cc84ea58-4e46-4c49-a043-eff30f663403",
-                                "id": "a40de5eb-aad9-4d46-8072-e0a62d836715",
-                                "sortorder": "",
-                                "text": "Ytterbium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "a36c95d6-92dc-4be6-b277-fca3f18f0c2a",
-                                "id": "f6ccc4c2-9da0-4180-acc2-35aff591010f",
-                                "sortorder": "",
-                                "text": "Yttrium"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "50cbd32b-14d0-4ac4-ade4-629a3ad8c694",
-                                "id": "f2c339c5-ef47-4560-99c5-5aa1678f2d74",
-                                "sortorder": "",
-                                "text": "Zinc"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "bc2b7ddc-7e71-479b-b89d-50c00794bae7",
-                                "id": "8950a0f5-0e18-4ae1-b8f7-63e8b3ec5eb4",
-                                "sortorder": "",
-                                "text": "Zirconium"
-                            }
-                        ],
                         "placeholder": {
                             "en": "Select an option"
                         },
@@ -9593,7 +9222,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000013"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b7f8a4c-b498-11e9-b10f-a4d18cec433a",
@@ -9629,13 +9258,38 @@
                     "card_id": "0b7f8a4c-b498-11e9-b10f-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9648,7 +9302,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b7f8a4c-b498-11e9-b10f-a4d18cec433a",
@@ -9705,14 +9359,11 @@
                 {
                     "card_id": "0b7f8a4c-b498-11e9-b10f-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9725,7 +9376,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ac4e5196-47e7-11f0-8081-020539808477",
@@ -9753,13 +9404,38 @@
                     "card_id": "ac4e5196-47e7-11f0-8081-020539808477",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9772,7 +9448,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ac4e5196-47e7-11f0-8081-020539808477",
@@ -9842,7 +9518,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9855,7 +9530,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b5b42026-b2f2-11e9-ac0c-a4d18cec433a",
@@ -9895,7 +9570,6 @@
                             "placeholder"
                         ],
                         "label": "material_data_assignment_statement_language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9908,7 +9582,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc650ab5-b497-11e9-a2e5-a4d18cec433a",
@@ -9944,13 +9618,38 @@
                     "card_id": "fc650ab5-b497-11e9-a2e5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9963,7 +9662,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc650ab5-b497-11e9-a2e5-a4d18cec433a",
@@ -10021,14 +9720,37 @@
                     "card_id": "fc650ab5-b497-11e9-a2e5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10041,17 +9763,30 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fec5c840-8593-11ea-97eb-acde48001122",
                     "config": {
-                        "defaultValue": "187beb4a-c999-47ba-9cb6-0b5e1293529d",
+                        "defaultValue": [
+                            {
+                                "labels": [
+                                    {
+                                        "id": "147967b2-b8e1-4015-915f-6d2099d2267a",
+                                        "language_id": "en-US",
+                                        "list_item_id": "6b031c2a-888a-4637-b853-2c01dc38c132",
+                                        "value": "p1_is_identified_by",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1b066f78-8d4b-4bb7-a83b-db15ae220811",
+                                "uri": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by"
+                            }
+                        ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Relation Assigned in Part Identifier Assignment Event",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10064,17 +9799,30 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fec5c840-8593-11ea-97eb-acde48001122",
                     "config": {
-                        "defaultValue": "768b2f11-26e4-4ada-a699-7a8d3fe9fe5a",
+                        "defaultValue": [
+                            {
+                                "labels": [
+                                    {
+                                        "id": "6dd60928-4696-46f0-b5db-c93ea708b331",
+                                        "language_id": "en",
+                                        "list_item_id": "a470419e-e8a2-4fd7-98f2-7b8d5bf3bf2a",
+                                        "value": "internal identifier",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                                "uri": "http://vocab.getty.edu/aat/300404621"
+                            }
+                        ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Geometric Annotation Identifier for Part ",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10087,7 +9835,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fec5c840-8593-11ea-97eb-acde48001122",
@@ -10227,13 +9975,24 @@
                     "card_id": "b11f140a-d2bc-11e9-9e67-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10246,7 +10005,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f23e6-d2bc-11e9-9216-a4d18cec433a",
@@ -10308,7 +10067,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10321,7 +10079,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f0cba-d2bc-11e9-b808-a4d18cec433a",
@@ -10375,7 +10133,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10388,7 +10145,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f23e6-d2bc-11e9-9216-a4d18cec433a",
@@ -10428,7 +10185,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10441,7 +10197,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f23e6-d2bc-11e9-9216-a4d18cec433a",
@@ -10527,14 +10283,37 @@
                     "card_id": "b11f1087-d2bc-11e9-8794-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10547,7 +10326,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f1c5c-d2bc-11e9-8e7a-a4d18cec433a",
@@ -10664,13 +10443,38 @@
                     "card_id": "b11f140a-d2bc-11e9-9e67-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10683,7 +10487,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f23e6-d2bc-11e9-9216-a4d18cec433a",
@@ -10693,7 +10497,6 @@
                             "placeholder"
                         ],
                         "label": "Part Removal Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10706,7 +10509,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f17ca-d2bc-11e9-9692-a4d18cec433a",
@@ -10785,13 +10588,38 @@
                     "card_id": "b11f2754-d2bc-11e9-9b12-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10804,7 +10632,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f140a-d2bc-11e9-9e67-a4d18cec433a",
@@ -10888,7 +10716,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10901,19 +10728,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f2754-d2bc-11e9-9b12-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10926,7 +10750,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f17ca-d2bc-11e9-9692-a4d18cec433a",
@@ -10998,14 +10822,11 @@
                 {
                     "card_id": "b11f0847-d2bc-11e9-9dc3-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11018,7 +10839,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f23e6-d2bc-11e9-9216-a4d18cec433a",
@@ -11090,13 +10911,38 @@
                     "card_id": "b11f0847-d2bc-11e9-9dc3-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11109,7 +10955,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f0cba-d2bc-11e9-b808-a4d18cec433a",
@@ -11166,13 +11012,38 @@
                     "card_id": "b11f1087-d2bc-11e9-8794-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11185,7 +11056,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f17ca-d2bc-11e9-9692-a4d18cec433a",
@@ -11232,7 +11103,6 @@
                             "placeholder"
                         ],
                         "label": "Part Removal Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11245,7 +11115,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b11f2754-d2bc-11e9-9b12-a4d18cec433a",
@@ -11307,7 +11177,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11320,7 +11189,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a149095e-d2bd-11e9-b3ca-a4d18cec433a",
@@ -11404,7 +11273,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11417,7 +11285,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc1542b8-b497-11e9-8473-a4d18cec433a",
@@ -11655,7 +11523,6 @@
                             "placeholder"
                         ],
                         "label": "Production Event Part Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11668,7 +11535,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc157af8-b497-11e9-917b-a4d18cec433a",
@@ -11678,7 +11545,6 @@
                             "placeholder"
                         ],
                         "label": "Production Event Part Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11691,7 +11557,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc157af8-b497-11e9-917b-a4d18cec433a",
@@ -11879,7 +11745,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11892,7 +11757,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc650e61-b497-11e9-b512-a4d18cec433a",
@@ -11928,13 +11793,38 @@
                     "card_id": "fc650e61-b497-11e9-b512-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11947,7 +11837,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc650e61-b497-11e9-b512-a4d18cec433a",
@@ -11974,14 +11864,11 @@
                 {
                     "card_id": "fc650e61-b497-11e9-b512-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11994,7 +11881,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc650e61-b497-11e9-b512-a4d18cec433a",
@@ -12034,7 +11921,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12047,7 +11933,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc156e4f-b497-11e9-8226-a4d18cec433a",
@@ -12109,7 +11995,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12122,7 +12007,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc156e4f-b497-11e9-8226-a4d18cec433a",
@@ -12234,7 +12119,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12247,7 +12131,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc15744a-b497-11e9-98c5-a4d18cec433a",
@@ -12364,13 +12248,24 @@
                     "card_id": "cc155cdc-b497-11e9-a9e8-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12383,7 +12278,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc155cdc-b497-11e9-a9e8-a4d18cec433a",
@@ -12441,13 +12336,38 @@
                     "card_id": "cc155cdc-b497-11e9-a9e8-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12460,7 +12380,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a149095e-d2bd-11e9-b3ca-a4d18cec433a",
@@ -12536,7 +12456,6 @@
                             "placeholder"
                         ],
                         "label": "Production Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12549,7 +12468,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc1568c5-b497-11e9-a58c-a4d18cec433a",
@@ -12559,7 +12478,6 @@
                             "placeholder"
                         ],
                         "label": "Production Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12572,7 +12490,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc1568c5-b497-11e9-a58c-a4d18cec433a",
@@ -12794,7 +12712,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12807,7 +12724,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc15817d-b497-11e9-8044-a4d18cec433a",
@@ -12859,7 +12776,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -12872,7 +12788,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "22c155b5-b498-11e9-8cfc-a4d18cec433a",
@@ -13020,13 +12936,38 @@
                     "card_id": "cc153642-b497-11e9-910a-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -13039,7 +12980,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc153642-b497-11e9-910a-a4d18cec433a",
@@ -13066,14 +13007,11 @@
                 {
                     "card_id": "cc153642-b497-11e9-910a-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -13086,7 +13024,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc154fe1-b497-11e9-8981-a4d18cec433a",
@@ -13122,13 +13060,38 @@
                     "card_id": "cc154fe1-b497-11e9-8981-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -13141,7 +13104,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc154fe1-b497-11e9-8981-a4d18cec433a",
@@ -13168,14 +13131,11 @@
                 {
                     "card_id": "cc154fe1-b497-11e9-8981-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -13188,7 +13148,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "cc154fe1-b497-11e9-8981-a4d18cec433a",
@@ -13275,14 +13235,11 @@
                 {
                     "card_id": "57f24d68-d2bd-11e9-afc6-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -13295,7 +13252,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "57f24d68-d2bd-11e9-afc6-a4d18cec433a",
@@ -13331,13 +13288,38 @@
                     "card_id": "57f24d68-d2bd-11e9-afc6-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -13350,7 +13332,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fc6516dc-b497-11e9-bfe6-a4d18cec433a",
@@ -18777,9 +18759,10 @@
                 {
                     "alias": "dimension_type_",
                     "config": {
-                        "rdmCollection": "c9e838f8-7660-4701-821c-721dac98a10b"
+                        "controlledList": "c9e838f8-7660-4701-821c-721dac98a10b",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18802,9 +18785,10 @@
                 {
                     "alias": "dimension_name_type_",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18873,9 +18857,10 @@
                 {
                     "alias": "dimension_unit",
                     "config": {
-                        "rdmCollection": "44295221-1215-4359-a079-234b317f65b7"
+                        "controlledList": "44295221-1215-4359-a079-234b317f65b7",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19015,9 +19000,10 @@
                 {
                     "alias": "dimension_name_language_",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19086,10 +19072,10 @@
                 {
                     "alias": "statement_language_",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19112,9 +19098,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19137,9 +19124,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "a16a4edc-c916-4293-af98-44d76ce6cba7"
+                        "controlledList": "a16a4edc-c916-4293-af98-44d76ce6cba7",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19231,9 +19219,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19338,9 +19327,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "f4a87a34-8288-4cec-8e20-b28bd567ce0a"
+                        "controlledList": "f4a87a34-8288-4cec-8e20-b28bd567ce0a",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19585,9 +19575,10 @@
                 {
                     "alias": "material_data_assignment_timespan_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19740,9 +19731,10 @@
                 {
                     "alias": "material_data_assignment_timespan_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19765,9 +19757,10 @@
                 {
                     "alias": "material_data_assignment_timespan_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19815,9 +19808,10 @@
                 {
                     "alias": "material_data_assignment_statement_type_metatype",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -19946,9 +19940,10 @@
                 {
                     "alias": "part_identifier_assignment_assigned_property_type",
                     "config": {
-                        "rdmCollection": "1b066f78-8d4b-4bb7-a83b-db15ae220811"
+                        "controlledList": "1b066f78-8d4b-4bb7-a83b-db15ae220811",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20293,9 +20288,10 @@
                 {
                     "alias": "addition_to_collection_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20352,9 +20348,10 @@
                 {
                     "alias": "addition_to_collection_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20377,9 +20374,10 @@
                 {
                     "alias": "addition_to_collection_technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20402,9 +20400,10 @@
                 {
                     "alias": "addition_to_collection_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20427,9 +20426,10 @@
                 {
                     "alias": "addition_to_collection_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20651,9 +20651,10 @@
                 {
                     "alias": "addition_to_collection_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20676,9 +20677,10 @@
                 {
                     "alias": "addition_to_collection_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20735,9 +20737,10 @@
                 {
                     "alias": "addition_to_collection_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20840,9 +20843,10 @@
                 {
                     "alias": "addition_to_collection_type",
                     "config": {
-                        "rdmCollection": "94343b71-a35a-4edd-8ffa-61c66ea8d417"
+                        "controlledList": "94343b71-a35a-4edd-8ffa-61c66ea8d417",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21027,9 +21031,10 @@
                 {
                     "alias": "addition_to_collection_identifier_type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21111,9 +21116,10 @@
                 {
                     "alias": "addition_to_collection_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21298,9 +21304,10 @@
                 {
                     "alias": "addition_to_collection_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21323,10 +21330,10 @@
                 {
                     "alias": "addition_to_collection_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21452,9 +21459,10 @@
                 {
                     "alias": "addition_to_collection_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21511,9 +21519,10 @@
                 {
                     "alias": "addition_to_collection_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21536,9 +21545,10 @@
                 {
                     "alias": "addition_to_collection_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21644,10 +21654,10 @@
                 {
                     "alias": "production_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21670,9 +21680,10 @@
                 {
                     "alias": "production_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21695,9 +21706,10 @@
                 {
                     "alias": "production_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21823,9 +21835,10 @@
                 {
                     "alias": "production_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22012,9 +22025,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22245,10 +22259,10 @@
                 {
                     "alias": "production_part_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22271,9 +22285,10 @@
                 {
                     "alias": "production_part_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22296,9 +22311,10 @@
                 {
                     "alias": "production_part_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22424,9 +22440,10 @@
                 {
                     "alias": "production_part_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22563,9 +22580,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "56991802-f539-4b22-b5a9-b1945fceb52b"
+                        "controlledList": "56991802-f539-4b22-b5a9-b1945fceb52b",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": true,
                     "fieldname": "type",
@@ -23012,9 +23030,10 @@
                 {
                     "alias": "removal_from_set_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23071,9 +23090,10 @@
                 {
                     "alias": "removal_from_set_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23096,9 +23116,10 @@
                 {
                     "alias": "removal_from_set_technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23121,9 +23142,10 @@
                 {
                     "alias": "removal_from_set_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23146,9 +23168,10 @@
                 {
                     "alias": "removal_from_set_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23483,9 +23506,10 @@
                 {
                     "alias": "removal_from_set_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23508,9 +23532,10 @@
                 {
                     "alias": "removal_from_set_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23570,9 +23595,10 @@
                 {
                     "alias": "removal_from_set_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23675,9 +23701,10 @@
                 {
                     "alias": "removal_from_set_type",
                     "config": {
-                        "rdmCollection": "51e3963f-00b3-4a62-8704-5c89822555de"
+                        "controlledList": "51e3963f-00b3-4a62-8704-5c89822555de",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23865,9 +23892,10 @@
                 {
                     "alias": "removal_from_set_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23949,9 +23977,10 @@
                 {
                     "alias": "removal_from_set_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24136,9 +24165,10 @@
                 {
                     "alias": "removal_from_set_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24161,10 +24191,10 @@
                 {
                     "alias": "removal_from_set_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24293,9 +24323,10 @@
                 {
                     "alias": "removal_from_set_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24355,9 +24386,10 @@
                 {
                     "alias": "removal_from_set_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24380,9 +24412,10 @@
                 {
                     "alias": "removal_from_set_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24405,9 +24438,10 @@
                 {
                     "alias": "material_data_assignment_classification",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -24645,9 +24679,10 @@
                 {
                     "alias": "material_data_assignment_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24670,9 +24705,10 @@
                 {
                     "alias": "material_data_assignment_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25026,9 +25062,10 @@
                 {
                     "alias": "removal_from_object_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25085,9 +25122,10 @@
                 {
                     "alias": "removal_from_object_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25110,9 +25148,10 @@
                 {
                     "alias": "removal_from_object_technique",
                     "config": {
-                        "rdmCollection": "af4360a2-0809-44a3-a72a-8a5f3c15ab31"
+                        "controlledList": "af4360a2-0809-44a3-a72a-8a5f3c15ab31",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25135,9 +25174,10 @@
                 {
                     "alias": "removal_from_object_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25160,9 +25200,10 @@
                 {
                     "alias": "removal_from_object_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25497,9 +25538,10 @@
                 {
                     "alias": "removal_from_object_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25522,9 +25564,10 @@
                 {
                     "alias": "removal_from_object_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25584,9 +25627,10 @@
                 {
                     "alias": "removal_from_object_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25689,9 +25733,10 @@
                 {
                     "alias": "removal_from_object_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25879,9 +25924,10 @@
                 {
                     "alias": "removal_from_object_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25963,9 +26009,10 @@
                 {
                     "alias": "removal_from_object_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26150,9 +26197,10 @@
                 {
                     "alias": "removal_from_object_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26175,10 +26223,10 @@
                 {
                     "alias": "removal_from_object_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26307,9 +26355,10 @@
                 {
                     "alias": "removal_from_object_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26369,9 +26418,10 @@
                 {
                     "alias": "removal_from_object_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26394,9 +26444,10 @@
                 {
                     "alias": "removal_from_object_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26517,9 +26568,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -26588,9 +26640,10 @@
                 {
                     "alias": "name_language_",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26673,9 +26726,10 @@
                 {
                     "alias": "name_type_",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26773,9 +26827,10 @@
                 {
                     "alias": "material_data_assignment_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26823,10 +26878,10 @@
                 {
                     "alias": "material_data_assignment_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26916,10 +26971,10 @@
                 {
                     "alias": "material",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "e4cb1e47-b2d0-49b9-8899-1f1776ad1103"
+                        "controlledList": "e4cb1e47-b2d0-49b9-8899-1f1776ad1103",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": true,
                     "fieldname": "material",
@@ -27427,9 +27482,10 @@
                 {
                     "alias": "production_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27452,9 +27508,10 @@
                 {
                     "alias": "production_part_technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27477,9 +27534,10 @@
                 {
                     "alias": "production_part_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27623,9 +27681,10 @@
                 {
                     "alias": "production_part_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27671,9 +27730,10 @@
                 {
                     "alias": "production_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27696,9 +27756,10 @@
                 {
                     "alias": "production_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27840,9 +27901,10 @@
                 {
                     "alias": "production_part_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27970,9 +28032,10 @@
                 {
                     "alias": "production_type",
                     "config": {
-                        "rdmCollection": "f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"
+                        "controlledList": "f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28098,9 +28161,10 @@
                 {
                     "alias": "production_part_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28123,9 +28187,10 @@
                 {
                     "alias": "production_part_type",
                     "config": {
-                        "rdmCollection": "f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"
+                        "controlledList": "f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28228,9 +28293,10 @@
                 {
                     "alias": "production_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28314,9 +28380,10 @@
                 {
                     "alias": "production_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28339,9 +28406,10 @@
                 {
                     "alias": "production_part_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28497,9 +28565,10 @@
                 {
                     "alias": "production_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28522,9 +28591,10 @@
                 {
                     "alias": "production_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28547,9 +28617,10 @@
                 {
                     "alias": "production_part_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28666,9 +28737,10 @@
                 {
                     "alias": "production_part_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29066,9 +29138,10 @@
                 {
                     "alias": "production_technique",
                     "config": {
-                        "rdmCollection": "1bb3db74-3dff-4e44-a629-7d6a0c1383e9"
+                        "controlledList": "1bb3db74-3dff-4e44-a629-7d6a0c1383e9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29196,9 +29269,10 @@
                 {
                     "alias": "production_part_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29278,9 +29352,10 @@
                 {
                     "alias": "production_part_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29303,9 +29378,10 @@
                 {
                     "alias": "production_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29488,9 +29564,10 @@
                 {
                     "alias": "production_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29693,9 +29770,10 @@
                 {
                     "alias": "production_part_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29718,9 +29796,10 @@
                 {
                     "alias": "production_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29936,9 +30015,10 @@
                 {
                     "alias": "part_identifier_assignment_polygon_identifier_classification",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -29961,9 +30041,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -30230,9 +30311,10 @@
                 {
                     "alias": "destruction_type_",
                     "config": {
-                        "rdmCollection": "079561dc-4c8f-40db-b658-c2fd5acdb3f2"
+                        "controlledList": "079561dc-4c8f-40db-b658-c2fd5acdb3f2",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -30371,9 +30453,10 @@
                 {
                     "alias": "destruction_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -30396,9 +30479,10 @@
                 {
                     "alias": "destruction_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -30518,9 +30602,10 @@
                 {
                     "alias": "destruction_name_language_",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -30717,9 +30802,10 @@
                 {
                     "alias": "destruction_identifier_type_",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -30788,10 +30874,10 @@
                 {
                     "alias": "destruction_statement_language_",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -30814,9 +30900,10 @@
                 {
                     "alias": "destruction_statement_name_language_",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -30935,9 +31022,10 @@
                 {
                     "alias": "destruction_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -31006,9 +31094,10 @@
                 {
                     "alias": "destruction_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -31031,9 +31120,10 @@
                 {
                     "alias": "destruction_time_name_language_",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -31056,10 +31146,10 @@
                 {
                     "alias": "destruction_time_type_",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -31358,9 +31448,10 @@
                 {
                     "alias": "destruction_time_duration_name_type_",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -31383,9 +31474,10 @@
                 {
                     "alias": "destruction_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -31431,9 +31523,10 @@
                 {
                     "alias": "destruction_time_name_type_",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -31456,9 +31549,10 @@
                 {
                     "alias": "destruction_time_duration_unit_",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -31588,9 +31682,9 @@
             "publication": {
                 "graph_id": "9519cb4f-b25b-11e9-8c7b-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "569f4c6e-522a-11f0-ab0e-020539808477",
-                "published_time": "2025-06-25T18:10:24.387"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "328f1198-f6e1-45ff-96af-207a934900c4",
+                "published_time": "2026-02-06T12:59:01.513"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Place.json
+++ b/arches_for_science/pkg/graphs/resource_models/Place.json
@@ -470,7 +470,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -483,7 +482,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "07e76d99-911a-11ec-a428-ad03e9261309",
@@ -609,7 +608,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -622,7 +620,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "23e25aa8-c071-11e9-80c7-a4d18cec433a",
@@ -658,14 +656,37 @@
                     "card_id": "23e25aa8-c071-11e9-80c7-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "7d08d556-b831-4a7b-8a47-2068db0db6e6",
+                                        "language_id": "en",
+                                        "list_item_id": "b441941d-8d0d-4db3-9a99-cd28886d500a",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "e24a3dd7-06bb-4238-a161-81ab6c582574",
+                                        "language_id": "en",
+                                        "list_item_id": "1e9d7790-e9fa-4971-a37c-0ee8ba4db798",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -678,19 +699,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "23e25aa8-c071-11e9-80c7-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -703,7 +749,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "23e25aa8-c071-11e9-80c7-a4d18cec433a",
@@ -799,13 +845,38 @@
                     "card_id": "23e25154-c071-11e9-a9e8-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -818,7 +889,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "23e25154-c071-11e9-a9e8-a4d18cec433a",
@@ -845,14 +916,11 @@
                 {
                     "card_id": "23e25154-c071-11e9-a9e8-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -865,7 +933,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c45fb747-b2f2-11e9-bf05-a4d18cec433a",
@@ -905,7 +973,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -918,7 +985,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "229e1580-c071-11e9-bcfc-a4d18cec433a",
@@ -988,7 +1055,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1001,7 +1067,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "229e1580-c071-11e9-bcfc-a4d18cec433a",
@@ -1180,7 +1246,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1193,7 +1258,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1be4c691-c071-11e9-bc3b-a4d18cec433a",
@@ -1281,13 +1346,24 @@
                     "card_id": "1be4c691-c071-11e9-bc3b-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1300,19 +1376,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1be4c691-c071-11e9-bc3b-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1325,7 +1426,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": "rgba(38,70,83,0.75)",
@@ -1943,9 +2044,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": "09f4f591-5654-4518-931b-7ab382fbc100"
+                        "controlledList": "09f4f591-5654-4518-931b-7ab382fbc100",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2100,9 +2202,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2323,9 +2426,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -2371,9 +2475,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2456,9 +2561,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2529,9 +2635,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2683,10 +2790,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2709,9 +2816,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2734,9 +2842,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "f44f7240-35c5-49e8-a0e3-2ffe308f0862"
+                        "controlledList": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -2828,9 +2937,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3078,9 +3188,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -3189,9 +3300,9 @@
             "publication": {
                 "graph_id": "cc8ed633-b25b-11e9-a13a-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "8968cbff-382f-11f0-b297-020539808477",
-                "published_time": "2025-05-23T16:42:06.845"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "8433c373-5e8f-4725-8536-7b15b9357acf",
+                "published_time": "2026-02-06T12:59:20.902"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Project.json
+++ b/arches_for_science/pkg/graphs/resource_models/Project.json
@@ -270,14 +270,10 @@
                     "component_id": "2f9054d8-de57-45cd-8a9c-58bbb1619030",
                     "config": {
                         "groupedCardIds": [
-                            "0b92888a-ca85-11e9-8e1d-a4d18cec433a",
-                            "0b923be6-ca85-11e9-880a-a4d18cec433a"
+                            "c8f6488e-c5f3-4e10-b082-71a04a678604",
+                            "3b1979fd-6e13-4e49-9c4f-32b2108ad4d5"
                         ],
-                        "sortedWidgetIds": [
-                            "0b9272a8-ca85-11e9-9149-a4d18cec433a",
-                            "0b928202-ca85-11e9-a8d3-a4d18cec433a",
-                            "0b9237fd-ca85-11e9-9e80-a4d18cec433a"
-                        ]
+                        "sortedWidgetIds": []
                     },
                     "constraints": [],
                     "cssclass": null,
@@ -786,7 +782,6 @@
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -799,7 +794,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b929321-ca85-11e9-8673-a4d18cec433a",
@@ -839,7 +834,6 @@
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -852,7 +846,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b929321-ca85-11e9-8673-a4d18cec433a",
@@ -992,13 +986,38 @@
                     "card_id": "0b926af8-ca85-11e9-afc6-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select one or more language"
                         }
@@ -1011,19 +1030,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b926af8-ca85-11e9-afc6-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select a type for this name"
                         }
@@ -1036,7 +1052,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b925b2e-ca85-11e9-9e82-a4d18cec433a",
@@ -1135,7 +1151,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1148,7 +1163,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b925b2e-ca85-11e9-9e82-a4d18cec433a",
@@ -1158,7 +1173,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1171,7 +1185,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b925b2e-ca85-11e9-9e82-a4d18cec433a",
@@ -1255,7 +1269,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1268,7 +1281,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b927a7a-ca85-11e9-89a5-a4d18cec433a",
@@ -1360,7 +1373,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1373,7 +1385,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "49394321-911a-11ec-a428-ad03e9261309",
@@ -1405,7 +1417,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1418,7 +1429,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b92748a-ca85-11e9-98a4-a4d18cec433a",
@@ -1536,7 +1547,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1549,7 +1559,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "80db4c61-911a-11ec-a428-ad03e9261309",
@@ -1701,30 +1711,24 @@
                     "card_id": "0b9266b5-ca85-11e9-9405-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name type",
-                        "options": [
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f4643b7d-2710-4aca-8892-c0eeed02dfe9",
-                                "id": "0798bf2c-ab07-43d7-81f4-f1e2d20251a1",
-                                "sortorder": "",
-                                "text": "alternate titles"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "18610abd-e0e5-48bb-9a7a-3830d75755d0",
-                                "id": "7d069762-bd96-44b8-afc8-4761389105c5",
-                                "sortorder": "",
-                                "text": "primary title"
-                            }
-                        ],
                         "placeholder": {
                             "en": "Select one or more types for this name"
                         },
@@ -1738,19 +1742,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000013"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b9266b5-ca85-11e9-9405-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select one or more languages of the content"
                         }
@@ -1763,7 +1792,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b9266b5-ca85-11e9-9405-a4d18cec433a",
@@ -1803,7 +1832,6 @@
                             "placeholder"
                         ],
                         "label": "Scale of Project",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1816,7 +1844,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b924654-ca85-11e9-be41-a4d18cec433a",
@@ -1826,32 +1854,6 @@
                             "placeholder"
                         ],
                         "label": "Scale of Project",
-                        "options": [
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "2f3da2d3-1a5e-4603-ae2c-e716319ee226",
-                                "id": "7fa8d3cd-c6ee-44e2-b636-bd85b35341c2",
-                                "sortorder": "",
-                                "text": "initiative"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "54d2f763-34aa-4830-bc1d-f9ed627cf164",
-                                "id": "8951f2fb-2b7c-4507-98c7-9bb6d9277fa8",
-                                "sortorder": "1",
-                                "text": "project"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "66ac5ba5-c498-48fc-9a31-e132dce34883",
-                                "id": "4de10d66-d0c7-4186-86f6-f7eb4a20f18b",
-                                "sortorder": "2",
-                                "text": "research task"
-                            }
-                        ],
                         "placeholder": {
                             "en": "Select type of project"
                         },
@@ -1865,7 +1867,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000009"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b92a2de-ca85-11e9-aa53-a4d18cec433a",
@@ -1935,7 +1937,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1948,7 +1949,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b92a2de-ca85-11e9-aa53-a4d18cec433a",
@@ -2024,7 +2025,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2037,7 +2037,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b9242bd-ca85-11e9-a735-a4d18cec433a",
@@ -2073,13 +2073,38 @@
                     "card_id": "0b9242bd-ca85-11e9-a735-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2092,7 +2117,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b9242bd-ca85-11e9-a735-a4d18cec433a",
@@ -2119,14 +2144,11 @@
                 {
                     "card_id": "0b9242bd-ca85-11e9-a735-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2139,7 +2161,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b9242bd-ca85-11e9-a735-a4d18cec433a",
@@ -2227,13 +2249,38 @@
                     "card_id": "0b92a657-ca85-11e9-8964-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select one or more languages of the content"
                         }
@@ -2246,20 +2293,43 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b92a657-ca85-11e9-8964-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "e24a3dd7-06bb-4238-a161-81ab6c582574",
+                                        "language_id": "en",
+                                        "list_item_id": "1e9d7790-e9fa-4971-a37c-0ee8ba4db798",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "7d08d556-b831-4a7b-8a47-2068db0db6e6",
+                                        "language_id": "en",
+                                        "list_item_id": "b441941d-8d0d-4db3-9a99-cd28886d500a",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select one or more types for this Statement"
                         }
@@ -2272,7 +2342,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b92a657-ca85-11e9-8964-a4d18cec433a",
@@ -2411,14 +2481,11 @@
                 {
                     "card_id": "0b928d42-ca85-11e9-888c-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2431,7 +2498,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b928d42-ca85-11e9-888c-a4d18cec433a",
@@ -2459,13 +2526,38 @@
                     "card_id": "0b928d42-ca85-11e9-888c-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2478,7 +2570,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b928d42-ca85-11e9-888c-a4d18cec433a",
@@ -2655,7 +2747,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Timespan",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2668,7 +2759,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0b92615c-ca85-11e9-96a2-a4d18cec433a",
@@ -3903,9 +3994,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "26d7ce44-20e5-44fb-a3c1-dfbe6bdd521b"
+                        "controlledList": "26d7ce44-20e5-44fb-a3c1-dfbe6bdd521b",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": true,
                     "fieldname": "proj_type",
@@ -4482,9 +4574,10 @@
                 {
                     "alias": "technique",
                     "config": {
-                        "rdmCollection": "3a8e8388-0bb9-42f2-bc77-fc5a1c640589"
+                        "controlledList": "3a8e8388-0bb9-42f2-bc77-fc5a1c640589",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4591,9 +4684,10 @@
                 {
                     "alias": "timespan_name_type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4616,9 +4710,10 @@
                 {
                     "alias": "timespan_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4664,9 +4759,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4689,9 +4785,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4760,9 +4857,10 @@
                 {
                     "alias": "timespan_type",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4831,9 +4929,10 @@
                 {
                     "alias": "timespan_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4938,9 +5037,10 @@
                 {
                     "alias": "timespan_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5009,9 +5109,10 @@
                 {
                     "alias": "timespan_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5165,9 +5266,10 @@
                 {
                     "alias": "timespan_duration_type",
                     "config": {
-                        "rdmCollection": "5f3c2407-2e22-4022-9795-2f3ef963d5aa"
+                        "controlledList": "5f3c2407-2e22-4022-9795-2f3ef963d5aa",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5213,9 +5315,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5295,9 +5398,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "f44f7240-35c5-49e8-a0e3-2ffe308f0862"
+                        "controlledList": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5368,9 +5472,10 @@
                 {
                     "alias": "name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5393,9 +5498,10 @@
                 {
                     "alias": "timespan_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5464,10 +5570,10 @@
                 {
                     "alias": "statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5559,9 +5665,10 @@
                 {
                     "alias": "name_type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5634,9 +5741,10 @@
                 {
                     "alias": "timespan_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5682,10 +5790,10 @@
                 {
                     "alias": "timespan_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5824,9 +5932,10 @@
                 {
                     "alias": "timespan_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5910,9 +6019,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6067,9 +6177,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6252,9 +6363,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6400,9 +6512,9 @@
             "publication": {
                 "graph_id": "0b9235d9-ca85-11e9-9fa2-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "554ecfbb-3817-11f0-b814-020539808477",
-                "published_time": "2025-05-23T13:48:51.513"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "32e97a68-965a-4836-b6e6-da87656360db",
+                "published_time": "2026-02-06T12:58:43.765"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Provenance Activity.json
+++ b/arches_for_science/pkg/graphs/resource_models/Provenance Activity.json
@@ -16,13 +16,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Duration of Timespan of Promise Event"
@@ -45,13 +45,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration of Timespan of Promise Event"
@@ -74,13 +74,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan"
@@ -103,13 +103,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement about Timespan of Promise Event"
@@ -132,13 +132,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about Timespan of Promise Event"
@@ -161,13 +161,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -190,10 +190,10 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
                         "en": "Provide the name(s) of a person(s) or group(s) responsible for carrying out the transfer of ownership (organization; gallery, agent) if applicable."
@@ -219,13 +219,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier"
@@ -248,13 +248,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -277,13 +277,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -306,13 +306,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -333,13 +333,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Digital Reference to Provenance Activity"
@@ -362,10 +362,10 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
                         "en": "Formal agreement of an upcoming transfer/movement/custody arrangement for a physical thing such as a work of art or instrument."
@@ -391,13 +391,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier for Transfer of Custody Event"
@@ -420,13 +420,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Acquisition Event"
@@ -449,13 +449,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -478,13 +478,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement about Transfer of Custody Event"
@@ -507,13 +507,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -536,13 +536,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier for Acquisition Event"
@@ -565,13 +565,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Duration of TimeSpan"
@@ -594,13 +594,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration"
@@ -623,13 +623,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Time Span of Provenance Event"
@@ -652,13 +652,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement about Timespan"
@@ -681,13 +681,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about Timespan"
@@ -710,13 +710,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -739,10 +739,10 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
                         "en": "Enter any identifiers (project numbers, barcodes, etc.) that refer specifically to the provenance event, if any."
@@ -768,10 +768,10 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
                         "en": "Enter the name of an individual provenance event (e.g. purchase, exhibtion, sales event, history, change of instrument location, etc). This can apply to any physical thing (work of art or instrument)."
@@ -797,13 +797,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Statement about Provenance Activity"
@@ -826,13 +826,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about provenance event"
@@ -855,10 +855,10 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
                         "en": "Provide the name(s) of a person(s) or group(s) responsible for carrying out the transfer of custody (organization; gallery, agent) if applicable."
@@ -884,13 +884,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Duration of Timespan of Transfer of Custody Event"
@@ -913,13 +913,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration of Timespan of Transfer of Custody Event"
@@ -942,13 +942,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Timespan of Transfer of Custody Event"
@@ -971,13 +971,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Statement about Timespan of Transfer of Custody Event"
@@ -1000,13 +1000,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about Timespan of Transfer of Custody Event"
@@ -1029,13 +1029,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Timespan of Transfer of Custody Event"
@@ -1058,13 +1058,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Type of Provenance Activity"
@@ -1087,13 +1087,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement about Acquisition Event"
@@ -1116,13 +1116,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -1145,13 +1145,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Internal Label for Provenance Activity"
@@ -1174,13 +1174,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Payment for Provenance Activity"
@@ -1203,13 +1203,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Paid Amount"
@@ -1232,13 +1232,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Location of Provenance Event"
@@ -1261,13 +1261,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Duration of TimeSpan of Move Event"
@@ -1290,13 +1290,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration"
@@ -1319,13 +1319,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan"
@@ -1348,13 +1348,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Statement"
@@ -1377,13 +1377,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about TimeSpan of Move Event"
@@ -1406,13 +1406,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -1435,13 +1435,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Person involved in Provenance Event"
@@ -1464,13 +1464,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "During Period"
@@ -1493,13 +1493,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier for Move Event"
@@ -1522,13 +1522,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier for Promise Event"
@@ -1551,13 +1551,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Reference in Source Material"
@@ -1580,13 +1580,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Parent Activity"
@@ -1609,13 +1609,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Promise Event"
@@ -1638,13 +1638,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -1667,13 +1667,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about Promise Event"
@@ -1696,13 +1696,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Location change or movement"
@@ -1725,13 +1725,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -1754,13 +1754,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement about Move Event"
@@ -1783,13 +1783,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -1812,13 +1812,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -1841,13 +1841,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration"
@@ -1870,13 +1870,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan"
@@ -1899,13 +1899,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Statement"
@@ -1928,13 +1928,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -1957,13 +1957,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -1986,13 +1986,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Duration of TimeSpan of Payment Event"
@@ -2015,13 +2015,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration"
@@ -2044,13 +2044,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan"
@@ -2073,13 +2073,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Statement"
@@ -2102,13 +2102,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement"
@@ -2131,13 +2131,13 @@
                     "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name"
@@ -2226,14 +2226,11 @@
                 {
                     "card_id": "0adac232-073d-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2246,19 +2243,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adac232-073d-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2271,7 +2293,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adac232-073d-11ea-aac2-acde48001122",
@@ -2353,7 +2375,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2366,7 +2387,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adaca70-073d-11ea-aac2-acde48001122",
@@ -2444,14 +2465,37 @@
                     "card_id": "0adad3b2-073d-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2464,7 +2508,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adad3b2-073d-11ea-aac2-acde48001122",
@@ -2530,13 +2574,38 @@
                     "card_id": "0adad3b2-073d-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2549,7 +2618,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adad3b2-073d-11ea-aac2-acde48001122",
@@ -2744,7 +2813,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2757,7 +2825,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adac818-073d-11ea-aac2-acde48001122",
@@ -2767,7 +2835,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2780,7 +2847,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adad718-073d-11ea-aac2-acde48001122",
@@ -2816,13 +2883,38 @@
                     "card_id": "0adad718-073d-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2835,19 +2927,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adad718-073d-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2860,7 +2949,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adad718-073d-11ea-aac2-acde48001122",
@@ -2940,13 +3029,38 @@
                     "card_id": "0adacd22-073d-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2959,7 +3073,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0adacd22-073d-11ea-aac2-acde48001122",
@@ -3024,14 +3138,11 @@
                 {
                     "card_id": "0adacd22-073d-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3044,7 +3155,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0dd3531a-07c8-11ea-aac2-acde48001122",
@@ -3114,7 +3225,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Identifier",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3127,7 +3237,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0dd3531a-07c8-11ea-aac2-acde48001122",
@@ -3159,7 +3269,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3172,7 +3281,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "108596fe-07c8-11ea-aac2-acde48001122",
@@ -3200,13 +3309,38 @@
                     "card_id": "108596fe-07c8-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3219,7 +3353,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "108596fe-07c8-11ea-aac2-acde48001122",
@@ -3345,13 +3479,38 @@
                     "card_id": "1321a6c8-07c8-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3364,19 +3523,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1321a6c8-07c8-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3389,7 +3545,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1321a6c8-07c8-11ea-aac2-acde48001122",
@@ -3447,13 +3603,24 @@
                     "card_id": "1321a90c-07c8-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3466,7 +3633,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1321a90c-07c8-11ea-aac2-acde48001122",
@@ -3524,13 +3691,38 @@
                     "card_id": "1321a90c-07c8-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3543,7 +3735,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1d3466fa-8e31-11eb-a9c4-faffc265b501",
@@ -3575,7 +3767,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3588,7 +3779,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c1fa037a-066f-11ea-b592-acde48001122",
@@ -3756,7 +3947,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3769,7 +3959,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6030c488-066c-11ea-b592-acde48001122",
@@ -4007,7 +4197,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Custody Transfer",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4020,7 +4209,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0c9080a0-066e-11ea-b592-acde48001122",
@@ -4184,7 +4373,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Acquisition",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4197,7 +4385,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0c9080a0-066e-11ea-b592-acde48001122",
@@ -4487,7 +4675,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Payment",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4500,7 +4687,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "870424ea-066e-11ea-b592-acde48001122",
@@ -4592,7 +4779,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4605,7 +4791,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "4bde466e-07c9-11ea-aac2-acde48001122",
@@ -4637,7 +4823,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4650,7 +4835,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5112ff5a-07c7-11ea-aac2-acde48001122",
@@ -4678,13 +4863,38 @@
                     "card_id": "5112ff5a-07c7-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4697,7 +4907,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5112ff5a-07c7-11ea-aac2-acde48001122",
@@ -4767,7 +4977,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4780,7 +4989,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "55432ff2-07d4-11ea-aac2-acde48001122",
@@ -4808,13 +5017,38 @@
                     "card_id": "55432ff2-07d4-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4827,7 +5061,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "55432ff2-07d4-11ea-aac2-acde48001122",
@@ -4953,13 +5187,38 @@
                     "card_id": "5821f3d4-07d4-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4972,19 +5231,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5821f3d4-07d4-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4997,7 +5253,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5821f3d4-07d4-11ea-aac2-acde48001122",
@@ -5055,13 +5311,24 @@
                     "card_id": "5821f636-07d4-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5074,7 +5341,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5821f636-07d4-11ea-aac2-acde48001122",
@@ -5132,13 +5399,38 @@
                     "card_id": "5821f636-07d4-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5151,7 +5443,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "590629ea-07c6-11ea-aac2-acde48001122",
@@ -5221,7 +5513,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5234,7 +5525,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "590629ea-07c6-11ea-aac2-acde48001122",
@@ -5340,7 +5631,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Move",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5353,7 +5643,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d8e79c9a-0670-11ea-b592-acde48001122",
@@ -5555,7 +5845,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Identifier",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5568,7 +5857,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5d93db48-066c-11ea-b592-acde48001122",
@@ -5600,7 +5889,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5613,7 +5901,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5e831b90-066c-11ea-b592-acde48001122",
@@ -5641,13 +5929,38 @@
                     "card_id": "5e831b90-066c-11ea-b592-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5660,7 +5973,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5e831b90-066c-11ea-b592-acde48001122",
@@ -5786,13 +6099,38 @@
                     "card_id": "5f28eafc-066c-11ea-b592-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5805,19 +6143,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5f28eafc-066c-11ea-b592-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5830,7 +6165,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5f28eafc-066c-11ea-b592-acde48001122",
@@ -5888,13 +6223,24 @@
                     "card_id": "5f28ed4a-066c-11ea-b592-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "7d08d556-b831-4a7b-8a47-2068db0db6e6",
+                                        "language_id": "en",
+                                        "list_item_id": "b441941d-8d0d-4db3-9a99-cd28886d500a",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5907,7 +6253,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5f28ed4a-066c-11ea-b592-acde48001122",
@@ -5965,13 +6311,38 @@
                     "card_id": "5f28ed4a-066c-11ea-b592-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5984,7 +6355,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "612547bc-073c-11ea-aac2-acde48001122",
@@ -6041,14 +6412,11 @@
                 {
                     "card_id": "612547bc-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6061,19 +6429,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "612547bc-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6086,7 +6479,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "612547bc-073c-11ea-aac2-acde48001122",
@@ -6168,7 +6561,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6181,7 +6573,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "61254cf8-073c-11ea-aac2-acde48001122",
@@ -6259,14 +6651,37 @@
                     "card_id": "61255194-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6279,7 +6694,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "61255194-073c-11ea-aac2-acde48001122",
@@ -6345,13 +6760,38 @@
                     "card_id": "61255194-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6364,7 +6804,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "61255194-073c-11ea-aac2-acde48001122",
@@ -6559,7 +6999,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6572,7 +7011,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "61254ac8-073c-11ea-aac2-acde48001122",
@@ -6582,7 +7021,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Duration",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6595,7 +7033,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "61255400-073c-11ea-aac2-acde48001122",
@@ -6631,13 +7069,38 @@
                     "card_id": "61255400-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6650,19 +7113,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "61255400-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6675,7 +7135,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "61255400-073c-11ea-aac2-acde48001122",
@@ -6755,13 +7215,38 @@
                     "card_id": "61254fa0-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6774,7 +7259,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "61254fa0-073c-11ea-aac2-acde48001122",
@@ -6839,14 +7324,11 @@
                 {
                     "card_id": "61254fa0-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6859,7 +7341,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c401608-066c-11ea-b592-acde48001122",
@@ -6895,13 +7377,38 @@
                     "card_id": "5c401608-066c-11ea-b592-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6914,19 +7421,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c401608-066c-11ea-b592-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6939,7 +7443,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c401608-066c-11ea-b592-acde48001122",
@@ -7131,13 +7635,38 @@
                     "card_id": "73763a54-07c6-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7150,19 +7679,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "73763a54-07c6-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7175,7 +7701,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "73763a54-07c6-11ea-aac2-acde48001122",
@@ -7233,13 +7759,24 @@
                     "card_id": "73763d24-07c6-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7252,7 +7789,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "73763d24-07c6-11ea-aac2-acde48001122",
@@ -7310,13 +7847,38 @@
                     "card_id": "73763d24-07c6-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7329,7 +7891,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "43de4156-0735-11ea-aac2-acde48001122",
@@ -7405,7 +7967,6 @@
                             "placeholder"
                         ],
                         "label": "Promise Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7418,7 +7979,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "43de4156-0735-11ea-aac2-acde48001122",
@@ -7450,7 +8011,6 @@
                             "placeholder"
                         ],
                         "label": "Currency",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7463,7 +8023,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "87042ff8-066e-11ea-b592-acde48001122",
@@ -7577,7 +8137,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Monetary Amount",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7590,7 +8149,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "87042ff8-066e-11ea-b592-acde48001122",
@@ -7706,14 +8265,11 @@
                 {
                     "card_id": "8d09888e-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7726,19 +8282,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d09888e-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7751,7 +8332,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d09888e-073c-11ea-aac2-acde48001122",
@@ -7833,7 +8414,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7846,7 +8426,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d098d84-073c-11ea-aac2-acde48001122",
@@ -7924,14 +8504,37 @@
                     "card_id": "8d0991ee-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -7944,7 +8547,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d0991ee-073c-11ea-aac2-acde48001122",
@@ -8010,13 +8613,38 @@
                     "card_id": "8d0991ee-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8029,7 +8657,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d0991ee-073c-11ea-aac2-acde48001122",
@@ -8224,7 +8852,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8237,7 +8864,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d098b68-073c-11ea-aac2-acde48001122",
@@ -8247,7 +8874,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Duration",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8260,7 +8886,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d09943c-073c-11ea-aac2-acde48001122",
@@ -8296,13 +8922,38 @@
                     "card_id": "8d09943c-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8315,19 +8966,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d09943c-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8340,7 +8988,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d09943c-073c-11ea-aac2-acde48001122",
@@ -8420,13 +9068,38 @@
                     "card_id": "8d099004-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8439,7 +9112,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8d099004-073c-11ea-aac2-acde48001122",
@@ -8504,14 +9177,11 @@
                 {
                     "card_id": "8d099004-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8524,7 +9194,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c400d02-066c-11ea-b592-acde48001122",
@@ -8608,7 +9278,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Duration",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8621,7 +9290,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c400d02-066c-11ea-b592-acde48001122",
@@ -8668,7 +9337,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8681,7 +9349,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c400d02-066c-11ea-b592-acde48001122",
@@ -8803,7 +9471,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8816,7 +9483,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "a7f8efca-07d4-11ea-aac2-acde48001122",
@@ -8908,7 +9575,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -8921,7 +9587,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "afccf2e0-07d5-11ea-aac2-acde48001122",
@@ -9030,14 +9696,11 @@
                 {
                     "card_id": "5c400a28-066c-11ea-b592-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9050,19 +9713,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c400a28-066c-11ea-b592-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9075,7 +9763,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c4011bc-066c-11ea-b592-acde48001122",
@@ -9137,7 +9825,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9150,7 +9837,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c4011bc-066c-11ea-b592-acde48001122",
@@ -9160,7 +9847,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9173,7 +9859,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c4011bc-066c-11ea-b592-acde48001122",
@@ -9265,7 +9951,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9278,7 +9963,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c4013a6-066c-11ea-b592-acde48001122",
@@ -9288,7 +9973,6 @@
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9301,7 +9985,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5c4013a6-066c-11ea-b592-acde48001122",
@@ -9341,7 +10025,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9354,7 +10037,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d13e2cd2-07d5-11ea-aac2-acde48001122",
@@ -9382,13 +10065,38 @@
                     "card_id": "d13e2cd2-07d5-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9401,7 +10109,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d13e2cd2-07d5-11ea-aac2-acde48001122",
@@ -9527,13 +10235,38 @@
                     "card_id": "d40c2874-07d5-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9546,19 +10279,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d40c2874-07d5-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9571,7 +10301,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d40c2874-07d5-11ea-aac2-acde48001122",
@@ -9629,13 +10359,24 @@
                     "card_id": "d40c2ac2-07d5-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9648,7 +10389,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d40c2ac2-07d5-11ea-aac2-acde48001122",
@@ -9706,13 +10447,38 @@
                     "card_id": "d40c2ac2-07d5-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9725,7 +10491,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "da43736a-07d4-11ea-aac2-acde48001122",
@@ -9735,7 +10501,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9748,7 +10513,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "da43736a-07d4-11ea-aac2-acde48001122",
@@ -9776,13 +10541,38 @@
                     "card_id": "da43736a-07d4-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9795,7 +10585,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "da43736a-07d4-11ea-aac2-acde48001122",
@@ -9921,13 +10711,38 @@
                     "card_id": "dd4a5b96-07d4-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9940,19 +10755,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "dd4a5b96-07d4-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -9965,7 +10777,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "dd4a5b96-07d4-11ea-aac2-acde48001122",
@@ -10023,13 +10835,24 @@
                     "card_id": "dd4a5df8-07d4-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10042,7 +10865,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "dd4a5df8-07d4-11ea-aac2-acde48001122",
@@ -10100,13 +10923,38 @@
                     "card_id": "dd4a5df8-07d4-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10119,7 +10967,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df561a8a-073c-11ea-aac2-acde48001122",
@@ -10176,14 +11024,11 @@
                 {
                     "card_id": "df561a8a-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10196,19 +11041,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df561a8a-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10221,7 +11091,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df561a8a-073c-11ea-aac2-acde48001122",
@@ -10303,7 +11173,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10316,7 +11185,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df561f9e-073c-11ea-aac2-acde48001122",
@@ -10394,14 +11263,37 @@
                     "card_id": "df562426-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10414,7 +11306,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df562426-073c-11ea-aac2-acde48001122",
@@ -10480,13 +11372,38 @@
                     "card_id": "df562426-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10499,7 +11416,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df562426-073c-11ea-aac2-acde48001122",
@@ -10694,7 +11611,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10707,7 +11623,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df561d78-073c-11ea-aac2-acde48001122",
@@ -10717,7 +11633,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Duration",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10730,7 +11645,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df562692-073c-11ea-aac2-acde48001122",
@@ -10766,13 +11681,38 @@
                     "card_id": "df562692-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10785,19 +11725,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df562692-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10810,7 +11747,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df562692-073c-11ea-aac2-acde48001122",
@@ -10890,13 +11827,38 @@
                     "card_id": "df562232-073c-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10909,7 +11871,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "df562232-073c-11ea-aac2-acde48001122",
@@ -10974,14 +11936,11 @@
                 {
                     "card_id": "df562232-073c-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -10994,7 +11953,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bda6faac-0670-11ea-b592-acde48001122",
@@ -11073,14 +12032,11 @@
                 {
                     "card_id": "e373a836-07c7-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11093,19 +12049,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373a836-07c7-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11118,7 +12099,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373a836-07c7-11ea-aac2-acde48001122",
@@ -11200,7 +12181,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11213,7 +12193,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373ad2c-07c7-11ea-aac2-acde48001122",
@@ -11291,14 +12271,37 @@
                     "card_id": "e373b1a0-07c7-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11311,7 +12314,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373b1a0-07c7-11ea-aac2-acde48001122",
@@ -11377,13 +12380,38 @@
                     "card_id": "e373b1a0-07c7-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11396,7 +12424,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373b1a0-07c7-11ea-aac2-acde48001122",
@@ -11591,7 +12619,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11604,7 +12631,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373ab1a-07c7-11ea-aac2-acde48001122",
@@ -11614,7 +12641,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Duration",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11627,7 +12653,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373b3f8-07c7-11ea-aac2-acde48001122",
@@ -11663,13 +12689,38 @@
                     "card_id": "e373b3f8-07c7-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11682,19 +12733,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373b3f8-07c7-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11707,7 +12755,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373b3f8-07c7-11ea-aac2-acde48001122",
@@ -11787,13 +12835,38 @@
                     "card_id": "e373afb6-07c7-11ea-aac2-acde48001122",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11806,7 +12879,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e373afb6-07c7-11ea-aac2-acde48001122",
@@ -11871,14 +12944,11 @@
                 {
                     "card_id": "e373afb6-07c7-11ea-aac2-acde48001122",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11891,7 +12961,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "7e98f348-066f-11ea-b592-acde48001122",
@@ -11931,7 +13001,6 @@
                             "placeholder"
                         ],
                         "label": "Classification",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -11944,7 +13013,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": null,
@@ -17230,9 +18299,10 @@
                 {
                     "alias": "type_n6",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17323,9 +18393,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17407,9 +18478,10 @@
                 {
                     "alias": "type_n44",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17432,9 +18504,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17480,9 +18553,10 @@
                 {
                     "alias": "language_n41",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17656,9 +18730,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17681,9 +18756,10 @@
                 {
                     "alias": "unit_n3",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17740,9 +18816,10 @@
                 {
                     "alias": "language_n40",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17811,9 +18888,10 @@
                 {
                     "alias": "language_n39",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17836,10 +18914,10 @@
                 {
                     "alias": "language_n38",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -17910,9 +18988,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18267,9 +19346,10 @@
                 {
                     "alias": "type_n5",
                     "config": {
-                        "rdmCollection": "f3eca78c-7547-4ca5-a7eb-b130391b40ed"
+                        "controlledList": "f3eca78c-7547-4ca5-a7eb-b130391b40ed",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18365,9 +19445,10 @@
                 {
                     "alias": "type_n7",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18470,9 +19551,10 @@
                 {
                     "alias": "type_n8",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18529,9 +19611,10 @@
                 {
                     "alias": "language_n37",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18669,9 +19752,10 @@
                 {
                     "alias": "type_n9",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18717,9 +19801,10 @@
                 {
                     "alias": "language_n36",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18742,9 +19827,10 @@
                 {
                     "alias": "type_n10",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18801,10 +19887,10 @@
                 {
                     "alias": "language_n35",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -18964,9 +20050,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -19336,9 +20423,10 @@
                 {
                     "alias": "type_n11",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19434,9 +20522,10 @@
                 {
                     "alias": "type_n12",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19539,9 +20628,10 @@
                 {
                     "alias": "type_n14",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19598,9 +20688,10 @@
                 {
                     "alias": "language_n34",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19692,9 +20783,10 @@
                 {
                     "alias": "type_n15",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19751,9 +20843,10 @@
                 {
                     "alias": "language_n33",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19891,9 +20984,10 @@
                 {
                     "alias": "type_n17",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19939,9 +21033,10 @@
                 {
                     "alias": "language_n32",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -19964,9 +21059,10 @@
                 {
                     "alias": "type_n21",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20023,10 +21119,10 @@
                 {
                     "alias": "language_n31",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20175,9 +21271,10 @@
                 {
                     "alias": "type_n24",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20418,9 +21515,10 @@
                 {
                     "alias": "type_n26",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20511,9 +21609,10 @@
                 {
                     "alias": "type_n27",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20595,9 +21694,10 @@
                 {
                     "alias": "type_n31",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20620,9 +21720,10 @@
                 {
                     "alias": "type_n32",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20668,9 +21769,10 @@
                 {
                     "alias": "language_n30",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20844,9 +21946,10 @@
                 {
                     "alias": "type_n38",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20869,9 +21972,10 @@
                 {
                     "alias": "unit_n1",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20928,9 +22032,10 @@
                 {
                     "alias": "language_n29",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -20999,9 +22104,10 @@
                 {
                     "alias": "language_n28",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21024,10 +22130,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21098,9 +22204,10 @@
                 {
                     "alias": "type_n41",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21286,9 +22393,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21391,9 +22499,10 @@
                 {
                     "alias": "type_n45",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21450,9 +22559,10 @@
                 {
                     "alias": "language_n27",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21590,9 +22700,10 @@
                 {
                     "alias": "type_n48",
                     "config": {
-                        "rdmCollection": "f44f7240-35c5-49e8-a0e3-2ffe308f0862"
+                        "controlledList": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21638,9 +22749,10 @@
                 {
                     "alias": "language_n26",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21663,9 +22775,10 @@
                 {
                     "alias": "type_n49",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -21722,10 +22835,10 @@
                 {
                     "alias": "language_n25",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22043,9 +23156,10 @@
                 {
                     "alias": "type_n54",
                     "config": {
-                        "rdmCollection": "83dd1837-e399-469f-a073-cd76edff810c"
+                        "controlledList": "83dd1837-e399-469f-a073-cd76edff810c",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22256,9 +23370,10 @@
                 {
                     "alias": "type_n56",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22349,9 +23464,10 @@
                 {
                     "alias": "type_n57",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22433,9 +23549,10 @@
                 {
                     "alias": "type_n60",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22458,9 +23575,10 @@
                 {
                     "alias": "type_n63",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22506,9 +23624,10 @@
                 {
                     "alias": "language_n24",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22682,9 +23801,10 @@
                 {
                     "alias": "type_n65",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22707,9 +23827,10 @@
                 {
                     "alias": "unit_n2",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22766,9 +23887,10 @@
                 {
                     "alias": "language_n23",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22837,9 +23959,10 @@
                 {
                     "alias": "language_n22",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22862,10 +23985,10 @@
                 {
                     "alias": "language_n21",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -22936,9 +24059,10 @@
                 {
                     "alias": "type_n64",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23118,9 +24242,10 @@
                 {
                     "alias": "classification",
                     "config": {
-                        "rdmCollection": "5f7df45b-31ae-44ce-a8cc-55ccdafa019d"
+                        "controlledList": "5f7df45b-31ae-44ce-a8cc-55ccdafa019d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23212,9 +24337,10 @@
                 {
                     "alias": "type_n62",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23260,9 +24386,10 @@
                 {
                     "alias": "language_n20",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23285,9 +24412,10 @@
                 {
                     "alias": "type_n61",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23344,10 +24472,10 @@
                 {
                     "alias": "language_n19",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23576,9 +24704,10 @@
                 {
                     "alias": "type_n58",
                     "config": {
-                        "rdmCollection": "696fd77f-0181-4d00-9372-b395b2fde9b3"
+                        "controlledList": "696fd77f-0181-4d00-9372-b395b2fde9b3",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications  Types of monetary amounts might include different prices - the asking price, the final price, the estimated price.\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23889,9 +25018,10 @@
                 {
                     "alias": "currency",
                     "config": {
-                        "rdmCollection": "9fe65e48-540c-4401-836d-947eb1878677"
+                        "controlledList": "9fe65e48-540c-4401-836d-947eb1878677",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe currency of the monetary amount. For example, if the amount represents 120 US dollars, then the currency would a concept that identifies US dollars.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -23914,9 +25044,10 @@
                 {
                     "alias": "type_n55",
                     "config": {
-                        "rdmCollection": "02dc399d-9c8c-406d-a4bf-56817eb03449"
+                        "controlledList": "02dc399d-9c8c-406d-a4bf-56817eb03449",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24201,9 +25332,10 @@
                 {
                     "alias": "type_n59",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24294,9 +25426,10 @@
                 {
                     "alias": "type_n53",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24378,9 +25511,10 @@
                 {
                     "alias": "type_n52",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24403,9 +25537,10 @@
                 {
                     "alias": "type_n51",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24451,9 +25586,10 @@
                 {
                     "alias": "language_n18",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24627,9 +25763,10 @@
                 {
                     "alias": "type_n50",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24652,9 +25789,10 @@
                 {
                     "alias": "unit_n4",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24711,9 +25849,10 @@
                 {
                     "alias": "language_n17",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24782,9 +25921,10 @@
                 {
                     "alias": "language_n16",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24807,10 +25947,10 @@
                 {
                     "alias": "language_n15",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -24881,9 +26021,10 @@
                 {
                     "alias": "type_n47",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25143,9 +26284,10 @@
                 {
                     "alias": "type_n46",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25271,9 +26413,10 @@
                 {
                     "alias": "type_n43",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25437,9 +26580,10 @@
                 {
                     "alias": "type_n42",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25496,9 +26640,10 @@
                 {
                     "alias": "language_n14",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25636,9 +26781,10 @@
                 {
                     "alias": "type_n40",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25684,9 +26830,10 @@
                 {
                     "alias": "language_n13",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25709,9 +26856,10 @@
                 {
                     "alias": "type_n39",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -25768,10 +26916,10 @@
                 {
                     "alias": "language_n12",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26055,9 +27203,10 @@
                 {
                     "alias": "type_n37",
                     "config": {
-                        "rdmCollection": "4a4050e9-00a8-42f5-9c7e-cf754060cd95"
+                        "controlledList": "4a4050e9-00a8-42f5-9c7e-cf754060cd95",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26130,9 +27279,10 @@
                 {
                     "alias": "type_n36",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26189,9 +27339,10 @@
                 {
                     "alias": "language_n11",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26329,9 +27480,10 @@
                 {
                     "alias": "type_n35",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26377,9 +27529,10 @@
                 {
                     "alias": "language_n10",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26402,9 +27555,10 @@
                 {
                     "alias": "type_n34",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26461,10 +27615,10 @@
                 {
                     "alias": "language_n9",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26728,9 +27882,10 @@
                 {
                     "alias": "type_n33",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26821,9 +27976,10 @@
                 {
                     "alias": "type_n30",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26905,9 +28061,10 @@
                 {
                     "alias": "type_n29",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26930,9 +28087,10 @@
                 {
                     "alias": "type_n28",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -26978,9 +28136,10 @@
                 {
                     "alias": "language_n8",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27154,9 +28313,10 @@
                 {
                     "alias": "type_n25",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27179,9 +28339,10 @@
                 {
                     "alias": "unit_n5",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27238,9 +28399,10 @@
                 {
                     "alias": "language_n7",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27309,9 +28471,10 @@
                 {
                     "alias": "language_n6",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27334,10 +28497,10 @@
                 {
                     "alias": "language_n5",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27408,9 +28571,10 @@
                 {
                     "alias": "type_n23",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27745,9 +28909,10 @@
                 {
                     "alias": "type_n22",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27838,9 +29003,10 @@
                 {
                     "alias": "type_n20",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27922,9 +29088,10 @@
                 {
                     "alias": "type_n19",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27947,9 +29114,10 @@
                 {
                     "alias": "type_n18",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -27995,9 +29163,10 @@
                 {
                     "alias": "language_n4",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28171,9 +29340,10 @@
                 {
                     "alias": "type_n16",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28196,9 +29366,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28255,9 +29426,10 @@
                 {
                     "alias": "language_n3",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28326,9 +29498,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28351,10 +29524,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28425,9 +29598,10 @@
                 {
                     "alias": "type_n13",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -28640,7 +29814,13 @@
                 }
             ],
             "ontology_id": "0b1f5462-faa7-11e9-8f09-3af9d3b32b71",
-            "publication": null,
+            "publication": {
+                "graph_id": "31e6b222-066c-11ea-b592-acde48001122",
+                "most_recent_edit_id": null,
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "bb487bec-fcea-4f53-a59a-42706f783411",
+                "published_time": "2026-02-06T13:00:05.354"
+            },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],
             "resource_instance_lifecycle": {

--- a/arches_for_science/pkg/graphs/resource_models/Sampling Activity.json
+++ b/arches_for_science/pkg/graphs/resource_models/Sampling Activity.json
@@ -834,13 +834,38 @@
                     "card_id": "03357887-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -853,19 +878,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357887-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -878,7 +900,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357887-1d9d-11eb-a29f-024e0d439fdb",
@@ -1026,14 +1048,37 @@
                     "card_id": "0335786f-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "88a56018-92f7-44d7-ba05-2eb19bcb9824",
+                                        "language_id": "en",
+                                        "list_item_id": "391818d1-5d43-4499-a007-7732969caadb",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "69abe4f9-f16f-47bf-8fdf-ccce67a18e5d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "b6aa61b6-5954-4f01-906c-a805b2bef198",
+                                        "language_id": "en",
+                                        "list_item_id": "2e45a071-47d0-4d6b-ba9d-9add9475a6d6",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "69abe4f9-f16f-47bf-8fdf-ccce67a18e5d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select one or more types for this Statement"
                         }
@@ -1046,19 +1091,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0335786f-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select one or more languages of the content"
                         }
@@ -1071,7 +1141,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0335786f-1d9d-11eb-a29f-024e0d439fdb",
@@ -1111,7 +1181,6 @@
                             "placeholder"
                         ],
                         "label": "Sampling Activity Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1124,7 +1193,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0335784e-1d9d-11eb-a29f-024e0d439fdb",
@@ -1230,7 +1299,6 @@
                             "placeholder"
                         ],
                         "label": "Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1243,7 +1311,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357857-1d9d-11eb-a29f-024e0d439fdb",
@@ -1283,7 +1351,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Statement",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1296,7 +1363,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357869-1d9d-11eb-a29f-024e0d439fdb",
@@ -1332,13 +1399,38 @@
                     "card_id": "03357869-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select one or more language"
                         }
@@ -1351,7 +1443,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357869-1d9d-11eb-a29f-024e0d439fdb",
@@ -1378,14 +1470,11 @@
                 {
                     "card_id": "03357869-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select a type for this name"
                         }
@@ -1398,7 +1487,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357869-1d9d-11eb-a29f-024e0d439fdb",
@@ -1497,7 +1586,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1510,7 +1598,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357884-1d9d-11eb-a29f-024e0d439fdb",
@@ -1520,7 +1608,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1533,7 +1620,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357884-1d9d-11eb-a29f-024e0d439fdb",
@@ -1669,7 +1756,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1682,7 +1768,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357860-1d9d-11eb-a29f-024e0d439fdb",
@@ -1753,7 +1839,7 @@
                         ],
                         "label": "Location of Sampling Activity",
                         "placeholder": {
-                            "en": null
+                            "en": ""
                         }
                     },
                     "id": "033578e8-1d9d-11eb-a29f-024e0d439fdb",
@@ -1774,7 +1860,6 @@
                             "placeholder"
                         ],
                         "label": "Type of Timespan",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1787,7 +1872,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357854-1d9d-11eb-a29f-024e0d439fdb",
@@ -1907,13 +1992,38 @@
                     "card_id": "03357875-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select one or more languages of the content"
                         }
@@ -1926,7 +2036,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "03357875-1d9d-11eb-a29f-024e0d439fdb",
@@ -2014,30 +2124,24 @@
                     "card_id": "03357875-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name type",
-                        "options": [
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "f4643b7d-2710-4aca-8892-c0eeed02dfe9",
-                                "id": "0798bf2c-ab07-43d7-81f4-f1e2d20251a1",
-                                "sortorder": "",
-                                "text": "alternate titles"
-                            },
-                            {
-                                "children": [],
-                                "collector": "",
-                                "conceptid": "18610abd-e0e5-48bb-9a7a-3830d75755d0",
-                                "id": "7d069762-bd96-44b8-afc8-4761389105c5",
-                                "sortorder": "",
-                                "text": "primary title"
-                            }
-                        ],
                         "placeholder": {
                             "en": "Select one or more types for this name"
                         },
@@ -2051,7 +2155,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000013"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0335786c-1d9d-11eb-a29f-024e0d439fdb",
@@ -2084,7 +2188,7 @@
                         ],
                         "label": "Instrument used in Sampling Activity",
                         "placeholder": {
-                            "en": null
+                            "en": ""
                         }
                     },
                     "id": "033578f7-1d9d-11eb-a29f-024e0d439fdb",
@@ -2123,13 +2227,38 @@
                     "card_id": "0335788a-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2142,7 +2271,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0335788a-1d9d-11eb-a29f-024e0d439fdb",
@@ -2177,14 +2306,11 @@
                 {
                     "card_id": "0335788a-1d9d-11eb-a29f-024e0d439fdb",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2197,7 +2323,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0335788a-1d9d-11eb-a29f-024e0d439fdb",
@@ -2237,7 +2363,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2250,7 +2375,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0335785a-1d9d-11eb-a29f-024e0d439fdb",
@@ -2312,7 +2437,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2325,7 +2449,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0335785a-1d9d-11eb-a29f-024e0d439fdb",
@@ -2366,7 +2490,7 @@
                         ],
                         "label": "Influence on Sampling Activity",
                         "placeholder": {
-                            "en": null
+                            "en": ""
                         }
                     },
                     "id": "03357902-1d9d-11eb-a29f-024e0d439fdb",
@@ -2387,7 +2511,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2400,7 +2523,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "fec2d45c-1da0-11eb-a29f-024e0d439fdb",
@@ -2411,7 +2534,7 @@
                         ],
                         "label": "Sampling Procedure",
                         "placeholder": {
-                            "en": null
+                            "en": ""
                         }
                     },
                     "id": "2155396a-1da1-11eb-a29f-024e0d439fdb",
@@ -2454,7 +2577,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2467,7 +2589,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "985a7550-1d9e-11eb-a29f-024e0d439fdb",
@@ -2477,7 +2599,6 @@
                             "placeholder"
                         ],
                         "label": "Sampling Activity Tool Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2490,7 +2611,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b1125005-911a-11ec-a428-ad03e9261309",
@@ -2522,7 +2643,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2535,7 +2655,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b3e171a9-1d9d-11eb-a29f-024e0d439fdb",
@@ -2585,7 +2705,7 @@
                         ],
                         "label": "Sampled Area Name",
                         "placeholder": {
-                            "en": null
+                            "en": ""
                         }
                     },
                     "id": "b3e171b1-1d9d-11eb-a29f-024e0d439fdb",
@@ -2714,7 +2834,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2727,7 +2846,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "c470c54b-911a-11ec-a428-ad03e9261309",
@@ -4627,9 +4746,10 @@
                 {
                     "alias": "technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4813,9 +4933,10 @@
                 {
                     "alias": "timespan_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4909,9 +5030,10 @@
                 {
                     "alias": "timespan_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4934,9 +5056,10 @@
                 {
                     "alias": "timespan_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4982,9 +5105,10 @@
                 {
                     "alias": "name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5030,10 +5154,10 @@
                 {
                     "alias": "statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5173,9 +5297,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5223,9 +5348,10 @@
                 {
                     "alias": "timespan_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5319,9 +5445,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5378,9 +5505,10 @@
                 {
                     "alias": "timespan_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5588,9 +5716,10 @@
                 {
                     "alias": "timespan_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5659,9 +5788,10 @@
                 {
                     "alias": "timespan_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5684,9 +5814,10 @@
                 {
                     "alias": "timespan_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5709,9 +5840,10 @@
                 {
                     "alias": "timespan_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5734,9 +5866,10 @@
                 {
                     "alias": "name_type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5782,9 +5915,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "69abe4f9-f16f-47bf-8fdf-ccce67a18e5d"
+                        "controlledList": "69abe4f9-f16f-47bf-8fdf-ccce67a18e5d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5830,9 +5964,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5912,10 +6047,10 @@
                 {
                     "alias": "timespan_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5984,9 +6119,10 @@
                 {
                     "alias": "timespan_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6084,9 +6220,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "6e3bd268-68bc-4464-aad0-82eabfd5a78f"
+                        "controlledList": "6e3bd268-68bc-4464-aad0-82eabfd5a78f",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6132,9 +6269,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6195,9 +6333,10 @@
                 {
                     "alias": "used_object_type",
                     "config": {
-                        "rdmCollection": "a373aabe-bba3-4c41-a363-d8f879c2f7ff"
+                        "controlledList": "a373aabe-bba3-4c41-a363-d8f879c2f7ff",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6281,9 +6420,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6617,9 +6757,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6817,9 +6958,9 @@
             "publication": {
                 "graph_id": "03357848-1d9d-11eb-a29f-024e0d439fdb",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "86ad554e-3833-11f0-a7a4-020539808477",
-                "published_time": "2025-05-23T17:10:40.249"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "22ffa594-c005-40dd-a663-697bec8e439e",
+                "published_time": "2026-02-06T12:59:33.694"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Textual Work.json
+++ b/arches_for_science/pkg/graphs/resource_models/Textual Work.json
@@ -1398,7 +1398,6 @@
                             "placeholder"
                         ],
                         "label": "Statement_creation_time_type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1411,7 +1410,7 @@
                     "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "02281c77-911b-11ec-a428-ad03e9261309",
@@ -1562,14 +1561,11 @@
                 {
                     "card_id": "e6037382-d348-11e9-a134-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1582,19 +1578,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e6037382-d348-11e9-a134-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1607,7 +1628,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e6037382-d348-11e9-a134-a4d18cec433a",
@@ -1691,7 +1712,6 @@
                             "placeholder"
                         ],
                         "label": "Textual Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1704,7 +1724,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "218dae8c-c074-11e9-92e5-a4d18cec433a",
@@ -1761,14 +1781,11 @@
                 {
                     "card_id": "9752c366-d349-11e9-908a-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1781,7 +1798,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9752c366-d349-11e9-908a-a4d18cec433a",
@@ -1839,13 +1856,38 @@
                     "card_id": "9752c366-d349-11e9-908a-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1858,7 +1900,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1174803a-c073-11e9-af86-a4d18cec433a",
@@ -1986,7 +2028,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1999,7 +2040,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1174803a-c073-11e9-af86-a4d18cec433a",
@@ -2009,7 +2050,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2022,7 +2062,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1174803a-c073-11e9-af86-a4d18cec433a",
@@ -2142,7 +2182,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2155,7 +2194,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "1174570f-c073-11e9-9f97-a4d18cec433a",
@@ -2247,7 +2286,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2260,19 +2298,30 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11747680-c073-11e9-b2b9-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2285,7 +2334,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11747680-c073-11e9-b2b9-a4d18cec433a",
@@ -2351,13 +2400,38 @@
                     "card_id": "11747680-c073-11e9-b2b9-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2370,7 +2444,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11747680-c073-11e9-b2b9-a4d18cec433a",
@@ -2402,7 +2476,6 @@
                             "placeholder"
                         ],
                         "label": "Subject this work is about",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2415,7 +2488,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "5a34d12a-8e31-11eb-a9c4-faffc265b501",
@@ -2447,7 +2520,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2460,7 +2532,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11747126-c073-11e9-b8d4-a4d18cec433a",
@@ -2522,7 +2594,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2535,7 +2606,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11747126-c073-11e9-b8d4-a4d18cec433a",
@@ -2612,7 +2683,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2625,7 +2695,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8c67342b-c073-11e9-bb19-a4d18cec433a",
@@ -2739,7 +2809,6 @@
                             "placeholder"
                         ],
                         "label": "Dimension Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2752,7 +2821,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8c67342b-c073-11e9-bb19-a4d18cec433a",
@@ -2866,7 +2935,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2879,7 +2947,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "eca44980-c07b-11e9-8425-a4d18cec433a",
@@ -2944,14 +3012,11 @@
                 {
                     "card_id": "8c67306b-c073-11e9-8553-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2964,19 +3029,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8c67306b-c073-11e9-8553-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2989,7 +3079,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "8c67306b-c073-11e9-8553-a4d18cec433a",
@@ -3144,7 +3234,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3157,7 +3246,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11749475-c073-11e9-8d9b-a4d18cec433a",
@@ -3188,7 +3277,6 @@
                             "placeholder"
                         ],
                         "label": "Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3201,7 +3289,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "117489a6-c073-11e9-888a-a4d18cec433a",
@@ -3232,7 +3320,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3245,7 +3332,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "117489a6-c073-11e9-888a-a4d18cec433a",
@@ -3456,13 +3543,38 @@
                     "card_id": "11746bde-c073-11e9-92fa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3475,19 +3587,16 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11746bde-c073-11e9-92fa-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3500,7 +3609,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11746bde-c073-11e9-92fa-a4d18cec433a",
@@ -3540,7 +3649,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3553,7 +3661,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11746621-c073-11e9-9fa1-a4d18cec433a",
@@ -3611,13 +3719,38 @@
                     "card_id": "11746621-c073-11e9-9fa1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3630,7 +3763,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11746621-c073-11e9-9fa1-a4d18cec433a",
@@ -3665,14 +3798,11 @@
                 {
                     "card_id": "11746621-c073-11e9-9fa1-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3685,7 +3815,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11747a73-c073-11e9-a9b2-a4d18cec433a",
@@ -3769,7 +3899,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3782,7 +3911,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11747a73-c073-11e9-a9b2-a4d18cec433a",
@@ -3881,7 +4010,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3894,7 +4022,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11748f26-c073-11e9-a1f2-a4d18cec433a",
@@ -3904,7 +4032,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Part Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -3917,7 +4044,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11748f26-c073-11e9-a1f2-a4d18cec433a",
@@ -4067,7 +4194,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Part Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4080,7 +4206,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11748f26-c073-11e9-a1f2-a4d18cec433a",
@@ -4304,7 +4430,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4317,7 +4442,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11749a47-c073-11e9-9b37-a4d18cec433a",
@@ -4327,7 +4452,6 @@
                             "placeholder"
                         ],
                         "label": "Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4340,7 +4464,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11749a47-c073-11e9-9b37-a4d18cec433a",
@@ -4454,7 +4578,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4467,7 +4590,7 @@
                     "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11749a47-c073-11e9-9b37-a4d18cec433a",
@@ -4562,14 +4685,37 @@
                     "card_id": "0096effa-c073-11e9-96ea-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "7d08d556-b831-4a7b-8a47-2068db0db6e6",
+                                        "language_id": "en",
+                                        "list_item_id": "b441941d-8d0d-4db3-9a99-cd28886d500a",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "e24a3dd7-06bb-4238-a161-81ab6c582574",
+                                        "language_id": "en",
+                                        "list_item_id": "1e9d7790-e9fa-4971-a37c-0ee8ba4db798",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4582,7 +4728,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0096effa-c073-11e9-96ea-a4d18cec433a",
@@ -4618,13 +4764,38 @@
                     "card_id": "0096effa-c073-11e9-96ea-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4637,7 +4808,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed05805-d341-11e9-9f58-a4d18cec433a",
@@ -4755,13 +4926,24 @@
                     "card_id": "bed05805-d341-11e9-9f58-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4774,7 +4956,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed07651-d341-11e9-bca2-a4d18cec433a",
@@ -4836,7 +5018,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4849,7 +5030,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed04f59-d341-11e9-8464-a4d18cec433a",
@@ -4903,7 +5084,6 @@
                             "placeholder"
                         ],
                         "label": "type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4916,7 +5096,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed07651-d341-11e9-bca2-a4d18cec433a",
@@ -4956,7 +5136,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -4969,7 +5148,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed07651-d341-11e9-bca2-a4d18cec433a",
@@ -5055,14 +5234,37 @@
                     "card_id": "bed053b8-d341-11e9-80e5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5075,7 +5277,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed06600-d341-11e9-9cb6-a4d18cec433a",
@@ -5192,13 +5394,38 @@
                     "card_id": "bed05805-d341-11e9-9f58-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5211,7 +5438,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed07651-d341-11e9-bca2-a4d18cec433a",
@@ -5221,7 +5448,6 @@
                             "placeholder"
                         ],
                         "label": "Publication Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5234,7 +5460,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed05e57-d341-11e9-8d7e-a4d18cec433a",
@@ -5313,13 +5539,38 @@
                     "card_id": "bed07b5e-d341-11e9-8c27-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5332,7 +5583,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed05805-d341-11e9-9f58-a4d18cec433a",
@@ -5416,7 +5667,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5429,19 +5679,16 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed07b5e-d341-11e9-8c27-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5454,7 +5701,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed05e57-d341-11e9-8d7e-a4d18cec433a",
@@ -5526,14 +5773,11 @@
                 {
                     "card_id": "bed047ba-d341-11e9-8eaa-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5546,7 +5790,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed07651-d341-11e9-bca2-a4d18cec433a",
@@ -5640,13 +5884,38 @@
                     "card_id": "bed047ba-d341-11e9-8eaa-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5659,7 +5928,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed04f59-d341-11e9-8464-a4d18cec433a",
@@ -5716,13 +5985,38 @@
                     "card_id": "bed053b8-d341-11e9-80e5-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5735,7 +6029,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed05e57-d341-11e9-8d7e-a4d18cec433a",
@@ -5782,7 +6076,6 @@
                             "placeholder"
                         ],
                         "label": "Particular Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5795,7 +6088,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed07651-d341-11e9-bca2-a4d18cec433a",
@@ -5917,7 +6210,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5930,7 +6222,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11745c21-c073-11e9-a97b-a4d18cec433a",
@@ -5940,7 +6232,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -5953,7 +6244,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "11745c21-c073-11e9-a97b-a4d18cec433a",
@@ -6063,13 +6354,38 @@
                     "card_id": "9752c730-d349-11e9-a375-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6082,20 +6398,43 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "9752c730-d349-11e9-a375-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6108,7 +6447,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "117484b8-c073-11e9-8bc1-a4d18cec433a",
@@ -6143,14 +6482,11 @@
                 {
                     "card_id": "117484b8-c073-11e9-8bc1-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Type of Name",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6163,19 +6499,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "117484b8-c073-11e9-8bc1-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Language of Text",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6188,7 +6549,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "117484b8-c073-11e9-8bc1-a4d18cec433a",
@@ -6275,14 +6636,11 @@
                 {
                     "card_id": "0096ec07-c073-11e9-b3ef-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6295,19 +6653,44 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0096ec07-c073-11e9-b3ef-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6320,7 +6703,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0096ec07-c073-11e9-b3ef-a4d18cec433a",
@@ -6412,7 +6795,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6425,7 +6807,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed06e33-d341-11e9-bb9b-a4d18cec433a",
@@ -6435,7 +6817,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6448,7 +6829,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bed06e33-d341-11e9-bb9b-a4d18cec433a",
@@ -6506,13 +6887,38 @@
                     "card_id": "e6037894-d348-11e9-a31c-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6525,7 +6931,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e6037894-d348-11e9-a31c-a4d18cec433a",
@@ -6613,14 +7019,37 @@
                     "card_id": "e6037894-d348-11e9-a31c-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6633,19 +7062,30 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0807573d-c073-11e9-ad64-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6658,7 +7098,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0807573d-c073-11e9-ad64-a4d18cec433a",
@@ -6724,13 +7164,38 @@
                     "card_id": "0807573d-c073-11e9-ad64-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6743,7 +7208,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0807573d-c073-11e9-ad64-a4d18cec433a",
@@ -6827,7 +7292,6 @@
                             "placeholder"
                         ],
                         "label": "Name Part Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6840,7 +7304,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "0807513a-c073-11e9-a960-a4d18cec433a",
@@ -6880,7 +7344,6 @@
                             "placeholder"
                         ],
                         "label": "Name Part Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -6893,7 +7356,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": "rgba(165,50,20,0.75)",
@@ -9902,10 +10365,10 @@
                 {
                     "alias": "statement_top__language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9928,9 +10391,10 @@
                 {
                     "alias": "statement_top__name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -9953,9 +10417,10 @@
                 {
                     "alias": "statement_top__type",
                     "config": {
-                        "rdmCollection": "f44f7240-35c5-49e8-a0e3-2ffe308f0862"
+                        "controlledList": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10047,9 +10512,10 @@
                 {
                     "alias": "statement_top__name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10263,9 +10729,10 @@
                 {
                     "alias": "statement_creation_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10517,9 +10984,10 @@
                 {
                     "alias": "name_top__type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10576,9 +11044,10 @@
                 {
                     "alias": "name_top__language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10601,9 +11070,10 @@
                 {
                     "alias": "name_top__part_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -10663,9 +11133,10 @@
                 {
                     "alias": "name_top__part_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11221,9 +11692,10 @@
                 {
                     "alias": "creation_partitioned__time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11246,9 +11718,10 @@
                 {
                     "alias": "creation_partitioned__part_technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11271,9 +11744,10 @@
                 {
                     "alias": "creation_partitioned__part_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11453,9 +11927,10 @@
                 {
                     "alias": "creation_partitioned__part_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11501,9 +11976,10 @@
                 {
                     "alias": "creation_partitioned__time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11526,9 +12002,10 @@
                 {
                     "alias": "creation_partitioned__identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11670,9 +12147,10 @@
                 {
                     "alias": "creation_partitioned__part_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11836,9 +12314,10 @@
                 {
                     "alias": "creation_partitioned__type",
                     "config": {
-                        "rdmCollection": "de10c1c8-a3a4-43e0-8afc-43720a9ad3a9"
+                        "controlledList": "de10c1c8-a3a4-43e0-8afc-43720a9ad3a9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11964,9 +12443,10 @@
                 {
                     "alias": "creation_partitioned__part_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -11989,9 +12469,10 @@
                 {
                     "alias": "creation_partitioned__part_type_n1",
                     "config": {
-                        "rdmCollection": "de10c1c8-a3a4-43e0-8afc-43720a9ad3a9"
+                        "controlledList": "de10c1c8-a3a4-43e0-8afc-43720a9ad3a9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12094,9 +12575,10 @@
                 {
                     "alias": "creation_partitioned__name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12180,9 +12662,10 @@
                 {
                     "alias": "creation_partitioned__time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12205,9 +12688,10 @@
                 {
                     "alias": "creation_partitioned__part_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12363,9 +12847,10 @@
                 {
                     "alias": "creation_partitioned__time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12388,9 +12873,10 @@
                 {
                     "alias": "creation_partitioned__time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12413,9 +12899,10 @@
                 {
                     "alias": "creation_partitioned__part_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12532,9 +13019,10 @@
                 {
                     "alias": "creation_partitioned__part_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -12932,9 +13420,10 @@
                 {
                     "alias": "creation_partitioned__technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13062,9 +13551,10 @@
                 {
                     "alias": "creation_partitioned__part_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13144,9 +13634,10 @@
                 {
                     "alias": "creation_partitioned__part_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13169,9 +13660,10 @@
                 {
                     "alias": "creation_partitioned__name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13354,9 +13846,10 @@
                 {
                     "alias": "creation_partitioned__time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13559,9 +14052,10 @@
                 {
                     "alias": "creation_partitioned__part_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13584,9 +14078,10 @@
                 {
                     "alias": "creation_partitioned__time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13715,9 +14210,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -13801,9 +14297,10 @@
                 {
                     "alias": "textual_reference_type",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -13849,9 +14346,10 @@
                 {
                     "alias": "digital_reference_digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -14004,9 +14502,10 @@
                 {
                     "alias": "dimension_type",
                     "config": {
-                        "rdmCollection": "c9e838f8-7660-4701-821c-721dac98a10b"
+                        "controlledList": "c9e838f8-7660-4701-821c-721dac98a10b",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14029,9 +14528,10 @@
                 {
                     "alias": "dimension_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14100,9 +14600,10 @@
                 {
                     "alias": "dimension_unit",
                     "config": {
-                        "rdmCollection": "44295221-1215-4359-a079-234b317f65b7"
+                        "controlledList": "44295221-1215-4359-a079-234b317f65b7",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14242,9 +14743,10 @@
                 {
                     "alias": "dimension_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14313,10 +14815,10 @@
                 {
                     "alias": "creation_partitioned__part_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14339,9 +14841,10 @@
                 {
                     "alias": "creation_partitioned__part_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14364,9 +14867,10 @@
                 {
                     "alias": "creation_partitioned__part_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14492,9 +14996,10 @@
                 {
                     "alias": "creation_partitioned__part_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14888,9 +15393,10 @@
                 {
                     "alias": "publication_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14947,9 +15453,10 @@
                 {
                     "alias": "publication_time_duration_unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14972,9 +15479,10 @@
                 {
                     "alias": "publication_technique",
                     "config": {
-                        "rdmCollection": "35ed167d-ab89-4f38-b046-3349256be725"
+                        "controlledList": "35ed167d-ab89-4f38-b046-3349256be725",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -14997,9 +15505,10 @@
                 {
                     "alias": "publication_statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -15022,9 +15531,10 @@
                 {
                     "alias": "publication_time_type",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -15395,9 +15905,10 @@
                 {
                     "alias": "publication_time_duration_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -15420,9 +15931,10 @@
                 {
                     "alias": "publication_statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -15482,9 +15994,10 @@
                 {
                     "alias": "publication_time_duration_type",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -15587,9 +16100,10 @@
                 {
                     "alias": "publication_type",
                     "config": {
-                        "rdmCollection": null
+                        "controlledList": "00000000-0000-0000-0000-000000000005",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -15777,9 +16291,10 @@
                 {
                     "alias": "publication_identifier_type",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -15861,9 +16376,10 @@
                 {
                     "alias": "publication_time_duration_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16048,9 +16564,10 @@
                 {
                     "alias": "publication_statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16073,10 +16590,10 @@
                 {
                     "alias": "publication_statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16205,9 +16722,10 @@
                 {
                     "alias": "publication_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16267,9 +16785,10 @@
                 {
                     "alias": "publication_time_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16292,9 +16811,10 @@
                 {
                     "alias": "publication_time_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16317,9 +16837,10 @@
                 {
                     "alias": "subject",
                     "config": {
-                        "rdmCollection": "8b7faa16-3846-4360-b767-bb2c823b6550"
+                        "controlledList": "8b7faa16-3846-4360-b767-bb2c823b6550",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16365,9 +16886,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "851c8546-9f11-4a8f-8c6c-2230b9a1c92d"
+                        "controlledList": "851c8546-9f11-4a8f-8c6c-2230b9a1c92d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16459,10 +16981,10 @@
                 {
                     "alias": "creation_partitioned__statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16485,9 +17007,10 @@
                 {
                     "alias": "creation_partitioned__statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16510,9 +17033,10 @@
                 {
                     "alias": "creation_partitioned__statement_type",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16638,9 +17162,10 @@
                 {
                     "alias": "creation_partitioned__statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16803,9 +17328,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"
+                        "controlledList": "fb8ccaf4-9d92-4150-b7cb-ed333ca767ea",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -16913,9 +17439,9 @@
             "publication": {
                 "graph_id": "a7b1a7c5-b25b-11e9-8a4e-a4d18cec433a",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "d0ae315e-3833-11f0-8ab0-020539808477",
-                "published_time": "2025-05-23T17:12:44.405"
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "af2b04db-f34d-4b0c-b6d9-51f14c841a3e",
+                "published_time": "2026-02-06T12:59:29.282"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/arches_for_science/pkg/graphs/resource_models/Visual Work.json
+++ b/arches_for_science/pkg/graphs/resource_models/Visual Work.json
@@ -16,13 +16,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Depicts Class of Thing"
@@ -45,13 +45,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Type of Visual Work"
@@ -74,13 +74,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Depicts Physical Thing"
@@ -105,13 +105,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Polygon Identifier for Visual Work"
@@ -134,13 +134,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Duration of TimeSpan of Creation Event"
@@ -163,13 +163,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier for Creation Event"
@@ -192,13 +192,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for TimeSpan of Creation Event"
@@ -221,13 +221,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about Creation Event"
@@ -250,13 +250,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Creation Event"
@@ -279,13 +279,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Duration of TimeSpan of Creation Event"
@@ -308,13 +308,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "TimeSpan of Creation Event"
@@ -337,13 +337,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement about Creation Event"
@@ -366,10 +366,10 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
                         "en": "Record any entity (person, place, event, thing) that had a known and substantial influence on the creation of the visual work."
@@ -395,13 +395,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Subject(s) of Visual Work"
@@ -424,13 +424,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Parent Work"
@@ -453,13 +453,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "External URI for this Visual Work"
@@ -482,13 +482,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name of Visual Work"
@@ -511,13 +511,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Name for Statement about Visual Work"
@@ -540,13 +540,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Statement about Visual Work"
@@ -569,13 +569,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Identifier for Visual Work"
@@ -596,13 +596,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Digital Reference to Visual Work"
@@ -625,13 +625,13 @@
                     "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
                     "helpenabled": false,
                     "helptext": {
-                        "en": null
+                        "en": ""
                     },
                     "helptitle": {
-                        "en": null
+                        "en": ""
                     },
                     "instructions": {
-                        "en": null
+                        "en": ""
                     },
                     "name": {
                         "en": "Internal Label for Visual Work"
@@ -711,7 +711,6 @@
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -724,7 +723,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c98649c-99f6-11ea-a9b7-3af9d3b32b71",
@@ -734,7 +733,6 @@
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -747,7 +745,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c98649c-99f6-11ea-a9b7-3af9d3b32b71",
@@ -827,14 +825,37 @@
                     "card_id": "e58eac30-c062-11e9-ad2d-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea",
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "7d08d556-b831-4a7b-8a47-2068db0db6e6",
+                                        "language_id": "en",
+                                        "list_item_id": "b441941d-8d0d-4db3-9a99-cd28886d500a",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "e24a3dd7-06bb-4238-a161-81ab6c582574",
+                                        "language_id": "en",
+                                        "list_item_id": "1e9d7790-e9fa-4971-a37c-0ee8ba4db798",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -847,7 +868,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e58eac30-c062-11e9-ad2d-a4d18cec433a",
@@ -883,13 +904,38 @@
                     "card_id": "e58eac30-c062-11e9-ad2d-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -902,19 +948,44 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e58e9fd9-c062-11e9-82fd-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -927,7 +998,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e58e9fd9-c062-11e9-82fd-a4d18cec433a",
@@ -992,14 +1063,11 @@
                 {
                     "card_id": "e58e9fd9-c062-11e9-82fd-a4d18cec433a",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1012,7 +1080,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e58e9fd9-c062-11e9-82fd-a4d18cec433a",
@@ -1044,7 +1112,6 @@
                             "placeholder"
                         ],
                         "label": "Type Depicted",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1057,7 +1124,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6291d6f0-8591-11ea-97eb-acde48001122",
@@ -1143,7 +1210,6 @@
                             "placeholder"
                         ],
                         "label": "Temporal Unit",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1156,7 +1222,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c986bcc-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1203,7 +1269,6 @@
                             "placeholder"
                         ],
                         "label": "Duration Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1216,7 +1281,7 @@
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c986bcc-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1311,13 +1376,38 @@
                     "card_id": "6c987126-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1330,7 +1420,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c987126-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1387,14 +1477,11 @@
                 {
                     "card_id": "6c987126-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1407,7 +1494,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c987126-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1443,13 +1530,38 @@
                     "card_id": "6c9866ae-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1462,7 +1574,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c9866ae-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1498,14 +1610,37 @@
                     "card_id": "6c9866ae-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "df8e4cf6-9b0b-472f-8986-83d5b2ca28a0",
-                            "72202a9f-1551-4cbc-9c7a-73c02321f3ea"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "84ebd397-b209-41f8-97d4-d52d0fa8633b",
+                                        "language_id": "en",
+                                        "list_item_id": "8485c6d0-bed5-4af6-84da-3f294dd9cb1c",
+                                        "value": "description",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300411780"
+                            },
+                            {
+                                "labels": [
+                                    {
+                                        "id": "167327e5-9278-4f40-95ca-4637b55ddfdd",
+                                        "language_id": "en",
+                                        "list_item_id": "74c7bf6c-fde6-4624-8373-7cb5078a8215",
+                                        "value": "brief text",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                                "uri": "http://vocab.getty.edu/aat/300418049"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Statement Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1518,7 +1653,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c9866ae-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1576,13 +1711,38 @@
                     "card_id": "6c985e52-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1595,7 +1755,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c985e52-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1660,14 +1820,11 @@
                 {
                     "card_id": "6c985e52-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "0fa02b3a-eb9b-4e6c-a0fd-3e948795df10"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1680,7 +1837,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c985e52-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1712,7 +1869,6 @@
                             "placeholder"
                         ],
                         "label": "TimeSpan Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1725,7 +1881,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c986ed8-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1867,13 +2023,38 @@
                     "card_id": "6c9869a6-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1886,7 +2067,7 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c9869a6-99f6-11ea-a9b7-3af9d3b32b71",
@@ -1922,13 +2103,24 @@
                     "card_id": "6c9869a6-99f6-11ea-a9b7-3af9d3b32b71",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9bbc937e-f091-40da-bcb6-3394a62cdfb0",
+                                        "language_id": "en",
+                                        "list_item_id": "fc0fb33a-63c1-4ada-af56-ab8956c127ea",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -1941,7 +2133,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c9869a6-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2069,7 +2261,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Technique",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2082,7 +2273,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c987446-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2188,7 +2379,6 @@
                             "placeholder"
                         ],
                         "label": "Creation Event Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2201,7 +2391,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c9861d6-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2263,7 +2453,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2276,7 +2465,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "6c9861d6-99f6-11ea-a9b7-3af9d3b32b71",
@@ -2346,7 +2535,6 @@
                             "placeholder"
                         ],
                         "label": "Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2359,7 +2547,7 @@
                     "sortorder": null,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "b0f0c12b-c065-11e9-a542-a4d18cec433a",
@@ -2469,13 +2657,38 @@
                     "card_id": "d92ef9f3-c062-11e9-be50-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "bc35776b-996f-4fc1-bd25-9f6432c1f349"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "9ef7c937-9c22-431b-b616-ec8a1262271d",
+                                        "language_id": "fr",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "anglais",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ad5573c8-b357-40b2-a5f6-d1dc57fa2c11",
+                                        "language_id": "de",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "Englisch",
+                                        "valuetype_id": "prefLabel"
+                                    },
+                                    {
+                                        "id": "ab46cdfd-d4f0-4b00-80e3-c7d4eaa171f9",
+                                        "language_id": "en",
+                                        "list_item_id": "38729dbe-6d1c-48ce-bf47-e2a18945600e",
+                                        "value": "English (language)",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                                "uri": "http://vocab.getty.edu/aat/300388277"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Language",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2488,19 +2701,30 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d92ef9f3-c062-11e9-be50-a4d18cec433a",
                     "config": {
                         "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
+                            {
+                                "labels": [
+                                    {
+                                        "id": "5a106529-1721-43e9-b902-40927ad79f08",
+                                        "language_id": "en",
+                                        "list_item_id": "5f400d39-3b6b-4b8a-939b-4e49787c7444",
+                                        "value": "preferred terms",
+                                        "valuetype_id": "prefLabel"
+                                    }
+                                ],
+                                "list_id": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                                "uri": "http://vocab.getty.edu/aat/300404670"
+                            }
                         ],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Name Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2513,7 +2737,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "d92ef9f3-c062-11e9-be50-a4d18cec433a",
@@ -2613,7 +2837,6 @@
                             "placeholder"
                         ],
                         "label": "Identifier Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2626,7 +2849,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "e67be194-c062-11e9-a001-a4d18cec433a",
@@ -2680,7 +2903,6 @@
                             "placeholder"
                         ],
                         "label": "Visual Work Subject",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2693,7 +2915,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "ed9a1d4e-8e31-11eb-a9c4-faffc265b501",
@@ -2725,7 +2947,6 @@
                             "placeholder"
                         ],
                         "label": "Digital Reference Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -2738,7 +2959,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 }
             ],
             "color": "rgba(210,78,43,0.85)",
@@ -3947,9 +4168,10 @@
                 {
                     "alias": "depicts_class_",
                     "config": {
-                        "rdmCollection": "273d0839-8911-468f-9eb1-b0cc3507b6e7"
+                        "controlledList": "273d0839-8911-468f-9eb1-b0cc3507b6e7",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -3972,9 +4194,10 @@
                 {
                     "alias": "type_n6",
                     "config": {
-                        "rdmCollection": "9830adca-4ef8-4088-8cff-cae89a8af60c"
+                        "controlledList": "9830adca-4ef8-4088-8cff-cae89a8af60c",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4267,10 +4490,10 @@
                 {
                     "alias": "language_n2",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4510,9 +4733,10 @@
                 {
                     "alias": "type_n7",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4535,9 +4759,10 @@
                 {
                     "alias": "type_n8",
                     "config": {
-                        "rdmCollection": "0eb564f7-3ccb-4b13-aab1-307011c8610a"
+                        "controlledList": "0eb564f7-3ccb-4b13-aab1-307011c8610a",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4612,9 +4837,10 @@
                 {
                     "alias": "type_n9",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4637,9 +4863,10 @@
                 {
                     "alias": "unit",
                     "config": {
-                        "rdmCollection": "bbf81641-b1dd-4ddf-858d-7e8ca823d385"
+                        "controlledList": "bbf81641-b1dd-4ddf-858d-7e8ca823d385",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4685,9 +4912,10 @@
                 {
                     "alias": "language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4710,9 +4938,10 @@
                 {
                     "alias": "type_n4",
                     "config": {
-                        "rdmCollection": "c53d3557-e033-4aa1-b020-0dc2b690025f"
+                        "controlledList": "c53d3557-e033-4aa1-b020-0dc2b690025f",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -4993,9 +5222,10 @@
                 {
                     "alias": "language_n1",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5041,9 +5271,10 @@
                 {
                     "alias": "type_n1",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5089,9 +5320,10 @@
                 {
                     "alias": "type_n2",
                     "config": {
-                        "rdmCollection": "a4095d09-de02-4675-ab63-42227d9e94bc"
+                        "controlledList": "a4095d09-de02-4675-ab63-42227d9e94bc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5185,9 +5417,10 @@
                 {
                     "alias": "type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5267,9 +5500,10 @@
                 {
                     "alias": "type_n5",
                     "config": {
-                        "rdmCollection": "7a8d3213-0a64-4f31-92a4-191b41236ae9"
+                        "controlledList": "7a8d3213-0a64-4f31-92a4-191b41236ae9",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5292,9 +5526,10 @@
                 {
                     "alias": "type_n3",
                     "config": {
-                        "rdmCollection": "1adae7ea-4884-432f-af44-c9aea3a48a3d"
+                        "controlledList": "1adae7ea-4884-432f-af44-c9aea3a48a3d",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5444,9 +5679,10 @@
                 {
                     "alias": "technique",
                     "config": {
-                        "rdmCollection": "3e46a547-fa4b-418d-bca7-18b2a5a50536"
+                        "controlledList": "3e46a547-fa4b-418d-bca7-18b2a5a50536",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5503,9 +5739,10 @@
                 {
                     "alias": "language_n3",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5528,9 +5765,10 @@
                 {
                     "alias": "language_n4",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5637,9 +5875,10 @@
                 {
                     "alias": "subject",
                     "config": {
-                        "rdmCollection": "52fbf9cc-3027-4d5c-9439-1856bb6e68a5"
+                        "controlledList": "52fbf9cc-3027-4d5c-9439-1856bb6e68a5",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5822,9 +6061,10 @@
                 {
                     "alias": "name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5904,9 +6144,10 @@
                 {
                     "alias": "name_type",
                     "config": {
-                        "rdmCollection": "80028d07-9c98-48cf-84db-f77bc01c8bbc"
+                        "controlledList": "80028d07-9c98-48cf-84db-f77bc01c8bbc",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -5998,10 +6239,10 @@
                 {
                     "alias": "statement_language",
                     "config": {
-                        "graphid": null,
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis is the language of the statement, drawn from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6024,9 +6265,10 @@
                 {
                     "alias": "statement_name_type",
                     "config": {
-                        "rdmCollection": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"
+                        "controlledList": "9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6049,9 +6291,10 @@
                 {
                     "alias": "statement_type",
                     "config": {
-                        "rdmCollection": "f44f7240-35c5-49e8-a0e3-2ffe308f0862"
+                        "controlledList": "f44f7240-35c5-49e8-a0e3-2ffe308f0862",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThis branch allows the classifications themselves to be classified in order to know what sort of type it is, without recognizing all of them individually. This is important when the set of first degree types is not easily enumerable, such as classifications for the type of object or work.  See: https://linked.art/model/base/#types-of-types\n\n# Arches Note:\nNote that the metatype is hidden from view. Ensure that it has a default set when imported into another branch or model.\n\n* BranchId: la-meta-classification\n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6177,9 +6420,10 @@
                 {
                     "alias": "statement_name_language",
                     "config": {
-                        "rdmCollection": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"
+                        "controlledList": "f7fc4f6d-fd46-4881-846f-4a08bc1a3fef",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nThe language of the name, selected from a controlled vocabulary.\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6282,9 +6526,10 @@
                 {
                     "alias": "identifier_type",
                     "config": {
-                        "rdmCollection": "4096365e-4fe7-412d-906c-16f3d356e8be"
+                        "controlledList": "4096365e-4fe7-412d-906c-16f3d356e8be",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
                     "exportable": false,
                     "fieldname": null,
@@ -6410,9 +6655,10 @@
                 {
                     "alias": "digital_reference_type",
                     "config": {
-                        "rdmCollection": "933cf221-2d71-478f-998a-a5e088457971"
+                        "controlledList": "933cf221-2d71-478f-998a-a5e088457971",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -6492,7 +6738,13 @@
                 }
             ],
             "ontology_id": "0b1f5462-faa7-11e9-8f09-3af9d3b32b71",
-            "publication": null,
+            "publication": {
+                "graph_id": "ba892214-b25b-11e9-bf3e-a4d18cec433a",
+                "most_recent_edit_id": null,
+                "notes": "Migrated concept/concept-list nodes to reference datatype",
+                "publicationid": "65efff7f-3e67-45e7-90d5-9a06e691fb33",
+                "published_time": "2026-02-06T12:59:06.235"
+            },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],
             "resource_instance_lifecycle": {

--- a/arches_for_science/pkg/reference_data/controlled_lists/afs_lists.xml
+++ b/arches_for_science/pkg/reference_data/controlled_lists/afs_lists.xml
@@ -1,0 +1,9561 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+  xmlns:arches="http://localhost:8000/"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+>
+  <skos:Concept rdf:about="http://localhost:8000/45eeaca7-077d-45d2-9a3b-34268ddd9ea6">
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms-id</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9">
+        <dcterms:title>Identifier Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en-US">Gallery Systems' The Museum System (TMS) Integer Identifier (ID)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c262b1b6-df83-42a7-9385-1e0cd2b9e706">
+    <skos:scopeNote xml:lang="de">Sammlung, die von einer nationalen Regierung unterhalten wird und in der Regel in einer Bibliothek, einem Archiv oder Museum untergebracht ist.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Collections maintained by a nation's government and housed typically in a library, archive or museum.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300263379</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3">
+        <dcterms:title>Object Types - Collection/Set</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Nationalsammlung (Sammlung)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">national collections</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d4518c68-1a63-49fc-b515-a251cbdb76e9">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300393177</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/c66a18f6-eb8a-43cb-92d1-f74feaaf29ed">
+        <dcterms:title>Personal Activity Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Of people and corporate bodies, the state of being professionally active. A common example is in reference to dates associated with people or corporate bodies, where the specific dates, and sometimes loci, of birth and death are unknown; the term is commonly so-used in the discipline of art history for estimated life dates based on the oeuvre or other documentation of the artist. It may refer to the time of the artist's apprenticeship through old age, regardless of whether this was his or her most prolific period. For people other than artists and architects, prefer "flourished," which has the connotation of demarking that time when the person has achieved full development or success. However, usage overlaps.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">active (professional function)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/313487f7-e22b-48ed-8b94-c2c7bdb384fd">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6">
+        <dcterms:title>Relationship Labels - Person</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">group left</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/313487f7-e22b-48ed-8b94-c2c7bdb384fd</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d67703ca-5e72-4d6f-9e86-bf8745006274">
+    <dcterms:identifier>http://localhost:8000/f7dda933-9221-4555-a828-493962ab9411</dcterms:identifier>
+    <skos:scopeNote xml:lang="en-US">No AAT Identifier yet</skos:scopeNote>
+    <skos:prefLabel xml:lang="en-US">Spreadsheet</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971">
+        <dcterms:title>Reference Types - Digital Resource Reference</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a5e9ba49-12ce-4440-9db9-484c8519c785">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388412</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">hindi</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef">
+        <dcterms:title>Languages</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="de">Hindi</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Hindi (language)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/249e9e0e-0af1-457e-b33e-ccb6824e5a2a">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677">
+        <dcterms:title>Dimension Types - Currencies</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Unit of German currency of varying value minted as gold coins by several German states from 1354.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">German florin (system of money)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412160</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/be85e667-6ccf-4a41-9664-4ba298d60e12">
+    <dcterms:identifier>https://afs.test.fargeo.com/be85e667-6ccf-4a41-9664-4ba298d60e12</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843">
+        <dcterms:title>Relationship Labels - Physical Thing</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">actor in part removal event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/acccfdce-e713-4172-93c5-edc0fabb9e1a">
+    <skos:prefLabel xml:lang="en">Czech (culture or style)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111166</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875">
+        <dcterms:title>Person Types - Nationality</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of the Czech Republic, or in general to cultures that have occupied the area of the modern nation in central Europe. It is also used to refer broadly to the culture of the Bohemian people.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/70ac381a-6eb8-4e33-9acd-12b8930f66c4">
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Portugal, or in general to the cultures that have occupied the same area in the western part of the Iberian Peninsula.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Portuguese (culture or style)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111207</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d4ed934d-ed5f-491f-bb64-2061e7251e21">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">argent</skos:prefLabel>
+    <skos:prefLabel xml:lang="pt">prata</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289">
+        <dcterms:title>Materials</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">silver (metal)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Pure metallic element having symbol Ag and atomic number 47; a malleable, ductile, white metal with characteristic sheen, considered a precious metal. Silver is widely distributed throughout the world, occurring rarely as metallic silver (in Peru, Norway) but more often as silver-gold alloys and silver ore. Today silver is obtained as a byproduct in the refinement of gold, lead, copper, or zinc ores. Silver was smelted from the ore galena as early as 3800 BCE. As a pure metal, silver is second to gold in malleability and ductility, can be polished to a highly reflective surface, and used -- typically in an alloy -- in jewelry, coinage, photography, mirrors, electrical contacts, and tableware.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Silber</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011029</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5bb6ff4f-33c1-4804-9768-e1aa876d5150">
+    <skos:prefLabel xml:lang="de">Nicht zu entscheiden</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">indéterminée</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">undetermined (language)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389645</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b194a7e9-3ddc-43ab-b882-6b4b6761a6c8">
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/4096365e-4fe7-412d-906c-16f3d356e8be">
+        <dcterms:title>Identifier Types - Generic</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/75b07500-6ca7-49c4-af11-d5174e148be3">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:prefLabel xml:lang="en">occurs before event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/3161211b-d4f3-4ce7-9e5d-ace00c3ad361</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88">
+        <dcterms:title>Relationship Labels - Sampling Activity</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8ead46b7-39b3-4f6a-b9d0-08994a595bb7">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388204</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">danois</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Danish (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Dänisch</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/478c39e7-9d07-4f5d-847d-ac887c2c4469">
+    <skos:prefLabel xml:lang="en">technical analysis</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379518</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725">
+        <dcterms:title>Techniques</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">The application of testing methods to materials or objects in order to analyze their composition and manufacture. In a conservation science context, this may refer to movable art works and artifactual objects in a conservation lab. For a broader range of testing methods, prefer "scientific analysis." </skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7b9d01ef-4a20-42aa-b1e9-2752045bb8d5">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/c8261144-c750-4f64-8980-e50f762b21a5">
+        <dcterms:title>Identifier Types - Place</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/479e887b-5700-4629-adfa-a71d652756fa">
+    <dcterms:identifier>http://localhost:8000/479e887b-5700-4629-adfa-a71d652756fa</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">partial payment</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/02dc399d-9c8c-406d-a4bf-56817eb03449">
+        <dcterms:title>Event Types - Payment </dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f899df4e-86eb-4579-aca8-d0cbadc31994">
+    <skos:prefLabel xml:lang="en-US">Joining as Leader</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/1ad61b29-95db-4885-a5ad-0d037e609488">
+        <dcterms:title>Group Joining Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://localhost:8000/f899df4e-86eb-4579-aca8-d0cbadc31994</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b9721f25-a10c-4b55-85fc-ce03bb85b3a0">
+    <skos:prefLabel xml:lang="en">file size</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/c2788105-d184-4192-b19f-7d504f43d7b0">
+        <dcterms:title>Dimension Types - Digital</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://localhost:8000/b9721f25-a10c-4b55-85fc-ce03bb85b3a0</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9bd0bf4d-e03e-4b9b-973c-692583d03d24">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/8dc4c1ac-aae5-41f6-817b-9ee5fef855fe">
+        <dcterms:title>Digital Resource Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="fr">base de données</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028543</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Elektronisch gespeicherter, strukturierter Datensatz, insbesondere solcher mit integrierter Software, die ihn auf vielfältige Weise verfügbar macht. Eine Datenbank wird verwendet, um Informationen zu speichern, sie abzufragen und wiederaufzufinden, besteht typischerweise aus einer Sammlung logisch zusammenhängender Informationen, die als Einheit verarbeitet, in maschinenlesbarer Form gespeichert und als Datensätze organisiert und strukturiert werden, welche in einem standardisierten Format vorliegen, um mit Hilfe eines Computers schnelles Durchsuchen und Finden zu ermöglichen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">databases</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Structured sets of data held in computer storage, especially those that incorporate software to make them accessible in a variety of ways. A database is used to store, query, and retrieve information, typically comprising a logical collection of interrelated information that is managed as a unit, stored in machine-readable form, and organized and structured as records that are presented in a standardized format in order to allow rapid search and retrieval by a computer.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Datenbank</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d5b6cfce-f3b4-4ff1-acf1-3b9353a87953">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31">
+        <dcterms:title>Method Types - Part Removal Technique</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">disassembling</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404064</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The process of taking apart, whether by damage or intentionally; examples are when folios of manuscripts are cut out of the volume for redistribution separately.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6590308b-8fa9-40a6-aee0-d273588a7cc5">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58">
+        <dcterms:title>Relationship Labels - Digital Resource</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d835a4c9-22a2-4200-aa9e-50a7f09ce915">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b">
+        <dcterms:title>Statement Types - Instrument</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">condition</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Condition is the overall state of an object, being, or environment, including physical characteristics such as appearance, pristineness, level of damage, completeness, working order, or quality.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389724</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/66069bec-6282-4518-960b-26917e674e3a">
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024">
+        <dcterms:title>Relationship Labels - Modification</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7ea073d1-9998-4fb3-9bb7-d674417a42c1">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300047896</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">installations (visual works)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Works dating from the 1960s or later that use their exhibition space as part of their design. Demanding a viewer's active engagement, installations are often created by artists in direct opposition to the notion of permanent artwork, or art as a commodity.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Installation (visuelles Werk)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">installations (visual works)</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Werk, das aus den 1960er Jahren und später datiert, das seinen Ausstellungsraum als Teil seiner Gestaltung nutzt. Aktives Engagement eines Betrachters fordernd, sind Installationen oft vom Künstler im direkten Gegensatz zu der Vorstellung eines dauerhaften Kunstwerks oder Kunst als Ware geschaffen.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b">
+        <dcterms:title>Object Types - Physical Thing</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dd91e772-2e37-4e47-8306-a678ce7fd10c">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/fd0222dd-bd50-4597-b092-d124833176b3">
+        <dcterms:title>Document Part Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">paragraphs</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417223</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">A distinct passage or section of a text, usually composed of several sentences, dealing with a particular point, a short episode in a narrative, a single piece of direct speech.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4f4cf6d3-c30a-4f08-a733-c8bd1276067b">
+    <skos:prefLabel xml:lang="en">projects (object groupings)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404832</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:scopeNote xml:lang="en">Physical works, such as drawings and written documents, that were used in the planning or execution of a definable physical work or set of works; also includes the finished works. Alternatively, a project may be planned, but unexecuted. For the conceptual activities of planning or carrying out of proposed undertakings or creations, use projects (artistic concepts).</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/da21d5fc-14f3-456d-8f8a-f0df95367196">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027200</dcterms:identifier>
+    <skos:altLabel xml:lang="de">Notiz (Dokumentengattung)</skos:altLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/f44f7240-35c5-49e8-a0e3-2ffe308f0862">
+        <dcterms:title>Statement Types - Generic</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">note</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Brief statements of a fact or experience, written down for review, or as an aid to memory, or to inform someone else; also includes short, informal letters.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Kurze Angabe über eine Tatsache oder ein Erlebnis, niedergeschrieben zur Überprüfung oder als Erinnerungshilfe, oder um jemand anderen zu informieren; schließt auch kurze, formlose Briefe mit ein.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c5c1b27b-de1d-4dd3-aeb6-3a8a2715a7dc">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e">
+        <dcterms:title>Dimension Types - Digital Units</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">gigabytes</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300265874</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:scopeNote xml:lang="en">A unit of information or computer file storage equal to one billion bytes. </skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/988861c2-a824-447d-a061-b52e26cbdf0c">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7">
+        <dcterms:title>Statement Types - Physical Thing</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028744</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Standardized symbols, notations, or other markings applied to objects during or after creation, conveying information such as the object's origin or maker, its authenticity, or a change in its official status. For lettering marked on something for documentation or commemoration, use "inscriptions." For marks inherent in the paper support, not applied as part of the image or work, use "watermarks."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">marks (identifying markings)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">marques (symbols)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5a7be6de-f130-472a-931e-635d830be28e">
+    <skos:prefLabel xml:lang="en">journals (periodicals)</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af">
+        <dcterms:title>Document Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="de">Zeitschrift</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300215390</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Periodical publications, particularly those containing scholarly articles or otherwise disseminating information on developments in  a particular subject field.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Periodische Veröffentlichung, meistens mit wissenschaftlichen Artikeln oder anderen, zur Verbreitung von Informationen über Entwicklungen in bestimmten Fachgebieten bestimmt.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/56316ca9-eec6-4065-9488-c5c59364f724">
+    <dcterms:identifier>https://afs.test.fargeo.com/fd194f67-9432-451b-98dc-be6b76742965</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7">
+        <dcterms:title>Relationship Labels - Collection or Set</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:prefLabel xml:lang="en">related event causal to creation event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1ab264bb-0caa-42be-96b9-5e68e4886947">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ef8baa96-3c1e-4479-8c7b-60877b70e1d4">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/ef8baa96-3c1e-4479-8c7b-60877b70e1d4</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">59</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object removed from collection</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1a3258bc-2083-41b0-aff6-705ba1b2fe03">
+    <skos:prefLabel xml:lang="fr">gouache (pientre)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300070114</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">gouache (paint)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:scopeNote xml:lang="en">A matte, opaque watercolor paint typically having gum arabic, gum senegal, or dextrin as a binder. Gouache paints differ from watercolor paints, which use transparent pigments. Chalk and other white fillers may be added to some colors. Gouache was used for miniature paintings in the 16th-18th centuries, for decorative paintings on interior walls, and for printing wall paper patterns. Poster paints are an inexpensive version of gouache. The term originally had a different meaning, referring to oil applied on top of tempera painting.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9517a001-391c-4b5b-9939-b62e832721c1">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300018125</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">African American</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Designates the styles, culture, and heritage of  Americans of African descent in North America. The styles capture the essence of the African American experience and how personal and political rebellion and triumphs over prejudice and social adversity have enriched and contributed to the music, art, and literature of American culture as a whole.</skos:scopeNote>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e">
+        <dcterms:title>Person Types - Ethnicities</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e5e99a36-05e6-4f0d-8b5b-fd657613a5a7">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/61dfad8f-cd46-47fd-820f-3e69ac423cc6</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383">
+        <dcterms:title>Relationship Labels - Textual Work</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">causally relevant to creation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/076513dd-d250-40dd-8d5c-e79b55a282d0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379101</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Standardized linear units of measure made up of twelve inches, 1/3 of a yard; equal to 0.3048 meters. It was a unit of length in both the imperial and US customary systems of measurement; since 1959, both units have been defined as the same by international agreement. Originally the unit was based on the length of a man's foot, varying in exact length at different periods and in different countries.</skos:scopeNote>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7">
+        <dcterms:title>Dimension Types - Physical Units</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">feet (units of measurement)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c3074d88-9974-43e7-817e-686dcada6b9c">
+    <skos:prefLabel xml:lang="en">recorded value of observation</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594">
+        <dcterms:title>Relationship Labels - Observation</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>https://afs.test.fargeo.com/c3074d88-9974-43e7-817e-686dcada6b9c</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8b8e6860-60f7-4de8-9368-05e18f72c183">
+    <skos:prefLabel xml:lang="en">French (culture or style)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">française</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of France, or in general to cultures that have occupied the area of the modern nation in western Europe.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111188</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5d21b903-1d8b-4539-9185-a5c07006f16f">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">period of group joining event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/5d21b903-1d8b-4539-9185-a5c07006f16f</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7db37c5b-95a0-411c-a088-3ba245c2de27">
+    <skos:prefLabel xml:lang="en">reconception</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/de10c1c8-a3a4-43e0-8afc-43720a9ad3a9">
+        <dcterms:title>Event Types - Textual Work Creation</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://localhost:8000/7db37c5b-95a0-411c-a088-3ba245c2de27</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8855248f-53da-4a46-8f05-41b95b1ebc8c">
+    <skos:prefLabel xml:lang="en">Mexican</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Culture and nationality of the nation of Mexico or its people.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">mexicaine</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300107963</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1095a156-7683-4887-911a-e6c8cf0c9212">
+    <skos:prefLabel xml:lang="en">location of destruction event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/1095a156-7683-4887-911a-e6c8cf0c9212</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7e6c493b-6434-4b3a-9513-02df44b78d24">
+    <skos:prefLabel xml:lang="en">German (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Deutsch</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388344</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">allemand</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:scopeNote xml:lang="en">West Germanic language that is the national language of Germany and Austria, one of the three official languages of Switzerland, and known in various communities in North and South America, South Africa, and Australia. As a written language German is quite uniform, although there are numerous regional differences in pronunciation and dialect.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4d40bcba-8ad8-4415-9781-94d501c50142">
+    <skos:prefLabel xml:lang="en">exchange (method of acquisition)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300263427</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Method of acquiring property by each party giving and receiving from the other party, usually regarding property of equal value. For example, an exchange may be made by individual authors, libraries, museums, and other institutions in which they exchange between or among each other their own publications or those of the institution with which they are connected, or duplicates from their own collections.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/5f7df45b-31ae-44ce-a8cc-55ccdafa019d">
+        <dcterms:title>Event Types - Provenance Activity</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/95950aa4-9344-4258-be98-829c70c69c8e">
+    <skos:scopeNote xml:lang="en">Designates the styles, culture, and heritage of  Americans of Asian descent in North America.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Asian-American</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300385962</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a5ed5507-0574-4726-ae98-fa0cd971c349">
+    <dcterms:identifier>http://localhost:8000/a5ed5507-0574-4726-ae98-fa0cd971c349</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Asian Indian</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/013d5917-b323-42e4-b138-5fc5d1a28937">
+    <dcterms:identifier>https://afs.test.fargeo.com/013d5917-b323-42e4-b138-5fc5d1a28937</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">physical object used in set addition event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">65</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/581d3c26-5265-4979-aa1a-8a0409583c48">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c">
+        <dcterms:title>Object Types - Group</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Groups of persons, commonly formed as business enterprises, considered in law as legal persons having an existence and rights and duties distinct from those of the individuals who form them. For unincorporated groups of persons contractually associated as joint principals in business, use "partnerships."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025969</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">corporations</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/57f9fcb6-bfe5-4556-b610-35eb17798e08">
+    <skos:prefLabel xml:lang="en">casting (process)</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb">
+        <dcterms:title>Event Types - Production</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">The act or process of making casts or of shaping in a mold; usually refers to pouring liquid material into a mold, as distinguished from pressing a material into a mold, for which prefer "molding."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053104</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4e5024a2-ec4f-4866-8146-fbc71624579d">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">creator in production event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/b5c6f06d-d6a6-482a-bebf-83c6da262e10</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/03720c4c-5c09-40c7-8c16-2a4c4b5fb46b">
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8">
+        <dcterms:title>Relationship Labels - Group</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/80da44f6-5e55-4763-95d0-8e7cb2bf402c">
+    <skos:prefLabel xml:lang="en">ivory (material)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Elfenbein</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011857</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">ivoire</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The modified form of dentin derived from animal teeth. The most common example is from the tusks of mature elephants; similar material is obtained from any tusked or large-toothed mammal such as a walrus or narwhal.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Veränderte Form des Dentin, das auf den Stoßzähne von ausgewachsenen Elefanten, wie auch auf Stoßzähnen oder großen Zähnen von Walrössern oder Narwalen gefunden wird.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5e4b95e8-70ff-41d4-8926-31182e4a5e56">
+    <skos:prefLabel xml:lang="en">shaving (process)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300263010</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Generally, the process of cutting or scraping the surface of something with a sharp-edged tool so as to remove a thin layer or unwanted extra material. In the context of skin and hide preparation, denotes the beamhouse operation of removing hair or excess dermal material to create an even thickness. In the context of bookbinding, for the removal of a small amount of material from the edges of a book, use "trimming."</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e3864544-e288-4c4b-bdec-3fc770c58a9a">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942">
+        <dcterms:title>Relationship Labels - Place</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f8b729da-4edc-4718-bcd3-569ddff655cd">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300077136</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/b27ffefc-18a1-468f-8923-87530b6f5943">
+        <dcterms:title>Professional Activity Technique</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Causing discrete agents or agencies to work together.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">coordinating</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bab3bf2a-e17e-461b-a7be-b3060a680072">
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c7954ef2-0053-400b-997c-d56a9f64940b">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388113</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">chinois</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Chinese (language)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="de">Chinesisch</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d3a32755-c1ab-4e04-9a3b-9bc1b20583b1">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026068</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en-US">auction catalogs</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">A listing of items, including works of art, manuscripts, books, or other items, that are for sale by auction.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5f443efa-08fa-41bf-9bad-b829e8083429">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103">
+        <dcterms:title>Chemical Elements</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/5f443efa-08fa-41bf-9bad-b829e8083429</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Mn</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Manganese (Mn)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">57</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f3432589-1ec7-4f21-90ff-3582608bbbc4">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025976</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Sammlung (Objektgruppe)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">collections (object groupings)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:scopeNote xml:lang="de">Bezieht sich auf eine Gruppe von Objekten oder Materialien mit einem einheitlichen Bezug, die von einem Individuum oder einer Organisation zusammengestellt wurde. Es kann sich um Kunstwerke in einem Museum oder Archiv handeln oder um separate literarische Werke, die nicht Teil einer Abhandlung oder einer Monographie zu einem Thema sind und dennoch kombiniert als Ganzheit publiziert wurden.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Accumulated groups of objects or materials having a focal characteristic and that have been brought together by an individual or organization. A collection comprises multiple items that are conceptually or physically arranged together for the purpose of cataloging or retrieval. A collection differs from an archival group because the items in a collection are bound informally for convenience and do not necessarily share a common provenance or otherwise meet the criteria for an archival group. Collection-level cataloging is appropriate for materials that share one or more common characteristics that make it useful for them to be clustered together. Individual items in a collection may be cataloged separately and linked to the collection. Examples of collections include a selected set of art works in a museum or archive, or separate literary works that do not form a treatise or monograph on a subject but have been combined and issued together as a whole.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2ba0ea42-dd28-4faa-9af9-28c86c505730">
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/7cc462a5-db43-4b25-a748-99892eba26aa">
+        <dcterms:title>Identifier Types - Provenance Activity</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4e7f0c35-fbb8-477f-8a19-00655d840e45">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300202383</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Converting, sound, motion pictures, images, or other analog data to binary form to be stored or altered with a computer.</skos:scopeNote>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/38867773-6543-4a98-90cc-dc1c7bec3340">
+        <dcterms:title>Event Types - Digital Resource Creation</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">digitizing</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/acfbbb87-8a30-40c8-8399-3b64d0bda2c2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379774</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:scopeNote xml:lang="en">Refers to the styles and cultures that developed in Egypt under the influence of Roman rule and culture.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Romano-Egyptian</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/87390b19-e026-4906-b67b-b91080134b48">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435418</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="en">For art information, a brief statement indicating how the work came into the current or an earlier collection or how it came to be on view at the repository. </skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <skos:prefLabel xml:lang="en">credit line</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bff5f7c9-b4e5-4fd7-8a3b-5b2d77aad099">
+    <skos:altLabel xml:lang="en">At</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/bff5f7c9-b4e5-4fd7-8a3b-5b2d77aad099</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Astatine (At)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9b07ede7-6bb9-4b6b-acfb-994bbd8e74e2">
+    <skos:prefLabel xml:lang="en">acknowledgments</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/52c977b9-3ee6-415c-ad88-70e01c72fd38">
+        <dcterms:title>Statement Types - Person</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Written recognitions of acts or achievements.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026687</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Danksagung</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Schriftliche Anerkennung für Handlungen oder Leistungen.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5e49ee59-6580-4fcb-a57c-be102f72bccd">
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <skos:scopeNote xml:lang="en">Unit of English currency, issued as a gold coin first struck in 1663.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412163</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">guinea (unit of currency)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b500136b-4b36-4db2-85b4-fdb6cce13f51">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">39</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Gold (Au)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/b500136b-4b36-4db2-85b4-fdb6cce13f51</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Au</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f5c09e53-94d2-4dc0-968d-6f6f932c811d">
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes assigned when an art object, book, or other item enters the collection of a museum, library, or other repository. Such codes are unique within the set of codes, and specifically identify the particular item at hand. The numbers may be marked on the objects or not.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300312355</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a">
+        <dcterms:title>Identifier Types - Physical Thing</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">Accession Number</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/78977488-8c32-407a-a6e8-912712c25b2a">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/dca6a321-3ab9-42bc-ac80-2171789ae205">
+        <dcterms:title>Identifier Types - Observation Event</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f6c7105e-fa1d-4da4-9c11-0fc3cb06c8f0">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/f6c7105e-fa1d-4da4-9c11-0fc3cb06c8f0</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">56</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Magnesium (Mg)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Mg</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5864a6e2-5d38-42d5-bfc3-e7a4972cebed">
+    <skos:scopeNote xml:lang="en">Nonprint materials, such as slides, transparencies, motion pictures, or filmstrips, that make use of sight and sound to convey information; refers especially to such materials when used for instruction.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">audiovisual materials</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028045</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/599b2119-6e98-430b-8ae6-61bcdce15a47">
+    <skos:scopeNote xml:lang="en">The constituent political and administrative units of various nations under a federal system of government, such as Australia and the United States of America.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300000776</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">states (political divisions)</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/09f4f591-5654-4518-931b-7ab382fbc100">
+        <dcterms:title>Object Types - Place</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="fr">etats</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c29f7171-e670-443e-8a22-9b4587e1e5f5">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/c29f7171-e670-443e-8a22-9b4587e1e5f5</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">actor in set addition event of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ae1cde57-9daf-48a9-a2fb-787574afc24b">
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dca6a321-3ab9-42bc-ac80-2171789ae205"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/24f4f6ae-ca63-4559-bfec-f50ab6c8346b">
+    <dcterms:identifier>https://afs.test.fargeo.com/24f4f6ae-ca63-4559-bfec-f50ab6c8346b</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of production event</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874">
+        <dcterms:title>Relationship Labels - Instrument</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0f0f9727-0dee-4ff5-bc8d-201aaf6ab338">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce">
+        <dcterms:title>Name Types - Physical Thing </dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en-US">catalogue title</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms/object/titles/catalogue-title</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6da257a3-a82f-48a4-b4f0-7276131b0c4e">
+    <skos:prefLabel xml:lang="en">Sulfur (S)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">S</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/6da257a3-a82f-48a4-b4f0-7276131b0c4e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">99</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/022f7c7c-94a4-4cfc-9a51-54d59351b357">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">inscriptions</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Inschrift</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Words, texts, lettering, or symbols marked on a work, including texts, legends, documentation notes, or commemoration. For standardized symbols or notations on objects that convey official information, use "marks (symbols)."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028702</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Beschriftung, mit der etwas markiert wird, insbesondere zur Dokumentation oder zum Gedenken. Bei einer Drucksache ist dies eine spezielle, in Buchstaben aufgedruckte Information, die für gewöhnlich nicht Teil eines größeren Textes ist. Bezüglich antiker Texte werden damit die meisten erhaltenen schriftlichen Äußerungen jeder Länge, außer Papyri, bezeichnet. Für standardisierte Symbole oder Bezeichnungen auf Objekten, die wichtige Informationen enthalten, siehe "Zeichen (Symbol)".</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3d4b1be4-0f59-44aa-bb73-b3c9774e47c5">
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/c8261144-c750-4f64-8980-e50f762b21a5"/>
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0159aa99-f9ef-43f6-a412-89df24b832bb">
+    <skos:prefLabel xml:lang="en">cutting (shaping or dividing)</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/a9e75b55-78b9-46a6-8cb2-aee3f5b5003e">
+        <dcterms:title>Event Types - Modification</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053069</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Making incisions with a sharp-edged instrument, thus removing material or dividing something into parts.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1adc4266-8512-4a59-9f40-a844539fbc27">
+    <dcterms:identifier>https://afs.test.fargeo.com/1b8ef6a7-c0ed-4437-b836-16c3dec42ce9</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <skos:prefLabel xml:lang="en">influence on activity</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/17324c42-eb04-4527-8ea4-fe6b37ba03d2">
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/17324c42-eb04-4527-8ea4-fe6b37ba03d2</dcterms:identifier>
+    <skos:prefLabel xml:lang="en-US">pilot project</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a1d82c77-ebd6-4215-ab85-2c0b6a68a0e8">
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="de">Französisch</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">French (language)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388306</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">General term for the French language.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">français</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e576485c-36c1-41e0-be6e-67dde3c52d9f">
+    <skos:prefLabel xml:lang="en">selection (analytical function)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Picking out or choosing in preference to another or others.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/cde31c5b-8ab2-4fbe-9b55-11eed1d478f7">
+        <dcterms:title>Event Types - Group Formation Events</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300123578</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d9008689-a4c7-4f2f-a2f2-f2c7da902340">
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ba983b76-67d1-4788-bbf3-40aa8093a268">
+    <skos:prefLabel xml:lang="en">Getty Manuscript Number</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54">
+        <dcterms:title>Identifier Types - Set</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/ba983b76-67d1-4788-bbf3-40aa8093a268</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9624bcad-0f1a-4c78-a919-f9eb6c532da2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055644</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The length of a straight vertical line extending from the bottom to the top of a form.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">height</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/c9e838f8-7660-4701-821c-721dac98a10b">
+        <dcterms:title>Dimension Types - Physical Thing</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/05137059-4a6c-4bf5-934d-c1ca7378246d">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">33</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/05137059-4a6c-4bf5-934d-c1ca7378246d</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for contact information</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c9f0727d-eff8-40fc-8afe-ef7fcd390169">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d">
+        <dcterms:title>Identifier Types - Person</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/89462b0b-71a7-4872-a6ca-18ded17f7568">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300080091</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">description (activity)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The activity or function of representing in spoken, written, or signed language the attributes or qualities of something or someone.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/8b7faa16-3846-4360-b767-bb2c823b6550">
+        <dcterms:title>Textual Work Types - Subject</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/907c2848-98fb-43e8-aa6a-64274ef9abf2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">photographies</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300046300</dcterms:identifier>
+    <skos:scopeNote xml:lang="en"><![CDATA[Refers to still images produced from radiation-sensitive materials (sensitive to light, electron beams, or nuclear radiation), generally by means of the chemical action of light on a sensitive film, paper, glass, or metal. Photographs may be positive or negative, opaque or transparent. The concept does not include reproductive prints of documents and technical drawings, for which descriptors found under "<reprographic copies>" are more appropriate. The concept may include photographs made by digital means.]]></skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:prefLabel xml:lang="en">photographs</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d1cfab03-ce07-4800-9b89-d6129b602228">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:prefLabel xml:lang="en">volumes (documents by form)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Objects comprising sheets of paper, vellum, papyrus, or another material that are bound together. Volumes may include printed books, manuscripts, sketchbooks, or albums. Where the parts of a historical volume have been dispersed, records for the individual sheets may be linked as a historical volume for research purposes. Given that an album contains individual drawings, prints, or other art works that have been mounted, the drawings, etc. in an album may be cataloged as items and linked to the record for the volume. For intact books, manuscripts, and sketchbooks, the illuminations or other parts may be better cataloged as components rather than items. The term may also refer to a separately bound portion or division of a written work or series that is divided into two or more sections, each contained in a separate binding; generally, multiple volumes of the same work or series are of similar dimensions and contained in similar bindings. </skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Sammlung von beschriebenen oder bedruckten Blättern, die zu einem Buch gebunden wurde. Die Bezeichnung kann sich auch auf den einzeln gebundenen Teil oder Abschnitt eines schriftlichen Werks beziehen, das in zwei oder mehr Teilen erscheint, jeder in einem separaten Einband; im Allgemeinen sind mehrere Bände desselben Werks oder derselben Reihe ähnlich groß und haben einen ähnlichen Einband.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Band (document by form)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300265632</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/581612f5-e396-4859-9d37-39591c91834d">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/581612f5-e396-4859-9d37-39591c91834d</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">40</arches:sortorder>
+    <skos:altLabel xml:lang="en">Hf</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Hafnium (Hf)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/af9fcf51-bfdc-4631-82c2-b4b4f34c1df7">
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/4096365e-4fe7-412d-906c-16f3d356e8be"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/48e08437-a15d-4f0f-adfc-77c1587f17b9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Designations for streets, highways, roads, or other thoroughfares, either proper names or numeric indicators.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">thoroughfare names</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/639b8e22-9565-4fa4-92d8-50c28d1df17d">
+        <dcterms:title>Contact Point Part Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300419273</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3946b808-80f1-42a1-9521-ce27043569b8">
+    <skos:scopeNote xml:lang="de">Bezeichnet eine durch Schnitzen aus einem harten Material wie Stein oder Holz ausgeführte Figur oder ein Muster. Meist bezogen auf relativ kleinformatige Arbeiten, die Teil einer größeren Arbeit sind oder nicht als Kunst angesehen. Für große und mittelgroße dreidimensionale Kunstwerke wird der umfassendere Term “Skulptur” oder ein anderer passender Begriff verwendet.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">carvings (visual works)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Schnitzerei (Schnitzkunst)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300047203</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:scopeNote xml:lang="en">Refers to works executed by cutting a figure or design out of a solid material such as stone or wood. It typically refers to works that are relatively small in size, are part of a larger work, or are not considered art. For large and medium-sized three-dimensional works of art, use the broader term "sculpture" or another appropriate term.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0d87b5d0-1aac-456f-81e7-62c260e2293d">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300263534</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Major executive or administrative units within an organization. For major autonomous or semi-autonomous units within an organization, use "divisions (organizational units)." Use of these terms in literature, especially with regard to the official titles of organizational units, is idiosyncratic and often no consistent distinction is made.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">departments (organizational units)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f4aa6d8e-151c-4e3b-b20c-6f999d91d238">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5">
+        <dcterms:title>Relationship Labels - Project</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>https://afs.test.fargeo.com/3077e707-7e96-4370-9e88-08d38a4e6fad</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/26a58b62-1396-48f0-838f-9773a9a2c5e0">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011845</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">cuir</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:prefLabel xml:lang="en">leather</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:scopeNote xml:lang="en">The skin or hide of an animal that has been tanned to render it resistant to putrefication and relatively soft and flexible when dry. For composite material made from scrap leather pieces, use "maril."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/aa1c30cc-f0cb-4f4a-8faa-9ba2d42323f5">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/7cc462a5-db43-4b25-a748-99892eba26aa"/>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e21920ed-72ee-4e63-a9c4-98e0fd2c6811">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Nickel (Ni)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Ni</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">66</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/e21920ed-72ee-4e63-a9c4-98e0fd2c6811</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c801eaae-849a-46b4-a97e-280b59c1f2d7">
+    <skos:scopeNote xml:lang="en">General term for the method of acquiring property through transference by one person or institution to another person or institution, voluntarily and without any payment required.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/f3eca78c-7547-4ca5-a7eb-b130391b40ed">
+        <dcterms:title>Event Types - Acquisition Event</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">gift (method of acquisition)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417637</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/24381687-0e47-4418-934e-c828c7ba16eb">
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="fr">autrichienne</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Austrian</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Austria, or of the culture in central Europe in the area comprising modern Austria.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111153</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/41d71deb-c14b-46b2-b174-074c9abd5e3f">
+    <skos:prefLabel xml:lang="en">informal title</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/41d71deb-c14b-46b2-b174-074c9abd5e3f</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/80cf80fe-9e17-48da-abc4-c7bef6a26cf5">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">43</arches:sortorder>
+    <skos:prefLabel xml:lang="en">starts after publication of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/80cf80fe-9e17-48da-abc4-c7bef6a26cf5</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1b04db65-66ba-4066-8acb-7dc0c672120a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/f24f177f-9849-48d9-ba67-621d577f71e9">
+        <dcterms:title>Identifier Types - Modification Event</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/deb7b57d-3b11-4e62-866f-b48cb12a4dbe">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">digital resource part of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/deb7b57d-3b11-4e62-866f-b48cb12a4dbe</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9a887cba-44fe-49b1-a36c-c517ab107a94">
+    <skos:prefLabel xml:lang="en">influence on part removal event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/9a887cba-44fe-49b1-a36c-c517ab107a94</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d529cea0-16fb-4c03-85e2-eb37bd499fc0">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/d529cea0-16fb-4c03-85e2-eb37bd499fc0</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Te</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Tellurium (Te)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">102</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3437adbb-97df-463a-b1c6-65ffaaf28414">
+    <skos:altLabel xml:lang="en">Ti</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">109</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Titanium (Ti)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/3437adbb-97df-463a-b1c6-65ffaaf28414</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3edc9a03-36c6-4b6a-8c19-3a626f5a0b7d">
+    <skos:scopeNote xml:lang="en">The process of removing an outer layer of material.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">stripping</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053712</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c4dae3ab-0d29-48ab-80e9-a92877edaeed">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dca6a321-3ab9-42bc-ac80-2171789ae205"/>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7c182fc3-2385-4e1c-9a2e-f3f21d6daf06">
+    <skos:prefLabel xml:lang="en">source reference for formation of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/7c182fc3-2385-4e1c-9a2e-f3f21d6daf06</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cf73b0a9-ecca-471c-ade9-e4fbcd404f63">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025820</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">conservation scientists</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/db261e02-be27-4a99-b9c1-875375103a1d">
+        <dcterms:title>Person Types - Profession</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Scientists who apply their knowledge to problems of conservation.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d83c4324-a95c-4a6b-930c-039b10def890">
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">45</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1eac353d-05b0-4291-bb48-4c98e2887de3">
+    <skos:prefLabel xml:lang="en">classification (category)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435444</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Indication of the placement of a work of art or architecture within a classification scheme that groups other, similar works together on the basis of similar characteristics</skos:scopeNote>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d">
+        <dcterms:title>Statement Types </dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1c55bd47-1895-4c3e-ba40-3dc0084cad2d">
+    <skos:prefLabel xml:lang="en">braccia</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">An historical Italian unit of length, equal to approximately 26/27 inches (66/68 cm), however usage varies.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404161</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c54f3642-9f8d-475d-8c6d-b82fc4b5b853">
+    <skos:prefLabel xml:lang="en">full names (personal names)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404688</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663">
+        <dcterms:title>Name Types - Personal</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Names for people, places, or things that are the fullest version of the name. For personal names, includes the first name, one or more middle names, one or more family names and last names, suffixes, and honorfics.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/582ce144-b5a7-4b1b-883f-163f323d3a66">
+    <dcterms:identifier>https://afs.test.fargeo.com/582ce144-b5a7-4b1b-883f-163f323d3a66</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:prefLabel xml:lang="en">observation procedure used in</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dd16dc11-132f-4d9a-96ed-9072f322257e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">100</arches:sortorder>
+    <skos:altLabel xml:lang="en">Ta</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Tantalum (Ta)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/dd16dc11-132f-4d9a-96ed-9072f322257e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8c1595e4-6f8e-434c-9f65-e1c3589c3f72">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">95</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/8c1595e4-6f8e-434c-9f65-e1c3589c3f72</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Silicon (Si)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Si</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/64136ae8-03ed-41fa-afe4-8a3408bd34b9">
+    <skos:prefLabel xml:lang="en">Indian (South Asian)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Nationality, styles, and culture of the modern nation of India, or more broadly to cultures that developed on the subcontinent of India, which is bounded by the Arabian Sea, the Indian Ocean, the Bay of Bengal, and the Himalayn Mountains. It may also refer even more broadly to cultures of India, the East Indies, and the former British Indian Empire. It was formerly used less specifically to refer to any Oriental or Asian culture. Do not use this term to refer to the indigenous populations of North or South America; see "Native American" or other appropriate terms.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300018863</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">indienne</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d9c6e689-f74b-4494-b8d4-cd6cc78297c9">
+    <skos:inScheme rdf:resource="http://localhost:8000/db261e02-be27-4a99-b9c1-875375103a1d"/>
+    <skos:prefLabel xml:lang="de">Konservator</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">conservators (people in conservation)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300102842</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">People responsible for treatment, preventive care, and research directed toward the long-term safekeeping of cultural and natural heritage. For those engaged in making changes to an object or structure in order to prevent further deterioration, see "preservationists." For those who make changes to an object or structure so as to closely approximate its state at a specific time in its past, see "restorers."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9961937d-eaeb-431b-9190-9e17eaebb688">
+    <skos:prefLabel xml:lang="de">druckgraphischen Blättern</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300041273</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">prints (visual works)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">gravures (général, œuvres visuelles)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Pictorial works produced by transferring images by means of a matrix such as a plate, block, or screen, using any of various printing processes. When emphasizing the individual printed image, use "impressions." Avoid the controversial expression "original prints," except in reference to discussions of the expression's use. If prints are neither "reproductive prints" nor "popular prints," use the simple term "prints." With regard to photographs, prefer "photographic prints"; for types of reproductions of technical drawings and documents, see terms found under "reprographic copies." </skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e8a9a948-1cc2-452f-bd4b-33b1d84e899d">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697">
+        <dcterms:title>Person Types - Genders</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Designates the state of a person or persons that do not identify as belonging to any particular gender.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300438735</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">agender</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/71f2308c-6d7e-423d-8d23-17a0df059a75">
+    <skos:prefLabel xml:lang="en">ounces (units for weight)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Units of weight equal to 1/16 of a pound avoirdupois (approximately 28 grams). Originally equaled 1/12 of a pound in troy and apothecaries' measure, equal to 480 grains (approx. 31.1 grams).</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379229</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6195ff8c-5970-41b6-9480-e92ce21dc0df">
+    <skos:prefLabel xml:lang="fr">hébreu</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388401</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Hebräisch</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Hebrew (language)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/24f2475d-0bcf-4f7c-a8c2-de2e60e7b333">
+    <skos:prefLabel xml:lang="fr">calligraphie</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300266660</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Works composed primarily of beautiful, elegant letters or flourishes that are typically created by hand with a pen, either in unjoined characters or in cursive writing. May also refer to similar works created by computer or another means.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Kalligraphie (Visuelles Werk)</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Werk, das hauptsächlich aus schönen, eleganten Buchstaben oder Schnörkeln gebildet ist, die gewöhnlich von Hand mit einem Schreibstift geschaffen wurden, entweder mit unverbundenen Buchstaben oder in kursiver Schreibschrift. Kann sich auch auf ähnliche Werke beziehen, die mit dem Computer oder anderen Mitteln geschaffen wurden.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">calligraphy (visual works)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0c9c8887-e4fb-480a-9cf0-9506b9650d40">
+    <skos:inScheme rdf:resource="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404656</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">nicknames</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Names or appellations that are given to a person, animal, or place as a familiar or humorous replacement for, or addition to, the proper name.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d7e6019e-f5fb-4d05-b563-f37d13747883">
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fd2e3734-ce0c-45ce-9498-f542d482cad4">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/fd2e3734-ce0c-45ce-9498-f542d482cad4</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Bismuth (Bi)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Bi</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5f9d4f70-ca98-4ff1-9c73-52877fbf83c3">
+    <skos:scopeNote xml:lang="en">Heritage science refers to all applications of science for the general study of cultural heritage, tangible and intangible; a cross disciplinary research domain including humanities and sciences, such as the natural, social, and formal sciences. In particular, heritage science focuses on issues such as promoting access to cultural heritage, its interpretation, conservation, and management.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417282</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">heritage science (cultural heritage discipline)</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/b3d6e036-e788-4c85-a1f0-3aa35f0a82f2">
+        <dcterms:title>Event Types - Professional Activity</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4f32380a-61fe-4b93-8620-ebfe2d54e66a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/cd093911-f1e1-4abb-bbb2-fcaea3ca03ab</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <skos:prefLabel xml:lang="en">location</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1ffe97e4-1822-4a6e-b170-861330764bbd">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/b5dfd5e3-779d-4b94-8552-c539e352fd68">
+        <dcterms:title>Personal Name Part Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">In the context of personal names, particularly in western culture, names that are positioned between a first name and a last name, possibly comprising an additional familiar name or a maternal family name. In other traditions, such as Islamic tradition, the middle name may be the primary personal name (analogous to the first name in western tradition) or another sort of name.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">middle names</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404654</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7156f8e2-d534-4f02-8f31-71f9a9a3a4aa">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300265866</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">A contraction of "binary digit," bits are units of information that represent either a zero or one, on or off, and are the smallest elements a computer is able to process.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">bits (computing)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b55dcf94-3e0d-4d33-af82-9262dc4e2e0f">
+    <dcterms:identifier>https://afs.test.fargeo.com/b55dcf94-3e0d-4d33-af82-9262dc4e2e0f</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of publication event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fbdfbed1-f686-47ce-b97d-10693d9a5901">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Brief statements of a fact or experience, written down for review, or as an aid to memory, or to inform someone else; also includes short, informal letters.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">note</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Kurze Angabe über eine Tatsache oder ein Erlebnis, niedergeschrieben zur Überprüfung oder als Erinnerungshilfe, oder um jemand anderen zu informieren; schließt auch kurze, formlose Briefe mit ein.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027200</dcterms:identifier>
+    <skos:altLabel xml:lang="de">Notiz (Dokumentengattung)</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/52c977b9-3ee6-415c-ad88-70e01c72fd38"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2f29e8ea-4d05-4995-8682-8ef84584a1a5">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Pd</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/2f29e8ea-4d05-4995-8682-8ef84584a1a5</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">74</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Palladium (Pd)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e683fc2f-c24f-4cad-9e52-582f960de82e">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379372</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Detailed examination principles and empirical processes of discovery and demonstration considered characteristic of scientific investigation, generally involving the observation, formulation of a hypothesis, experimentation, and development of a conclusion.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">scientific analysis</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/3a8e8388-0bb9-42f2-bc77-fc5a1c640589">
+        <dcterms:title>Method Types - Observation Technique</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b0eabbd6-16ea-41c4-bc1a-b36b6ea02d5e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d"/>
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3789dcf2-e752-4a70-8507-8c3ca1e3804c">
+    <skos:scopeNote xml:lang="en">Documents comprising texts that are relatively short in length, sometimes but not always abbreviated versions of longer texts.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">brief text</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9">
+        <dcterms:title>Statement Types - Digital Resource</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300418049</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0ce70c72-c0c8-4b2d-86af-39821d6a3d07">
+    <skos:prefLabel xml:lang="en">teams</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300248011</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+    <skos:scopeNote xml:lang="en">Groups of two or more people or animals functioning as a collaborative unit in some joint action, such as a sport, game, project, or task.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2a343ae1-3e8d-43f7-a84e-fbf38dcda817">
+    <dcterms:identifier>https://afs.test.fargeo.com/2a343ae1-3e8d-43f7-a84e-fbf38dcda817</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location of professional activity of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d0705d15-91a1-4ac3-b298-94a554b5ef77">
+    <skos:prefLabel xml:lang="en">ULAN</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/d0705d15-91a1-4ac3-b298-94a554b5ef77</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/47ca47bd-3aef-48eb-86c0-ce5895098b26">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264383</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the process or branch of fine art concerned with creating sculpture, which are three-dimensional works. It refers particularly to carving or engraving a hard material, or with molding or casting a malleable material, so as to produce designs or figures in relief, in intaglio, or in the round. It is typically used to refer to the production of large or medium-sized objects in stone, clay, or bronze. The production of small objects in bronze or stone is typically referred to by a specific term, such as "stone carving" or "die sinking." The production of sculpture in wood or ivory is typically referred to as "carving," even though the finished work in these materials may be called "sculpture (visual work)."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">sculpting</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b65471e5-4a52-4fd5-8bd2-73eb0e98f029">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/b65471e5-4a52-4fd5-8bd2-73eb0e98f029</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">refers to</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4649d0f2-ad6c-4905-a24e-8d784c2cbc48">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055649</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/c9e838f8-7660-4701-821c-721dac98a10b"/>
+    <skos:prefLabel xml:lang="en">volume (quantity or mass)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The quantity or mass of an object or material that occupies space.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa563901-745f-4edf-b1d4-26b24508e362">
+    <skos:scopeNote xml:lang="en">General term for units of currency based on gold coins of France issued in the reign of Louis XIII and subsequently till the time of Louis XVI.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">louis (unit of currency)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412166</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3b5b53d3-bc3b-4b94-bbce-b435cbb8d210">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Calcium (Ca)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/3b5b53d3-bc3b-4b94-bbce-b435cbb8d210</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Ca</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/27a55f27-4725-4440-bfd3-725cdebbf2ed">
+    <skos:prefLabel xml:lang="fr">cire (wax)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">37</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300014585</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">wax</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Any solid or semi-solid substance that is slightly greasy to touch, usually solid, translucent, and has a low melting point; waxes are not a chemically homogeneous group. Waxes are composed of long chain hydrocarbon compounds, and may contain esters of fatty acids and alcohols, are thermoplastic and melt at low temperatures of between 40 and 100 C. In general, waxes are water-repellent, smooth, soluble in organic solvents, and classified as animal (e.g., beeswax), vegetable (e.g., bayberry), mineral (e.g., paraffin), or synthetic (e.g., polyethylene). Waxes are used for polishes, candles, crayons, sealants, coatings, adhesives, waterproofing, carbon paper, media in encaustic and wax emulsion paintings, and as repellents in wax-resist watercolor paintings.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/54a65679-78fc-483a-81ef-0f760ab2c467">
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011727</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">chalk</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">A fine-grained limestone, or soft, earthy form of calcium carbonate; used chiefly in putty, crayons, paint, rubber products, linoleum, and as a pigment and abrasive.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/24b976c1-14c5-4606-a686-08f7d5fb8e7c">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">peinture-émail</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">enamel paint</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300147678</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Paint made from oil, resin, varnish, or a combination of these, mixed with finely ground pigment; usually giving a glossy finish, but sometimes giving a semigloss or flat finish.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cddda87a-6281-4547-a2e0-4047994836c8">
+    <skos:scopeNote xml:lang="en">In the sciences, taking of samples for technical analysis.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379429</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">sampling</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/8b7faa16-3846-4360-b767-bb2c823b6550"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f903e2b8-5579-4159-b28d-9d8544c88c4b">
+    <skos:prefLabel xml:lang="en">issues (object groupings)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:scopeNote xml:lang="en">All examples of a set number or amount of multiples, such as coins, notes, stamps, prints, copies of a newspaper, books, periodicals, etc. that were issued at one time or otherwise sharply distinguished in pattern, design, color, or identifying numbers from those issued at another time.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300312349</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ce4ffb8a-597e-47c5-8d60-96f17fc92bb3">
+    <dcterms:identifier>http://localhost:8000/ce4ffb8a-597e-47c5-8d60-96f17fc92bb3</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/1230c0d7-ed5b-4f97-b54d-74bda170c7e3">
+        <dcterms:title>Object Types - Digital Object Service</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">map service</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bd10b3df-47fc-49fb-a459-108f9cd60d16">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">dissolution event period</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/bd10b3df-47fc-49fb-a459-108f9cd60d16</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a9590301-77dc-4b3d-aa36-d669d1e338e3">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054698</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Forming or producing letters to record the ideas which characters and words express or to communicate the ideas by visible signs.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">writing (processes)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/de10c1c8-a3a4-43e0-8afc-43720a9ad3a9"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0b9b05f5-9b5b-44ab-8090-98e195953043">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027201</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Feldnotiz</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Notiz, häufig in einem Buch, die von Forschern oder Landvermessern niedergeschrieben wird, während sie vor Ort sind.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Notes, often in books, kept by researchers or surveying parties while on site.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">note de terrain</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">field notes</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d">
+        <dcterms:title>Object Types - Textual Work</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3787d26c-11a1-447c-8a71-74b862714f5f">
+    <skos:scopeNote xml:lang="en">Refers to groups of archaeological artifacts found in association with each other, as from one level, activity area, or site, regardless of their material or type. </skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Bezieht sich auf eine Ansammlung archäologischer Fundstücke, die zusammen gefunden wurden, entweder in einer Schicht, einem Arbeitsbereich oder einer Fundstelle, ungeachtet des Werkstoffes oder der Typologie.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Fundkomplex (Objektgruppe)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300256847</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">assemblages (archaeological artifacts)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c84d1624-d004-4640-9653-6a6cd99c32e2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411837</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">feminine</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Having chracteristics, qualities, attributes, or actions associated with the female sex.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/750f96bf-bea6-4034-b424-015be432f738">
+    <skos:prefLabel xml:lang="fr">base de données</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Datenbank</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Elektronisch gespeicherter, strukturierter Datensatz, insbesondere solcher mit integrierter Software, die ihn auf vielfältige Weise verfügbar macht. Eine Datenbank wird verwendet, um Informationen zu speichern, sie abzufragen und wiederaufzufinden, besteht typischerweise aus einer Sammlung logisch zusammenhängender Informationen, die als Einheit verarbeitet, in maschinenlesbarer Form gespeichert und als Datensätze organisiert und strukturiert werden, welche in einem standardisierten Format vorliegen, um mit Hilfe eines Computers schnelles Durchsuchen und Finden zu ermöglichen.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971"/>
+    <skos:prefLabel xml:lang="en">databases</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Structured sets of data held in computer storage, especially those that incorporate software to make them accessible in a variety of ways. A database is used to store, query, and retrieve information, typically comprising a logical collection of interrelated information that is managed as a unit, stored in machine-readable form, and organized and structured as records that are presented in a standardized format in order to allow rapid search and retrieval by a computer.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028543</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c1046e53-a3c7-4e1e-b9a3-5051b5fb2e33">
+    <skos:scopeNote xml:lang="en">Strings of characters that uniquely identify a location on the internet or other network to which email can be sent; the email address is typically a point of contact for a particular individual or organization.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435686</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">email addresses</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/92d3e507-9d66-4122-9cd6-36430cf36e3c">
+        <dcterms:title>Name Types - Contact Point</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8e08ccab-5aea-4d44-9b89-9e0834aa8390">
+    <skos:prefLabel xml:lang="en">Copper (Cu)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/8e08ccab-5aea-4d44-9b89-9e0834aa8390</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Cu</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bf2a55ff-b9c6-4216-bb96-172825edef68">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300375748</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:scopeNote xml:lang="de">Sammlung historischer Aufzeichnungen und anderer Primärquellen, die im Lauf des Lebens eines Individuums oder einer Institution entstanden sind und erhalten wird, um die Funktion oder Geschichte der Person oder der Einrichtung zu dokumentieren. Die Dokumente können materiell oder digital vorliegen.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Collections of historical records and primary source documents that have accumulated over the course of an individual's or organization's lifetime, and are kept to show the function or history of the person or an organization. Documents may be tangible or digital.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Archiv (Objektgruppe)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">archives (groupings)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1e4e1d74-2c6b-4a09-adb9-fd1b314584e7">
+    <skos:prefLabel xml:lang="en">Digital Object Identifier (DOI)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417432</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Unique alpha-numeric strings assigned by a regsitration agency to identify content and provide a persistent link to a location on the Internet.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dad241d2-175c-4319-bcf9-c1ba70bda7e6">
+    <skos:prefLabel xml:lang="en">Neon (Ne)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/dad241d2-175c-4319-bcf9-c1ba70bda7e6</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">64</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Ne</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4b2ed1f9-3b31-47c1-975e-1e114f0fe099">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">shipping</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/4a4050e9-00a8-42f5-9c7e-cf754060cd95">
+        <dcterms:title>Event Types - Move </dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Process of transporting goods sending goods to people, stores, or other destinations.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053899</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/98e0163b-7e26-4d1b-9b2e-1c5f289b5ea0">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Moscovium (Mc)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/98e0163b-7e26-4d1b-9b2e-1c5f289b5ea0</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Mc</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">62</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b404f414-7aef-403b-a04d-300b2df8a884">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+    <skos:altLabel xml:lang="en">Eu</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/b404f414-7aef-403b-a04d-300b2df8a884</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Europium (Eu)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/96f82847-9d23-4abb-ac9c-18050223bd8a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/61dfad8f-cd46-47fd-820f-3e69ac423cc6">
+    <skos:prefLabel xml:lang="en">causally relevant to creation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/61dfad8f-cd46-47fd-820f-3e69ac423cc6</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/903c4a8b-4051-4791-9ee9-9fd96e222117">
+    <skos:prefLabel xml:lang="en">thaler (unit of currency)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412168</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">General term for units of currency based on various large silver coins of Central Europe minted from the late 15th to the mid-19th century.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fe766393-d00d-463e-b706-4ca9ad772b7d">
+    <skos:scopeNote xml:lang="en">Instruments that measure color by comparing a given color to a standard color, a scale of colors, or certain combinations of primary colors.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Gerät zur Farbmessung, das eine gegebene Farbe mit einer Standardfarbe, einer Farbskala oder bestimmten Kombinationen von Primärfarben vergleicht.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300196006</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb">
+        <dcterms:title>Means Types - Object Used</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">colorimeters</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">colorimètre</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Kolorimeter</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/72006c28-5bee-4c31-9b64-64d06ca3ab8b">
+    <skos:prefLabel xml:lang="en">découpage (image making technique)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The technique of decorating surfaces with cut-outs of paper, linoleum, plastic, or other flat material, over which a finish is applied.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300262913</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc">
+        <dcterms:title>Event Types - Visual Work Creation Event</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c03ea5ca-3d96-4357-bf29-0e81aafd7674">
+    <skos:scopeNote xml:lang="en">Hypertext documents of text or images that are accessible via the World Wide Web, hosted on a web site.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971"/>
+    <skos:scopeNote xml:lang="de">Hypertextdokument mit Text oder Bildern, das über das World Wide Web abrufbar ist und auf einer Website gehostet wird.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264578</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Webseite</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Web pages (documents)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa1a87ca-74cb-45aa-84a1-30ba3363df29">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/a7e17177-c533-4027-a66a-0c4fe961d7fc">
+        <dcterms:title>Identifier Types - Instrument</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/89d67de0-53ea-464e-8a28-448e6c267d87">
+    <skos:inScheme rdf:resource="http://localhost:8000/92d3e507-9d66-4122-9cd6-36430cf36e3c"/>
+    <skos:scopeNote xml:lang="en">Phone numbers connected to a fax machine, fax service, or fax server, rather than to a voice telephonic device.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435689</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">fax numbers</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d51ffccd-e187-4894-bd14-18c862f92cd6">
+    <skos:scopeNote xml:lang="de">Gruppe von separaten bibliographischen Objekten, miteinander in Beziehung stehend,durch die Tatsache, dass jedes zusätzlich zu seinen eigenen Titel einen Sammeltitel für die Gruppe als Ganzes enthält; sie werden sukzessive herausgegeben; in der bildenden Kunst wird der Begriff für eine Gruppe von Werken eines einzelnen Künstlers verwendet, die eine spezifische und sinnhafte Beziehung zwischen den Arbeiten besitzen.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">A conceptual grouping of visual arts works, literary works, or performance art created in succession by the same author, artist, or studio and intended by the creator(s) to be seen together or in succession as a cycle of works. Works in a series typically share the same or related subjects, the same or similar media, or other characteristics, but their defining characteristic is that they were intended to be conceptually related as a series. Individual items in a series may be cataloged separately and linked to the series. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">series (object groupings)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027349</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Serie (Gruppe)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">série</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/854d0bd9-4dd1-483c-900f-f67c0e73d438">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/ca9e81f3-471d-4d1f-b323-edc816b1c522">
+        <dcterms:title>Identifier Types - Visual Work</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5d9da344-2f3a-4f35-a5cd-3cb3f4a3535c">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300019195</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Laotian</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to the style associated with Laos located in the valley of the Upper Mekong. The hybrid style reflects Myanmar, Thai, and Khmer influences. The basis of the artistic style of this region is religion and tradition, characterized by Buddhist and Hindu iconography and narrative relief panels rooted in Theravada Buddhist and Hindu principles. Folk arts in this style feature basket making, wood and ivory carvings, and silver and gold works. In architecture, the style features temples patterned after Khmer temple mountains with sloping, stepped roofs comprised of small flat tiles, and the wihan, a rectangular building containing an altar with Buddhist images. In sculpture, the style is mostly devoted to the representation of Buddha in royal attire. Sculpture is constructed in bronze, lacquered wood, and sometimes stone and is adorned with inlaid glass or mother-of-pearl. Bas-relief sculpture is rare and is mostly found as wood murals, though mural scenes in lime mortar, stucco, or cement exist. Textile arts in the style feature silk cloth with ikat and weft designs that include dot patterns, geometric and zoomorphic motifs.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4916b590-691a-4bcd-9fdd-bcc756484682">
+    <skos:scopeNote xml:lang="en">Recorded information, often standardized in format and content and treated as a unit. Records include such compilations of data regardless of medium, that are created, received, and maintained by a project, agency, institution, organization, or individual in pursuance of legal obligations, in the transaction of business, for the storage of research and knowledge, or for other purposes.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Aufgezeichnete Information, nicht an ein bestimmtes Medium gebunden; produziert, empfangen und geführt von einer Behörde, Institution, Organisation oder Einzelperson, um gesetzlichen Verpflichtungen nachzukommen oder zur Aufrechterhaltung des Geschäftsbetriebes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Akte</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">records (documents)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026685</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2e51a0c5-67a5-4be3-b2a9-6241b671cc1f">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/2e51a0c5-67a5-4be3-b2a9-6241b671cc1f</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">86</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Rhodium (Rh)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Rh</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/63e4f894-576a-4035-aa8b-f4b392efd20f">
+    <skos:prefLabel xml:lang="en">source reference work for publication event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">41</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/63e4f894-576a-4035-aa8b-f4b392efd20f</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/907fce8b-2b57-44ee-bd98-d40aa28abd77">
+    <dcterms:identifier>https://afs.test.fargeo.com/907fce8b-2b57-44ee-bd98-d40aa28abd77</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">modified by</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/67ee8af0-c9a0-4e1d-8f2b-19b35fcb57e6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Collections of library materials separated from the general collection because they are rare and valuable materials, such as prints and drawings, or they are of a certain form, subject, period, etc.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300311990</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Sondersammlung (Sammlung)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">special collections</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Sammlung, die in einer Bibliothek vom allgemeinen Bestand gesondert aufbewahrt wird, weil es sich entweder um seltenes und besonders wertvolles Material wie beispielsweise Drucke und Zeichnungen oder um ein spezielles Sammelgebiet (Thema, Periode, Medienform etc.) handelt.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/70847092-39b5-4620-97ed-2ec6e1a14c21">
+    <dcterms:identifier>https://afs.test.fargeo.com/70847092-39b5-4620-97ed-2ec6e1a14c21</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <skos:prefLabel xml:lang="en">period of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ac2a0b23-c92f-482e-8f55-292386f66b86">
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+    <skos:scopeNote xml:lang="de">Bericht mit den Details und Ergebnissen einer Untersuchung über ein wissenschaftliches oder technisches Problem.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Technischer Bericht</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Reports giving details and results of a specific investigation of a scientific or technical problem.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027323</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bc2b7ddc-7e71-479b-b89d-50c00794bae7">
+    <skos:altLabel xml:lang="en">Zr</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">117</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Zirconium (Zr)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/bc2b7ddc-7e71-479b-b89d-50c00794bae7</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/eda33b72-4404-49fc-8cff-98383ff47234">
+    <skos:prefLabel xml:lang="en">livre (unit of currency)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412165</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:scopeNote xml:lang="en">General term for any of a number of monetary in use in France between the 8th and 18th centuries.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/411b634d-3ead-498c-9b30-29f0512e9771">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412001</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Swiss franc (system of money)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The standard unit of currency of Switzerland.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f208062a-4a4f-4d7d-bfc3-673e5c506a3c">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d3e16385-0bb4-4940-b9b7-780d305d1592">
+    <skos:prefLabel xml:lang="en">source reference for professional activity of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/d3e16385-0bb4-4940-b9b7-780d305d1592</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5bd94b1d-b8b0-44fb-8e1a-fab715b2e8d0">
+    <skos:scopeNote xml:lang="en">Information about the dimensions, size, or scale of the work, presented in a syntax suitable for display to the end-user and including any necessary indications of uncertainty, ambiguity, and nuance. It may include the scale of the work. It may also include the number of the parts of a complex work, series, or collection. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">dimensions description</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435430</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f396443b-2e35-44e3-8887-8bbb39f6b44a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055147</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/c82d6f85-ae67-4c28-b07a-c114f6d6ba50">
+        <dcterms:title>Meta Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Pattern of attitudes and behavior that in any society is deemed appropriate to one sex rather than another. For the concept of physiological traits that distinguish the males and females of a species, use "sex." For the sum of an individual's sexual emotions, ideas, and behavior, use "sexuality."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">sex role</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e7c365a4-aa13-41ea-870a-64780dfb3d39">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379769</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31"/>
+    <skos:prefLabel xml:lang="en">extracting (subtractive process)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Signifies the act of drawing forth a material from that which holds it.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/85c8889f-d85f-41e4-8e3c-69644d98bee9">
+    <skos:altLabel xml:lang="en">Br</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/85c8889f-d85f-41e4-8e3c-69644d98bee9</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Bromine (Br)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f7df4fa5-f302-410e-9855-2c1283338846">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">66</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">physical object used in set removal event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/f7df4fa5-f302-410e-9855-2c1283338846</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/44a26d59-7aec-4a10-b042-5a9e20fbea1c">
+    <skos:prefLabel xml:lang="en">period of set removal event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/44a26d59-7aec-4a10-b042-5a9e20fbea1c</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">52</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/11378278-d14a-49c7-afe6-3a7fbb60f347">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054216</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/c372cf0b-f0f4-4730-a97d-c892dfbefcd7">
+        <dcterms:title>Profession Technique</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The art and practice of applying pigments suspended in water, oil, egg yolk, molten wax, or other liquid to a surface to create an expressive or communicative image. Paint is usually, but not always, applied with a brush. For the application of paint primarily to protect a surface or add a general color, use "painting (coating)."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">painting (image-making)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d2345f0c-b4e8-4190-b199-cbf283f405f5">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:prefLabel xml:lang="en">modification used in</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/d2345f0c-b4e8-4190-b199-cbf283f405f5</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f95cba70-7ad2-4ce9-a4dd-9f87085b2e15">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e6c99d74-08b7-42c3-b663-978873bb3865">
+    <skos:prefLabel xml:lang="de">Österreichischer Schilling</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <skos:scopeNote xml:lang="en">Austrian unit of currency 1925-2002, with a lapse during WWII. It was replaced by the Euro as the country’s sole currency in 2002. </skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412158</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Austrian Shilling (system of money)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2f4c6357-f437-4948-9a7c-78350dfe37b8">
+    <skos:prefLabel xml:lang="en">source reference for group leaving event of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/2f4c6357-f437-4948-9a7c-78350dfe37b8</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">40</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6f91f3d7-bb19-4d23-9ba4-e18d37825054">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300189604</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">folios (leaves)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The individual leaves of a book or manuscript numbered on the recto only. The two sides of the folio are typically numbered using 'r' for recto, meaning the front or righ-hand page, and 'v' for verso, meaning the back or left-hand side. Reference to a folio is distinguished from reference to a "page" in that a page is numbered on both sides.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3966ec93-968e-4f31-a38b-75adadc09c3c">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300024979</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Members of the species Homo sapiens and their close extinct relatives, as distinguished from other animals, spirits, or other entities.</skos:scopeNote>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/273d0839-8911-468f-9eb1-b0cc3507b6e7">
+        <dcterms:title>Visual Work Types - Subject Depicted</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">people (agents)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f73e0b59-f329-4b8f-932e-7c9426567c2c">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027483</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Buch, in das finanzielle Transaktionen eingetragen werden. </skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Geschäftsbuch</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Books in which financial accounts are kept.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">account books</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/60c464bb-9a23-4a83-b18f-3babcc25b87e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">48</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of production of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/3e308dfd-eb14-4ecf-842f-7a37c1baf89c</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/14e00b4d-126d-4b88-a9fa-76a6ae5dd089">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/14e00b4d-126d-4b88-a9fa-76a6ae5dd089</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:prefLabel xml:lang="en">occurs before creation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/102d6dc8-5a56-418e-afbf-799398a37ba8">
+    <skos:prefLabel xml:lang="en">headings</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/fd0222dd-bd50-4597-b092-d124833176b3"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">In the composition of pages, matter set apart from the text as a title or a summary of the text that follows.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300200862</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f3f82fdc-b944-44d3-ad88-bdae0bf97b74">
+    <skos:prefLabel xml:lang="en">source reference work for curation event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/f3f82fdc-b944-44d3-ad88-bdae0bf97b74</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e844ea45-fb8c-43e1-bf5d-34dda5575c14">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/e844ea45-fb8c-43e1-bf5d-34dda5575c14</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">parent physical object</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">42</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/541c4e7c-8a87-4604-804a-76b85b4948cd">
+    <dcterms:identifier>http://localhost:8000/541c4e7c-8a87-4604-804a-76b85b4948cd</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/641c4612-732b-48c3-b958-3af2c5c3f647">
+        <dcterms:title>Method Types - Creation Technique</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">uploading</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0a14e5d4-2bde-46ad-9eed-e888bab1e53b">
+    <skos:altLabel xml:lang="en">Li</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Lithium (Li)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/0a14e5d4-2bde-46ad-9eed-e888bab1e53b</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">53</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/299a2526-ed43-4578-ab31-aca6ab0b4a2f">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412167</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">General term for units of currency based on English silver or cupronickel coins valued at twelve pence and minted from the mid-16th century until 1970.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">shilling (unit of currency)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f29c3f29-101a-4e82-95bb-cdd7008e27af">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300033618</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Gemälde</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:prefLabel xml:lang="fr">peintures (visual works)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:prefLabel xml:lang="en">paintings (visual works)</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Individuelles Werk, bei dem die Darstellungen hauptsächlich durch das direkte Auftragen von Farbstoffen gebildet werden, die in Öl, Wasser, Eigelb, geschmolzenem Wachs oder anderer Flüssigkeit aufgelöst sind und bei dem die Farbmasse auf eine meist zweidimensionale Oberfläche aufgetragen wird. </skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Unique works in which images are formed primarily by the direct application of pigments suspended in oil, water, egg yolk, molten wax, or other liquid, arranged in masses of color, onto a generally two-dimensional surface.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ac3c260d-a77a-4ebb-8281-43282e53f0d2">
+    <skos:scopeNote xml:lang="en">Identifying numbers assigned to a telephone or group of telephones; the numbers are dialled in order to make a connection to telephonic devices.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/92d3e507-9d66-4122-9cd6-36430cf36e3c"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435688</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">telephone numbers</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c19556af-cfb1-49f1-a014-1ef2ccaa4208">
+    <dcterms:identifier>https://afs.test.fargeo.com/49961e2c-7ee0-4989-bae4-385e47472ef0</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">55</arches:sortorder>
+    <skos:prefLabel xml:lang="en">used in professional activity of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/210c4d7a-e17a-4f3d-b684-bf8cd803dcfa">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/db261e02-be27-4a99-b9c1-875375103a1d"/>
+    <skos:scopeNote xml:lang="en">Persons who superintend or manage the collections, exhibitions, research activities, and personnel of a museum, art gallery, zoo, or other place of exhibit; also, the superintendents or managers of a single collection or subject of study in such an institution.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025633</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">curators</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4895c70f-fb12-4412-84d5-86abe742cb30">
+    <skos:prefLabel xml:lang="en">Chlorine (Cl)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/4895c70f-fb12-4412-84d5-86abe742cb30</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Cl</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/17060cf6-23de-457f-b98f-8bce7b99d325">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/17060cf6-23de-457f-b98f-8bce7b99d325</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital document</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/aea93315-18f4-4ee5-9a13-549f27e88c1e">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Berkelium (Bk)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/aea93315-18f4-4ee5-9a13-549f27e88c1e</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Bk</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/61a740d5-03dd-460a-8b45-6ae438b4c352">
+    <skos:prefLabel xml:lang="en">influence on publication event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/61a740d5-03dd-460a-8b45-6ae438b4c352</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/aaf58bb4-82c4-4aa6-b8c0-7755018217eb">
+    <skos:prefLabel xml:lang="en">location of production of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/aaf58bb4-82c4-4aa6-b8c0-7755018217eb</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/02040456-2800-4934-9a95-70b2af7e8966">
+    <skos:inScheme rdf:resource="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404686</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">official names</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Names for people, places, or things that are legal or otherwise formally sanctioned.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7860b0f4-b777-40e9-a320-6dde997fe2d6">
+    <skos:inScheme rdf:resource="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e"/>
+    <skos:prefLabel xml:lang="en">kilobytes</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">A unit of measure for information or computer storage representing 1024 or 1000 bytes. The most commonly referred to unit of computer file size.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300265870</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8c59ec9a-c7df-4c52-9104-6b7de8ee8151">
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <skos:prefLabel xml:lang="en">Vietnamese (culture or style)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to the cultures that developed in the region situated along the eastern coast of the Indochinese Peninsula known as modern North and South Vietnam. Artistic production in this region features a broad scope and an intermingling of styles, featuring dynastic temple construction that included variations of tower shrines, sanctuaries, porticoes, molded capitals, and recesses, and grandiose and refined sculptural programs featuring monster figures that decorated corners of architraves, figures of lions, solid snake-like ornamentation reminiscent of Indo-Khmer foliage motifs and Dong Song styles, and large icons and relief panels carved in sensual styles suggestive of Chen-la works. From the 15th through 18th centuries, architectural planning incorporated Confucian and Taoist elements and sculptural styles of this period feature elaborately-colored woodwork based upon the dragon-and-cloud decoration of the Ming and Ch'ing Dynasties of China.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300019239</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0109a0a0-5016-4f77-aad1-54c8f230c6f1">
+    <dcterms:identifier>https://afs.test.fargeo.com/2e0fefb8-7556-4ffb-b946-e3546bac2e72</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">actor in</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bf289514-b63e-46e6-9575-ac40d643f5e7">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/bf289514-b63e-46e6-9575-ac40d643f5e7</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">parent place</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/83da6018-d9b0-4524-a239-e8e02bdef92a">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <skos:prefLabel xml:lang="en">actor carrying out sampling activity</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/83da6018-d9b0-4524-a239-e8e02bdef92a</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e05856b0-bc90-4ce5-9ea4-b6a891adfecb">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">35</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location of set addition event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/e05856b0-bc90-4ce5-9ea4-b6a891adfecb</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fbb90342-3b1d-4fc9-835b-85f0c0c29268">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404764</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The originating cause or substance of some material thing or physical agency, or the conceptual inspiration for a conceptual thing.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b"/>
+    <skos:prefLabel xml:lang="en">sources (general concept)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5f550e54-3649-4c9d-b538-5e039e749572">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/814cfe88-8330-43b7-a600-26096b7764c1</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <skos:prefLabel xml:lang="en">occurs before</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/75221889-4ace-4cb4-ae7e-6044a938a2ff">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/75221889-4ace-4cb4-ae7e-6044a938a2ff</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">occurs before publication of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e79353e8-cae5-471f-9321-f28c38f56119">
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a7e17177-c533-4027-a66a-0c4fe961d7fc"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/34b081cd-6fcc-4e00-9a43-0a8a73745b45">
+    <skos:prefLabel xml:lang="en">vellum (parchment)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Fine-quality calf or lamb parchment used  for writing, illuminations, or binding books. The terms "vellum" and "parchment" are sometimes confused and used interchangeably.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Schreibpergament</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011852</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">vélin</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">35</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5f400d39-3b6b-4b8a-939b-4e49787c7444">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/80028d07-9c98-48cf-84db-f77bc01c8bbc">
+        <dcterms:title>Name Types - Generic</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404670</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">preferred terms</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Terms or names that are designated among all synonyms or lexical variants for a concept, to be used as the default term or name in displays and other situations; distinguished from "nonpreferred terms."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ab17510a-b66c-455a-9f59-f4049ce522fa">
+    <skos:scopeNote xml:lang="en">Providing a border or case to surround, support, enclose, or call attention to such items as a work of art, mirror, or document, leaving the item itself visible.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">framing (processes)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300240903</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2c1d1ac2-3f1c-4796-9f01-f0857b918c9e">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411307</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Groupings into which items are divided to be sold at an auction.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:prefLabel xml:lang="en">auction lots</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/eda0630d-68b1-4948-94dd-5c1317142729">
+    <dcterms:identifier>https://afs.test.fargeo.com/eda0630d-68b1-4948-94dd-5c1317142729</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">actor in formation event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/19be9af0-ab28-48c5-9632-377541fcfd8b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/cd093911-f1e1-4abb-bbb2-fcaea3ca03ab</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e6b13e70-d78e-499e-bc6a-e1e66c4eb631">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">39</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f51d6b90-1bd4-425d-91a9-04c2bb9f0164">
+    <skos:altLabel xml:lang="en">Rb</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/f51d6b90-1bd4-425d-91a9-04c2bb9f0164</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">88</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Rubidium (Rb)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f2c2a779-eab2-45d1-88c9-982556eb39a0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2fe66f7d-a761-4861-ab10-985b578bbe9b">
+    <skos:scopeNote xml:lang="de">Kleines, in der Regel gerades Messer mit dünner Klinge, manchmal auch mit austauschbaren Klingen, für präzises Schneiden oder vorsichtiges Entfernen eines Materials von einem anderen verwendet.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">scalpels</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">scalpel</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300262233</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:scopeNote xml:lang="en">Small, thin-bladed, usually straight knives, sometimes with changeable blades, used for precise cutting or delicate removal of one material from another.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Skalpell</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/479bf620-ff68-405f-9a85-975439fad879">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300410335</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">General term for a solid marking substance in the form of a slender rod, which is then enclosed in a cylinder of wood, metal, or plastic to form a "pencil (drawing and writing equipment)." Common examples of materials used in "pencils (drawing and writing equipment)" are graphite, lead, and pigmented wax.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="en">pencil (marking material)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4b056d74-6a84-4d40-b7d2-8f8eb76c1bd1">
+    <dcterms:identifier>https://afs.test.fargeo.com/a7cb9b76-59e2-47d4-8da6-52891ebbf4a5</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for contact information of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">37</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/26ed262a-f60b-44a9-8401-af993bcb3ed4">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">location of group joining event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/26ed262a-f60b-44a9-8401-af993bcb3ed4</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b32661b5-dba0-4de6-908c-d0104e3b3f94">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">67</arches:sortorder>
+    <skos:altLabel xml:lang="en">Nh</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Nihonium (Nh)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/b32661b5-dba0-4de6-908c-d0104e3b3f94</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/84556902-d04b-4ad0-8dee-1cab211a98f6">
+    <dcterms:identifier>https://afs.test.fargeo.com/84556902-d04b-4ad0-8dee-1cab211a98f6</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of formation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2d8ddf38-37c9-4bd9-8bb1-75ac2b7f13d4">
+    <skos:inScheme rdf:resource="http://localhost:8000/641c4612-732b-48c3-b958-3af2c5c3f647"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054700</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">editing</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Collecting, preparing, altering, and arranging materials for publication or public presentation, including but not restricted to data, written materials, film, and tape.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8cd23459-6ee6-4ee1-a1ca-02784ee94bd6">
+    <skos:prefLabel xml:lang="en">source reference work for professional activity</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/0cd2452d-daca-4cb1-bb15-d6aba7ca0b26</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">51</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/368c7c19-733a-40eb-a033-3e950ac513a0">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/77181be9-230a-490e-8b81-2c242efdcfb9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111221</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Switzerland, or in general to cultures that have occupied the Alpine region of northwestern Europe, north of Italy and west of Austria.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="en">Swiss</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">suisse</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/49add32c-3045-47aa-b1c7-9cf3307a2754">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300061163</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Taking apart or removing significant pieces, especially to reduce or disable the function.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">dismantling</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/76b3401e-243a-4980-8caa-78fbedc77ed8">
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/254161a9-5063-42e7-a718-05e1b6baebea">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="en">ultraviolet radiation</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2">
+        <dcterms:title>Event Types - Destruction Event</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300056056</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Electromagnetic radiation with wavelength shorter than that of visible light and longer than that of x-rays.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b69d9192-59a6-42df-9bef-234842ee4bab">
+    <skos:prefLabel xml:lang="en">textiles (visual works)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:prefLabel xml:lang="fr">textiles</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">General term for carpets, fabrics, costume, or other works made of textile materials, which are natural or synthetic fibers created by weaving, felting, knotting, twining, or otherwise processing. For works of art or high craft that employ textile as a medium, prefer "textile art (visual works)."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300014063</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/84aeb52a-47ee-4767-886e-849583afcaab">
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dca6a321-3ab9-42bc-ac80-2171789ae205"/>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b49c7a4b-e991-4725-b419-24177f07d05c">
+    <skos:prefLabel xml:lang="en">physical object used in production</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">62</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/b49c7a4b-e991-4725-b419-24177f07d05c</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c5f909c8-d870-4752-b62d-d18f945f1ddf">
+    <skos:scopeNote xml:lang="en">In the context of modern western personal names, the names that are hereditary and common to all members of a family; used with a first name to distinguish an individual from others with the same first name. In other cultural traditions, last names may not be hereditary family names or they may not be used at all. Before last names became common in western tradition, personal names were qualified with the addition of epithets, place names, ancestors' names, or terms for professions; these were added to a first name on an individual basis, not necesssarily hereditary for a family.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/b5dfd5e3-779d-4b94-8552-c539e352fd68"/>
+    <skos:prefLabel xml:lang="en">last names</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404652</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0ad7ee80-84b7-479d-a7f6-4229839643c3">
+    <skos:prefLabel xml:lang="en">Native American</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Typically reserved to refer narrowly to the cultures of the native peoples of the United States and Canada, excluding the Eskimos and Aleuts. For the indigenous peoples of Canada use the term "First Nations." For the broader concept of the cultures of any native peoples of Central America, South America, North America, or the West Indies who are considered to belong to the Mongoloid division of the human species, use "Amerindian (culture)."</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300017437</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/87428d10-277e-4e9e-a642-ab129e05a6c0">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">74</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a210183c-c615-46f6-ac2c-e3c378817e34">
+    <skos:scopeNote xml:lang="en">Styles and cultures that developed in Spain and elsewhere under Spanish influence, especially those that developed under the influence of colonists from Spain and their descendants in the Americas.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Hispanic</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300386138</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6dd419c8-178e-4144-b107-da5aaf329529">
+    <skos:prefLabel xml:lang="en">translated titles</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+    <skos:scopeNote xml:lang="en">Titles or names that have been translated into a language other than the original language, or expressed in a writing system other than the original.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417194</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6add5a1c-f3ad-4393-ad77-3092929d3079">
+    <skos:prefLabel xml:lang="en">source reference work for birth event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/6add5a1c-f3ad-4393-ad77-3092929d3079</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">44</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b3498065-2de2-43d1-945c-96713ffb1fb8">
+    <skos:prefLabel xml:lang="fr">collections privées</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:scopeNote xml:lang="en">Collections owned and maintained by private individuals, outside of the public domain.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Sammlung, die ein Individuum zusammenstellt und besitzt und nicht öffentliches Eigentum ist.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">private collections</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Privatsammlung</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300146236</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/043f82e6-540c-4c3c-a37c-365509c12cbe">
+    <skos:prefLabel xml:lang="en">cadastre number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/043f82e6-540c-4c3c-a37c-365509c12cbe</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/c8261144-c750-4f64-8980-e50f762b21a5"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/efd96a8d-da15-4a59-a7e4-0e08a6e5c1c4">
+    <skos:prefLabel xml:lang="de">graphische Künste</skos:prefLabel>
+    <skos:prefLabel xml:lang="pt">artes gráficas</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="pt">Processos e técnicas para criar imagens usando as artes da gravura, ilustração, desenho e outras técnicas que dependem da linha e não da cor para renderizar o design. No uso histórico, o termo se refere mais amplamente à apresentação em forma visual bidimensional, incluindo a maioria das artes em papel, painel ou tela, incluindo pintura.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Processes and techniques for making images using the arts of printmaking, illustration, drawing, and other techniques that depend upon line and not color to render the design. In historical usage, the term referred more broadly to presentation in two-dimensional visual form, including most arts on paper, panel, or canvas, including painting.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264849</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">arts graphiques</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">graphic arts</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/00a828d4-74d8-45ed-b4ec-cf6f709bb693">
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">creator</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/00a828d4-74d8-45ed-b4ec-cf6f709bb693</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3774b3a4-96bc-4643-b260-c0fce1127bcf">
+    <skos:scopeNote xml:lang="pt">Refere-se ao processo de fazer com que as imagens paradas pareçam se mover, principalmente pela técnica de fotografar desenhos ou objetos em estágios progressivos de execução de uma ação, para que o movimento seja simulado quando as imagens são projetadas como uma série em rápida sucessão.Refers to the process of making still images appear to move, particularly by the technique of photographing drawings or objects in progressive stages of performing an action, so that movement is simulated when the images are projected as a series in quick succession.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">animation (process)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the process of making still images appear to move, particularly by the technique of photographing drawings or objects in progressive stages of performing an action, so that movement is simulated when the images are projected as a series in quick succession.</skos:scopeNote>
+    <skos:prefLabel xml:lang="pt">animação</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053160</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/15599306-151c-4508-8e9c-ba0f10a709b0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:prefLabel xml:lang="en-US">scholarly title </skos:prefLabel>
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms/object/titles/scholarly-title-(5/5/2011)</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/07352117-9e9a-485e-a042-a3df8c7d1d6a">
+    <skos:prefLabel xml:lang="en">Tin (Sn)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">108</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/07352117-9e9a-485e-a042-a3df8c7d1d6a</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Sn</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3bce59c5-68d7-4cea-a696-3ebd9d5ea9af">
+    <skos:prefLabel xml:lang="en">digital images</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">images numérisées</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Images created using a binary numerical system electronically stored in the form of encoded picture elements, or pixels.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300215302</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bbaee296-3eb4-44c9-8bc9-ecaadca00e01">
+    <skos:prefLabel xml:lang="en">Phosphorus (P)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/bbaee296-3eb4-44c9-8bc9-ecaadca00e01</dcterms:identifier>
+    <skos:altLabel xml:lang="en">P</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">75</arches:sortorder>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/603141b9-5dae-462c-9b6a-4e418ec7772b">
+    <dcterms:title>Motivation</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/abeca9ea-214c-4a19-91d1-233c940fd679">
+    <skos:prefLabel xml:lang="en">biology</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054466</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The study of living organisms, including their structure, functioning, origin and evolution, classification, interrelationships, and distribution.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/c372cf0b-f0f4-4730-a97d-c892dfbefcd7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/462f6bb2-da16-4c46-80e1-cc750fc8e648">
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <skos:prefLabel xml:lang="en">object/work type (category)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435443</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The kind of object or work described, e.g., painting, book, cathedral.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e49fda8f-fc61-47e3-9d66-127323d9aadb">
+    <skos:scopeNote xml:lang="en">Proper names of geographic locations, such as a nations, empires, towns, villages, hills, or lakes.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404655</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">place names</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9c852036-3d98-496c-b784-c2fbddfde69e">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/e4362f02-74d1-4229-a33c-06aac1540e65</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">occurs after event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7be0d823-b871-4006-9eed-e0351c604f05">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:scopeNote xml:lang="en">An indication of the substances or materials used in the creation of a work, as well as any implements, production or manufacturing techniques, processes, or methods incorporated in its fabrication, presented in a syntax suitable for display to the end-user and including any necessary indications of uncertainty, ambiguity, and nuance. For works on paper, descriptions of watermarks may also be included.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">materials/technique description</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435429</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f3612d52-0bdb-471d-afec-a3378c25b452">
+    <skos:prefLabel xml:lang="de">Verkaufskatalog</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026074</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Katalog, in dem Gegenstände aufgelistet sind, die zum Verkauf stehen.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:scopeNote xml:lang="en">Catalogs that enumerate items that are for sale.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en-US">sales catalogs</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e0b23285-bd55-43d8-9cef-f28df2e2a44e">
+    <dcterms:identifier>http://localhost:8000/e0b23285-bd55-43d8-9cef-f28df2e2a44e</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266">
+        <dcterms:title>Statement Types - Experiment</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">instrument settings</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3c44d93c-01e5-4768-9b00-61db7f350d6a">
+    <skos:prefLabel xml:lang="en">influence on creation event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/3c44d93c-01e5-4768-9b00-61db7f350d6a</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c17e82b5-450c-43d4-a66d-b4796532316a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Brief statements of a fact or experience, written down for review, or as an aid to memory, or to inform someone else; also includes short, informal letters.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Kurze Angabe über eine Tatsache oder ein Erlebnis, niedergeschrieben zur Überprüfung oder als Erinnerungshilfe, oder um jemand anderen zu informieren; schließt auch kurze, formlose Briefe mit ein.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Notiz (Dokumentengattung)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">note</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">notes (documents)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027200</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/67f6e3e0-b6ae-4417-9c72-d71c5d48b971">
+    <skos:prefLabel xml:lang="en">collection removed from</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/67f6e3e0-b6ae-4417-9c72-d71c5d48b971</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9dd99086-3a90-4102-8335-33986fe797e3">
+    <skos:prefLabel xml:lang="en">prefixes (name additions)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404845</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/b5dfd5e3-779d-4b94-8552-c539e352fd68"/>
+    <skos:scopeNote xml:lang="en">Titles of courtesy, professional titles, military rank, adjectives, or other words used before a personal name. Examples are words to indicate gender, marital status, social position, or included for another purpose, such as the following words and abbreviations: Mr., Mrs., Miss, Ms., Dr., Sir, and Rev.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6d302f17-decd-4f33-9606-c1df25e306ee">
+    <skos:prefLabel xml:lang="en">Russian (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">russe</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Russisch</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389168</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d5e68b90-83be-4307-8583-f7e5e939832c">
+    <skos:scopeNote xml:lang="en">Digital microscopes that combine three-dimensional image capture, image stitching, and modelling data. These scan an object through multiple focal planes and compiles this data into a three-dimensional image.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">3D digital microscopes</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300444123</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3161211b-d4f3-4ce7-9e5d-ace00c3ad361">
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:prefLabel xml:lang="en">occurs before event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/3161211b-d4f3-4ce7-9e5d-ace00c3ad361</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b5cd85b4-622b-434d-b5b1-4da47d089517">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/b5cd85b4-622b-434d-b5b1-4da47d089517</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">location of destruction event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0e5d03f3-613c-4e36-9783-e93e317b56a6">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/9830adca-4ef8-4088-8cff-cae89a8af60c">
+        <dcterms:title>Object Types - Visual Work</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">images (object genre)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="de">In einem allgemeinen Sinn bezieht sich der Begriff auf alle Abbildungen und Darstellungen von Objekten, Gebäuden, Personen, Tieren, Pflanzen, Orten oder Phänomenen, unabhängig davon, ob das optische Gegenstück in der Realität oder nur in der Vorstellung existiert. Der Begriff kann engere Bedeutungen in bestimmten Kontexten erhalten. Er kann sich auf eine Abbbildung beziehen. die sich unterscheidet vom originalen Bildträger, beispielsweise wenn er sich eine Zeichnung bezieht, im Unterschied zu dem Papier, auf dem sie erstellt wurde. Für die Darstellung eines Objekts im Gegensatz zur materiellen Objekt selbst, wie bei der Unterscheidung zwischen einer Fotografie oder einem digitalen Bild und dem Kunst-Objekt, verwenden Sie die Bie Bezeichnung "visuelle Surrogate" oder das UF "Bilder (visuelle Surrogate)."</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Bild (object genre)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264387</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Depictions and representations on a surface in two dimensions or low relief, or digital, whether the optical counterpart exists in reality or only in imagination. For example, the term may refer to a depiction as distinguished from its support, as when referring to a drawing as distinct from the paper upon which it is drawn. For a representation of an object as opposed to the tangible object itself, as when distinguishing between a photograph or digital image and the art object depicted, use the descriptor "visual surrogates" or the UF "images (visual surrogates)." For three-dimensional works, use "objects" or a more specific term, such as "sculpture (visual works)."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/02899026-debc-4b08-8f8a-5750362ff27e">
+    <skos:scopeNote xml:lang="en">The sum total of ways of living, artifacts, customs, and so on, built up by a group of people and transmitted from one generation to another.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">culture (concept)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055768</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0c07fee2-14e2-4af3-b987-5d6d00958b45">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+    <skos:prefLabel xml:lang="en">organizations (groups)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Groups of people organized for a purpose, typically characterized by a more or less constant membership, a body of officers or functionaries, and a set of regulations governing their activities and conduct.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025948</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/eec63d9c-cc98-4f2b-86cc-6a51485ff9b3">
+    <dcterms:identifier>https://afs.test.fargeo.com/eec63d9c-cc98-4f2b-86cc-6a51485ff9b3</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">influence on formation event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d3760ea8-324f-479c-b8ea-7b1b05fcb7c1">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">38</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/d3760ea8-324f-479c-b8ea-7b1b05fcb7c1</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Ge</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Germanium (Ge)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066">
+    <skos:inScheme rdf:resource="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54"/>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/31ea3a41-4561-4e0e-af20-00157fe9715b">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300131119</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+    <skos:prefLabel xml:lang="en-US">printmaking</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Druckgrafik</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to the activity of producing prints as works of art; for the specific processes employed, use such terms as "intaglio printing" or "mezzotint." For the production of other types of printed material, use "printing."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/51933bfe-248b-4ed3-a4e1-36bf1bac589d">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/51933bfe-248b-4ed3-a4e1-36bf1bac589d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">influence on set removal event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0cb8fa21-80b6-4afe-aeca-c9863ed725d6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms/object/place/found</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <skos:prefLabel xml:lang="en-US">place found</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6b9745b3-fbac-428a-8c44-2eb2af625808">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055547</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Social science concepts related to law.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">rights statement</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0d734a1c-eaea-4a42-a7a5-8a60ebdb9247">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300033936</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Miniatur (painting)</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Gemälde in einem sehr kleinen Maßstab. Der Begriff wird oft speziell auf kleine Szenen in illuminierten Handschriften angewandt oder auf Porträts auf Pergament oder Elfenbein, die in Europa und Amerika von der Renaissance bis ins 19. Jahrhundert populär waren. Für Malereien in Handschriften ist auch der Begriff "Buchmalerei" geeignet.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Paintings on a very small scale. The term is often applied specifically to small scenes in illuminated manuscripts or to portraits on vellum or ivory that were popular in Europe and America from the Renaissance into the 19th century. For paintings in manuscripts, the term "illuminations" may also be appropriate. </skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:prefLabel xml:lang="en">miniatures (paintings)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/12868967-09d9-4ffa-8127-6103936bd27f">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <skos:altLabel xml:lang="en">Db</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/12868967-09d9-4ffa-8127-6103936bd27f</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Dubnium (Db)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ad04f159-3d1f-4508-b820-870eebbc40e4">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">91</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Samarium (Sm)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/ad04f159-3d1f-4508-b820-870eebbc40e4</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Sm</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/84554ae9-0437-4ef3-94a3-6718fef184fe">
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <skos:scopeNote xml:lang="en">The cultures, styles, and periods characteristic of China. To specifically refer to the cultures of ancient Chine, use "Ancient Chinese."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Chinese (culture or style)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300018322</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">chinoise</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/71c34097-58ba-444d-8c8b-ba3d108454f5">
+    <skos:prefLabel xml:lang="en">has project part</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/71c34097-58ba-444d-8c8b-ba3d108454f5</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8e39291b-e186-4571-b03d-e7b5b74b030e">
+    <skos:inScheme rdf:resource="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to the resolution capability of electronic imaging devices such as computer monitors, digital cameras, televisions, or scanners, expressed as the number of pixels per linear distance (pixels per inch or pixels per centimeter). Pixel density can also describe the resolution of image files.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412057</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">pixel density</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ecb98f2b-7104-4bbc-ae9a-8837104052a8">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Broadly used to describe portions of the earth's surface that share common repeating characteristics that can be comprehended at a glance. Landscapes are more than scenery or political units; they are systems of natural and cultural contexts. If possible use a more specific term.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Landschaft (Lebensraum)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/273d0839-8911-468f-9eb1-b0cc3507b6e7"/>
+    <skos:prefLabel xml:lang="fr">paysages (environments)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">landscapes (environments)</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Begriff mit großem Bedeutungsumfang, um Teile der Erdoberfläche zu beschreiben, die sich dank wiederkehrender Charakteristika auf einen Blick erfassen lassen. Eine Landschaft ist mehr als eine ästhetische oder politische Einheit; sie ist ein System, in dem natürliche und kulturelle Zusammenhänge interagieren. Wenn möglich, sollte ein spezifischerer Begriff verwendet werden.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300008626</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2f397086-f12b-4f43-881b-2f582b307968">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417645</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Method of acquiring property for temporary use, with or without the payment of interest.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">loan (method of acquisition)</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/83dd1837-e399-469f-a073-cd76edff810c">
+        <dcterms:title>Event Types - Transfer of Custody</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/299de067-b416-4778-b01c-a8efbb51d36b">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/299de067-b416-4778-b01c-a8efbb51d36b</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">51</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Lawrencium (Lr)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Lr</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/814cfe88-8330-43b7-a600-26096b7764c1">
+    <skos:prefLabel xml:lang="en">occurs before</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/814cfe88-8330-43b7-a600-26096b7764c1</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/834b28f1-d181-4366-b294-44e21f4810f1">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of death event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/834b28f1-d181-4366-b294-44e21f4810f1</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b9845f81-8de2-43be-a243-b91cc6924cdf">
+    <skos:prefLabel xml:lang="fr">grec ancien (jusqu'à 1453)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Ancient Greek (language)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Griechisch</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300387827</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ccd97ae1-f7ae-409e-8cbb-a87cdb131acd">
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8455d232-8591-4e04-ac90-1f04ccd46f73">
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/662b53c0-2e26-4b87-a6d0-109b7f611e05">
+    <skos:prefLabel xml:lang="en">databases</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/5da484cb-7537-43be-91cb-dc28c4369efb">
+        <dcterms:title>Digital File Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028543</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Structured sets of data held in computer storage, especially those that incorporate software to make them accessible in a variety of ways. A database is used to store, query, and retrieve information, typically comprising a logical collection of interrelated information that is managed as a unit, stored in machine-readable form, and organized and structured as records that are presented in a standardized format in order to allow rapid search and retrieval by a computer.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Datenbank</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">base de données</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Elektronisch gespeicherter, strukturierter Datensatz, insbesondere solcher mit integrierter Software, die ihn auf vielfältige Weise verfügbar macht. Eine Datenbank wird verwendet, um Informationen zu speichern, sie abzufragen und wiederaufzufinden, besteht typischerweise aus einer Sammlung logisch zusammenhängender Informationen, die als Einheit verarbeitet, in maschinenlesbarer Form gespeichert und als Datensätze organisiert und strukturiert werden, welche in einem standardisierten Format vorliegen, um mit Hilfe eines Computers schnelles Durchsuchen und Finden zu ermöglichen.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/26a055ac-f801-4170-a4d5-a11d72d51eba">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417644</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Method of acquiring property by legally conferring existing ownership to another person or institution; it does not necessarily involve benefactors.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5f7df45b-31ae-44ce-a8cc-55ccdafa019d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">transfer (method of acquisition)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6cf9b53f-7e44-4264-8fa4-5d828ff3de72">
+    <skos:prefLabel xml:lang="de">Patent (Regierungsakte)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">brevets</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">patents</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027832</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Grants made by a government to an inventor, assuring the inventor the sole right to make, use, and sell the invention for a certain period of time.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Das von einer Regierung an einen Erfinder erteilte alleinige Recht, die Erfindung für eine bestimmte Dauer zu produzieren, zu nutzen und zu verkaufen.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d1a8cc2c-a671-4ecf-8034-9348e2f0a8c7">
+    <skos:prefLabel xml:lang="en">adaptations (literary works)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/de10c1c8-a3a4-43e0-8afc-43720a9ad3a9"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300410356</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Written works or works derived from written works, where the second work is an alteration or amendment a text to make it suitable for another purpose. An example of an adaptation is a version of an earlier text made to better agree with a philosophy other than that intended by the original. Other examples are written works adapted for another medium, such as film, broadcasting, or stage production. For visual works adapted from another work, use "adaptations (derivative objects)."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5188d98d-4faf-4150-aaaf-d70038f9e202">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">source reference work for death event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">46</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/5188d98d-4faf-4150-aaaf-d70038f9e202</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f147d843-7622-4109-bd73-c7fb05f1adea">
+    <dcterms:identifier>http://localhost:8000/f147d843-7622-4109-bd73-c7fb05f1adea</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:prefLabel xml:lang="en">sample description</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6b031c2a-888a-4637-b853-2c01dc38c132">
+    <skos:prefLabel xml:lang="en-US">p1_is_identified_by</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/1b066f78-8d4b-4bb7-a83b-db15ae220811">
+        <dcterms:title>Properties</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/488d4b61-a85a-4185-9f0a-2735b8ac8c8a">
+    <skos:prefLabel xml:lang="en">creator of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/6ea01af9-52df-4ddf-bd9e-2efda73f574f</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ca88ef39-c76c-412a-bf9b-e9c8e3e89e08">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379099</dcterms:identifier>
+    <skos:prefLabel xml:lang="en-US">meters (units for distance)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The fundamental units of length in the metric system (International Systems of Units, SI), equivalent to approximately 39.37 inches. Defined as the distance travelled by light in a vacuum in 1/299,792,458 second. Historically, the meter was defined by the French Academy of Sciences in 1791 as 1/10,000,000 of the quadrant of the Earth’s circumference from the North Pole through Paris to the equator. </skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6bea9a27-6b4b-4133-8ad9-105e9fee5dcb">
+    <skos:prefLabel xml:lang="en">Web pages (documents)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264578</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Hypertextdokument mit Text oder Bildern, das über das World Wide Web abrufbar ist und auf einer Website gehostet wird.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Webseite</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:scopeNote xml:lang="en">Hypertext documents of text or images that are accessible via the World Wide Web, hosted on a web site.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a7c83cb3-d116-4fb4-907c-c394fa3a63e0">
+    <skos:prefLabel xml:lang="en">insect damage</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Damage caused by insects.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300230031</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/74c7bf6c-fde6-4624-8373-7cb5078a8215">
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <skos:scopeNote xml:lang="en">Documents comprising texts that are relatively short in length, sometimes but not always abbreviated versions of longer texts.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">brief text</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300418049</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1001587a-3524-455f-92ea-34deafc7bf68">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/1001587a-3524-455f-92ea-34deafc7bf68</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">estimate</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/5f3c2407-2e22-4022-9795-2f3ef963d5aa">
+        <dcterms:title>TimeSpan Types - Duration</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ecc63434-f2b1-4ffc-af3b-cac3bf40ef96">
+    <skos:prefLabel xml:lang="en">technical analysis</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a8e8388-0bb9-42f2-bc77-fc5a1c640589"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379518</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The application of testing methods to materials or objects in order to analyze their composition and manufacture. In a conservation science context, this may refer to movable art works and artifactual objects in a conservation lab. For a broader range of testing methods, prefer "scientific analysis." </skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0f419fca-4b00-422d-8353-0b24a18d7e8e">
+    <skos:scopeNote xml:lang="en">Process of removing an outer layer by drawing the edge of some instrument held nearly perpendicularly across the surface.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053711</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+    <skos:prefLabel xml:lang="en">scraping</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b86ae9c8-c9c8-4d58-b614-c9ba51553c4c">
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cc9cf0a6-30cf-4c31-9be5-4f5be7e216f8">
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:scopeNote xml:lang="en">Refers to the context of or associated specifically with the modern political entity of the United States of America.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300107956</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">américaine</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">American (North American)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f01725e2-b782-4d35-ab86-9196faadc6b0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en-US">Gallery Systems' The Museum System (TMS) Integer Identifier (ID)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms-id</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/27b0c339-73b3-41c7-9a6a-736085f7cfb3">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">55</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object part</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/27b0c339-73b3-41c7-9a6a-736085f7cfb3</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d435267f-7de2-4321-9b02-f495386866b3">
+    <skos:inScheme rdf:resource="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404683</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">married names</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Regarding personal names, last names acquired by a person, usually a woman, through marriage; distinguished from "maiden names."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9ce6c237-f015-4ee0-b7e3-9cc10b006483">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404630</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">uniform resource locators</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/4096365e-4fe7-412d-906c-16f3d356e8be"/>
+    <skos:scopeNote xml:lang="en">Unique resource locators that, in addition to identifying a resource, provide the address of the internet document according to one of a variety of protocols.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f55a9b9d-b1d8-443a-897a-c150b1a04de6">
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/7cc462a5-db43-4b25-a748-99892eba26aa"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4f861b2d-0400-41f7-a08b-a871f1e51316">
+    <skos:prefLabel xml:lang="en">members</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/07e8d7a0-551f-4200-8c71-8a03e1f02d36">
+        <dcterms:title>Role Types - Group</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300263077</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Those who have membership in an organization, community, joint enterprise, or other group.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/577e77ea-4381-47a9-962b-eadd844a9110">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">period of set addition event of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/577e77ea-4381-47a9-962b-eadd844a9110</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">50</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/90426117-4930-4fac-9c26-16aa06c451ac">
+    <skos:prefLabel xml:lang="de">Finnisch</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="en">Finnish (language)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388299</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">finnois</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8316bfa9-13bc-4707-9783-d32880ebe205">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <skos:prefLabel xml:lang="en">location of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/8f3bebaa-3ee9-41a8-bbed-f484d2efc300</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7c7c227d-2936-4b08-b778-c6462eceb6fa">
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/40a37f81-29fa-4d6e-a0fa-ea99d894343d">
+    <dcterms:identifier>https://afs.test.fargeo.com/40a37f81-29fa-4d6e-a0fa-ea99d894343d</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object used in group joining event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">33</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/86d75104-eaba-4116-9201-0db856830aa4">
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">thaï</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Thai (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Thailändisch</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389405</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ab4e604c-8af4-4b55-8d62-a9875c260552">
+    <skos:prefLabel xml:lang="en">Arabian (culture)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the semitic race inhabiting the Arabian peninsula and neighboring areas, particularly during the pre-Islamic period from about 4,500 BCE to the early 7th century CE. Periods related to Arabian cultures.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300019797</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3fe53655-f35b-45cd-8aea-153181da165c">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/3fe53655-f35b-45cd-8aea-153181da165c</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Ir</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Iridium (Ir)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">47</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8ec473f8-cdf5-478f-a5b1-64e2de49cf99">
+    <skos:prefLabel xml:lang="en">acknowledgments</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written recognitions of acts or achievements.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026687</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Danksagung</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f44f7240-35c5-49e8-a0e3-2ffe308f0862"/>
+    <skos:scopeNote xml:lang="de">Schriftliche Anerkennung für Handlungen oder Leistungen.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/adfd842e-3eb4-4ac7-8115-d3f886a66a93">
+    <dcterms:identifier>https://afs.test.fargeo.com/adfd842e-3eb4-4ac7-8115-d3f886a66a93</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:prefLabel xml:lang="en">sample created by</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/42ec4165-cf43-4861-9b0b-2868d1020af3">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">89</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c3c3b964-007c-434d-8df9-ac687a3be542">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Koreanisch</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">coréen</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388633</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Korean (language)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ecbe79a1-8a8f-4a13-a7da-0442f0e78af2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/076cbfad-bfce-4096-894b-04467470fbc8">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Ho</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Holmium (Ho)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/076cbfad-bfce-4096-894b-04467470fbc8</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">43</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0e099c0e-663a-4330-8597-d39eb9fda10a">
+    <skos:prefLabel xml:lang="en">data conversion</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Changing the representation of data in a database from one form to another, as for instance changing the storage medium, data format, or the code in which the data is held.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300155333</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/641c4612-732b-48c3-b958-3af2c5c3f647"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/58d98835-1370-4665-88fb-230bed179b67">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">exchange (method of acquisition)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/83dd1837-e399-469f-a073-cd76edff810c"/>
+    <skos:scopeNote xml:lang="en">Method of acquiring property by each party giving and receiving from the other party, usually regarding property of equal value. For example, an exchange may be made by individual authors, libraries, museums, and other institutions in which they exchange between or among each other their own publications or those of the institution with which they are connected, or duplicates from their own collections.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300263427</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/36e53ad9-0f86-4fc0-be00-d2b09025a360">
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055768</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">culture (concept)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The sum total of ways of living, artifacts, customs, and so on, built up by a group of people and transmitted from one generation to another.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bc9c0337-59b4-453e-8a97-a990f7dd412f">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/cd093911-f1e1-4abb-bbb2-fcaea3ca03ab</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">location</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/219c15b1-a525-4833-aeeb-ec3c3bffc665">
+    <skos:scopeNote xml:lang="en">Alloy of copper and zinc, usually with copper as the major alloying element and zinc up to 40% by weight.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">brass (alloy)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300010946</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">laiton</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c2df50e0-5453-437e-9c89-a150fc8172c7">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/b7b40309-f000-41cb-bc1b-630487e657ee</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of creation of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cc7bbe70-cea7-4c54-89ea-cbc00ec7e470">
+    <dcterms:identifier>https://afs.test.fargeo.com/cc7bbe70-cea7-4c54-89ea-cbc00ec7e470</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for set removal event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">78</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1e9d7790-e9fa-4971-a37c-0ee8ba4db798">
+    <skos:prefLabel xml:lang="en">description</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written, digital, spoken, or signed representations of the attributes or qualities of something or someone.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/f44f7240-35c5-49e8-a0e3-2ffe308f0862"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411780</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5d26c70d-774b-4403-9c54-c81fe776eabe">
+    <skos:prefLabel xml:lang="en">interpretation</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300226183</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Explanation of what is not immediately plain or explicit, as in suggesting what meaning is to be found in a set of data or in a visual work.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b5366c4d-3d1f-4643-982f-9aadf4ff17a7">
+    <skos:prefLabel xml:lang="en">pastel (material)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404632</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:scopeNote xml:lang="en">General term for various combinations of ground, powdery pigment and aqueous binder that are used in drawing and dry painting, delivered via a crayon or stick. Pastel as a material is soft and blendable. For the crayons or sticks containing the pigment and binder, use "pastels (crayons)."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4b4478ab-03e4-40b4-9cdc-e1a5c63f5aa8">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Rf</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Rutherfordium (Rf)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/4b4478ab-03e4-40b4-9cdc-e1a5c63f5aa8</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">90</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fbc4dc2f-61f7-4d80-969d-d61fdd71de23">
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/dor-uuid</dcterms:identifier>
+    <skos:prefLabel xml:lang="en-US">Getty Digital Object Repository (DOR) Universally Unique Identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/25e6160c-b4d6-48d9-9e9b-828d58c42105">
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:scopeNote xml:lang="de">Bericht mit den Details und Ergebnissen einer Untersuchung über ein wissenschaftliches oder technisches Problem.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Reports giving details and results of a specific investigation of a scientific or technical problem.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027323</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Technischer Bericht</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/49961e2c-7ee0-4989-bae4-385e47472ef0">
+    <skos:prefLabel xml:lang="en">used in professional activity of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">41</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/49961e2c-7ee0-4989-bae4-385e47472ef0</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/aef8720d-9383-47e2-893b-781c7ab8ca83">
+    <dcterms:identifier>https://afs.test.fargeo.com/9d84c6cb-70b1-4607-a035-2175a18f1991</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">38</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for dimension</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c7927e81-cd9f-4600-96ba-335200563fe5">
+    <skos:prefLabel xml:lang="en">Egyptian (ancient)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300020251</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to the styles and culture that developed in antiquity in the Nile Valley in the area of modern-day Egypt and southwards. For the cultures and styles of the modern nation of Egypt, use "Egypt (modern)."</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">égyptienne</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dd621f69-7e2a-492c-9921-30d42bbac20d">
+    <dcterms:identifier>https://afs.test.fargeo.com/dd621f69-7e2a-492c-9921-30d42bbac20d</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">is referred to in</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c6d0fd93-ac62-4927-b15b-5388af12d956">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379543</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Systematic assessments of the condition of a group, collection, or system, for example, the contents of a library or archive. For reports on individual items, use "condition reports."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <skos:prefLabel xml:lang="en">condition surveys</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/651dec1d-d823-4b52-a37b-47e7fe013ff2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">has member</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/651dec1d-d823-4b52-a37b-47e7fe013ff2</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/46a2da83-1594-4823-8480-1407d3f1d671">
+    <skos:prefLabel xml:lang="en">Black (general, race and ethnicity)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435249</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">General designation for the race, ethnicity, styles, culture, and heritage of people of sub-Saharan African origin or descent in places outside Africa, or of members of any dark-skinned group of peoples, including those of  Australian Aboriginal origin or descent.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f5cc9b43-ae9b-43ed-91e5-baf11f7eafd2">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">45</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/f5cc9b43-ae9b-43ed-91e5-baf11f7eafd2</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of part removal event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cac7d7cc-1ee6-4935-b929-7bd30ca6896e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">instrument settings</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"/>
+    <dcterms:identifier>http://localhost:8000/e0b23285-bd55-43d8-9cef-f28df2e2a44e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/21121df1-9699-469d-924c-50f575c1ba83">
+    <skos:inScheme rdf:resource="http://localhost:8000/5da484cb-7537-43be-91cb-dc28c4369efb"/>
+    <skos:scopeNote xml:lang="en">Hypertext documents of text or images that are accessible via the World Wide Web, hosted on a web site.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Web pages (documents)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Hypertextdokument mit Text oder Bildern, das über das World Wide Web abrufbar ist und auf einer Website gehostet wird.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264578</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Webseite</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/24b56b86-97c4-4fe5-a6e2-4a7a5d5ba8f1">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Manuscripts that have been reviewed and prepared to be published.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028579</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">manuscripts for publication</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0b6d8038-8207-4a1a-900b-bf0fc55aca79">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/0b6d8038-8207-4a1a-900b-bf0fc55aca79</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">70</arches:sortorder>
+    <skos:altLabel xml:lang="en">No</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Nobelium (No)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/49e10ca8-12ae-4ead-9494-34c35a8de316">
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">image shown</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/49e10ca8-12ae-4ead-9494-34c35a8de316</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6f9434ce-8758-4b83-bfe9-d80ca9bf888e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411780</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">description</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written, digital, spoken, or signed representations of the attributes or qualities of something or someone.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5b1a15d7-f4ce-48ec-871f-d09b330feeb1">
+    <skos:altLabel xml:lang="de">Provenienz</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <skos:altLabel xml:lang="fr">provenance</skos:altLabel>
+    <skos:scopeNote xml:lang="en">The history of the ownership and transmission of an object, including previous locations of a work. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">provenance statement</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055863</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/60a15f0c-7dc7-4fbd-817a-4d827ff58c97">
+    <skos:prefLabel xml:lang="en">Krypton (Kr)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/60a15f0c-7dc7-4fbd-817a-4d827ff58c97</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Kr</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">49</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b2f45594-6c10-49d7-a4b7-24e5ca839838">
+    <skos:prefLabel xml:lang="en">brief text</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300418049</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b"/>
+    <skos:scopeNote xml:lang="en">Documents comprising texts that are relatively short in length, sometimes but not always abbreviated versions of longer texts.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e8300d8d-587a-46c1-8e79-44ee57b2c043">
+    <skos:prefLabel xml:lang="fr">américaine</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">American (North American)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300107956</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the context of or associated specifically with the modern political entity of the United States of America.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/93011327-679b-4c33-8197-fbf47f500c51">
+    <skos:prefLabel xml:lang="en">related event causal to formation event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/93011327-679b-4c33-8197-fbf47f500c51</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7882a788-a6ba-42d7-bb02-7c2776d82353">
+    <skos:inScheme rdf:resource="http://localhost:8000/c9e838f8-7660-4701-821c-721dac98a10b"/>
+    <skos:scopeNote xml:lang="en">The length of a straight line passing through the center of a circle or sphere, terminated at each end by its circumference or surface.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055624</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">diameter</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d70d092d-eb98-42fe-a153-a88732e5745b">
+    <skos:prefLabel xml:lang="en">Barium (Ba)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Ba</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/d70d092d-eb98-42fe-a153-a88732e5745b</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5de7e9c2-2f7e-485d-983f-659bdca2884c">
+    <dcterms:identifier>https://afs.test.fargeo.com/2a343ae1-3e8d-43f7-a84e-fbf38dcda817</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of professional activity of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/eef169bf-1736-495e-bfae-f0bf3a5a2189">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">text carried by physical object</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">87</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/eef169bf-1736-495e-bfae-f0bf3a5a2189</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e63a4c50-3e46-40a1-9e20-75e58a2ebe59">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/cd093911-f1e1-4abb-bbb2-fcaea3ca03ab</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/94326469-5f79-4830-96be-0beb2d3cfc6f">
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+    <skos:prefLabel xml:lang="en">hypothesis</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/94326469-5f79-4830-96be-0beb2d3cfc6f</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2f3699e4-1581-4bd7-b7f5-e2ac769d114d">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">loan (method of acquisition)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/5f7df45b-31ae-44ce-a8cc-55ccdafa019d"/>
+    <skos:scopeNote xml:lang="en">Method of acquiring property for temporary use, with or without the payment of interest.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417645</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f557e168-9472-40d2-9344-1c7030c534e1">
+    <skos:prefLabel xml:lang="en">source reference work for production event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">84</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/93dc6410-1d4f-4c8e-8652-497a4f9cec9f</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/46123a1f-6786-4cef-8193-c1f72e67cc5c">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/46123a1f-6786-4cef-8193-c1f72e67cc5c</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">member of set</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7d9253fe-5b76-444d-84aa-34f35f0be80e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435443</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">object/work type (category)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The kind of object or work described, e.g., painting, book, cathedral.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5745583d-2795-4305-995f-a85929f8bd54">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111201</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Norway, or in general to the cultures that have occupied the western part of the Scandinavian peninsula in northwestern Europe.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="en">Norwegian (culture)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">norvégienne</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/169ec513-9931-462e-9d64-433a8919a798">
+    <skos:inScheme rdf:resource="http://localhost:8000/4096365e-4fe7-412d-906c-16f3d356e8be"/>
+    <skos:prefLabel xml:lang="en">Archival Resource Key (ARK)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/169ec513-9931-462e-9d64-433a8919a798</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/be56d99a-4be6-4e2e-ab58-2432d8a77e46">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404628</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+    <skos:prefLabel xml:lang="en">Lot Number</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Distinguishing identification numbers or codes assigned to either a plot of land or a batch of items, such as at an auction.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6046ddcf-6698-4e9f-8c04-7459109d04e3">
+    <skos:prefLabel xml:lang="en">location of professional activity</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/6046ddcf-6698-4e9f-8c04-7459109d04e3</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/840026ad-a4ee-42ef-850f-6b7d83162961">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">105</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/840026ad-a4ee-42ef-850f-6b7d83162961</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Thallium (Tl)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Tl</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/afc13dca-6cef-4a8a-95a5-071ff442988f">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">digital reference to observation</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/afc13dca-6cef-4a8a-95a5-071ff442988f</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cd16e65e-436a-4404-853a-820f68e10c77">
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d"/>
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/95992bc0-f737-4752-ae22-480ce73590bd">
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/590afd37-bae2-4f4c-bdc4-07da5d69057b">
+    <dcterms:identifier>https://afs.test.fargeo.com/590afd37-bae2-4f4c-bdc4-07da5d69057b</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for set addition event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">77</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/edd7c6a0-1eb8-4114-b33c-83b125b77caf">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/edd7c6a0-1eb8-4114-b33c-83b125b77caf</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Am</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Americium (Am)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a36c95d6-92dc-4be6-b277-fca3f18f0c2a">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/a36c95d6-92dc-4be6-b277-fca3f18f0c2a</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Y</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">115</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Yttrium (Y)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ffc79063-a21e-46b3-9441-0c8dac5b6161">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Polish (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">polonais</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Polnisch</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389109</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ca1546cf-6ee5-428d-9728-b90fc8820baa">
+    <skos:prefLabel xml:lang="en">occurs after</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/ca1546cf-6ee5-428d-9728-b90fc8820baa</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a97300e6-62c2-43ee-8465-b31be07d7452">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/46123a1f-6786-4cef-8193-c1f72e67cc5c</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">member of set</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/78525076-60d1-4e00-8cf1-6ca9f3a3f02e">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/78525076-60d1-4e00-8cf1-6ca9f3a3f02e</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Pr</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Praseodymium (Pr)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">80</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/46ee3c61-8b7c-40d3-8619-151db0303872">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:prefLabel xml:lang="en">sampling motivation</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/d12c085c-fa9a-4cc6-83b7-15031ce63c19</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8bbe17da-47f1-475d-a38d-29edbe08a4d4">
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/49b09fc6-d1e1-46a7-a500-9089a68027eb">
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:scopeNote xml:lang="en">Refers to a broad range of alloys of copper, specifically any non-ferrous alloy of copper, tin, and zinc or other trace metals. Bronze was made before 3,000 BCE -- possibly as early as 10,000 BCE, although its common use in tools and decorative items is dated only in later artifacts. The proportions of copper and tin vary widely, from 70 to 95 percent copper in surviving ancient artifacts. Because of the copper base, bronze may be very malleable and easy to work. By the Middle Ages in Europe, it was recognized that using the metals in certain proportions could yield specific properties. Some modern bronzes contain no tin at all, substituting other metals such as aluminum, manganese, and even zinc. Historically, the term was used interchangeably with "latten." U.S. standard bronze is composed of 90% copper, 7% tin and 3% zinc. Ancient bronze alloys sometimes contained up to 14% tin.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300010957</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">bronze (metal)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">bronze (metal)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/265d5422-709a-4e7b-bc0a-88e4a87608f7">
+    <skos:scopeNote xml:lang="en">Recording the entry of items into a collection in the order of acquisition.</skos:scopeNote>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/94343b71-a35a-4edd-8ffa-61c66ea8d417">
+        <dcterms:title>Event Types - Set Addition</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">accessioning (collections management)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054626</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cf140f56-6a2b-4cfd-9cae-ddc2af1d74a2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Californium (Cf)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Cf</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/cf140f56-6a2b-4cfd-9cae-ddc2af1d74a2</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/23584071-d3f1-452b-92e3-77ee47acc3ab">
+    <skos:scopeNote xml:lang="de">Kurze Angabe über eine Tatsache oder ein Erlebnis, niedergeschrieben zur Überprüfung oder als Erinnerungshilfe, oder um jemand anderen zu informieren; schließt auch kurze, formlose Briefe mit ein.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Brief statements of a fact or experience, written down for review, or as an aid to memory, or to inform someone else; also includes short, informal letters.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">note</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/69abe4f9-f16f-47bf-8fdf-ccce67a18e5d">
+        <dcterms:title>Statement Types - Sampling Activity</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:altLabel xml:lang="de">Notiz (Dokumentengattung)</skos:altLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027200</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/df4f12d3-48ca-49af-8e96-edc6d52af481">
+    <skos:scopeNote xml:lang="en">Paint formed of an emulsion of fatty and watery constituents. The standard emulsion is usually created with egg yolk and water, with variants of man-made emulsions created with whole egg, linseed oil, casein glue, gum, or wax.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">tempera</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300015062</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">33</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/35cd4540-54b2-4bd0-a7d8-8d7801c177ef">
+    <skos:prefLabel xml:lang="en">source reference for curation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/35cd4540-54b2-4bd0-a7d8-8d7801c177ef</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5c57af12-3510-4dfb-b924-97bbf55ddbd3">
+    <dcterms:identifier>http://localhost:8000/5c57af12-3510-4dfb-b924-97bbf55ddbd3</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Collection Identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5fc4650f-5791-4351-bc52-1c5308eb730e">
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+    <skos:scopeNote xml:lang="de">Ergänzung, die als Kommentar oder Erklärung hinzugefügt wird, wie beispielsweise jene, die einem Titel in einer Bibliografie, einer Leseliste oder einem Katalog beigefügt ist und die betreffende Publikation beschreiben, erklären oder bewerten soll.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Notes added as comment or explanation, such as those accompanying an entry in a bibliography, reading list, or catalogue intended to describe, explain, or evaluate the publication referred to.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Anmerkung</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">annotations</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026100</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/40e645da-a6b7-4f01-99ec-75e38d8043fe">
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms/object/place/found</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:prefLabel xml:lang="en-US">place found</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/46744fc9-2c59-4dda-a056-36ebf04dd941">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="en">influence on formation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/46744fc9-2c59-4dda-a056-36ebf04dd941</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e4ddf63f-6b87-49b4-9e48-954d35b5724b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/7cc462a5-db43-4b25-a748-99892eba26aa"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dc5fe25b-6499-4b41-9ac8-08db72fcadf4">
+    <skos:inScheme rdf:resource="http://localhost:8000/cde31c5b-8ab2-4fbe-9b55-11eed1d478f7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">designation</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/dc5fe25b-6499-4b41-9ac8-08db72fcadf4</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e7301d1f-8acf-4e16-b0e3-654655e23d7e">
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Alloy in which copper is the principle element.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">copper alloy</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300010942</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">alliage de cuivre</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fdb282ff-4e71-4334-9993-46956fc2b64d">
+    <skos:prefLabel xml:lang="en">experimentation</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Testing a hypothesis or model. In science and related fields, refers to testing systematically under controlled conditions in order to discover the qualities, behavior, or effects of the subject of the experiment.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300137801</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/080f39d1-b54b-4260-9506-57eb802e5b4e">
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">previous number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/080f39d1-b54b-4260-9506-57eb802e5b4e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f181937b-426c-41e9-bd4f-be1d6f6d7ca4">
+    <dcterms:identifier>https://afs.test.fargeo.com/3077e707-7e96-4370-9e88-08d38a4e6fad</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8913b62a-23fe-4a7e-aeca-52356160b92e">
+    <skos:prefLabel xml:lang="en">transfer (method of acquisition)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417644</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f3eca78c-7547-4ca5-a7eb-b130391b40ed"/>
+    <skos:scopeNote xml:lang="en">Method of acquiring property by legally conferring existing ownership to another person or institution; it does not necessarily involve benefactors.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/657ca95e-9cc4-4b11-86a8-8ef4580734b6">
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ca9e81f3-471d-4d1f-b323-edc816b1c522"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5d471d02-cb7e-48bf-8fba-c367ffde2c07">
+    <skos:scopeNote xml:lang="en">The domains or territories of counts. In current usage, usually refers to particular divisions that have been made to an area for administrative, judicial, and political purposes. In Britain, counties are defined by various official methods, and serve as the most important divisional units in the country. In the United States, counties are the political and administrative divisions below the state and above the city; a few U.S. states call such divisions "districts" or "parishes" rather than "counties."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">counties</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/09f4f591-5654-4518-931b-7ab382fbc100"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300000771</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d26ceb40-6ab7-45ab-84d2-8e12cc571a7b">
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0f434613-5533-490e-89f0-0aae96040b52">
+    <skos:prefLabel xml:lang="en">parent project of observation</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/0f434613-5533-490e-89f0-0aae96040b52</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3f7292a1-ce1f-4db4-b47e-3c5eca402ae3">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/4b220b03-17eb-44b8-b3db-3fa46f23697d</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/e17c5d7f-eaf2-4e7d-9490-a3e362f74bdc">
+        <dcterms:title>Identifier Types - Sampling Activity</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">session number</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3d5fe8da-ee28-44d1-bb12-d736c9ebc8b9">
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+    <skos:prefLabel xml:lang="en">has place part</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/3d5fe8da-ee28-44d1-bb12-d736c9ebc8b9</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/391818d1-5d43-4499-a007-7732969caadb">
+    <skos:prefLabel xml:lang="en">description</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written, digital, spoken, or signed representations of the attributes or qualities of something or someone.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411780</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/69abe4f9-f16f-47bf-8fdf-ccce67a18e5d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0fdc503e-e2d5-4bff-b351-56d83d79e702">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/0fdc503e-e2d5-4bff-b351-56d83d79e702</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Pb</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">52</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Lead (Pb)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f18613e5-aa77-4400-97b9-aaf6987de517">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300072633</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">depth (size/dimension)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/c9e838f8-7660-4701-821c-721dac98a10b"/>
+    <skos:scopeNote xml:lang="en">Length of a straight line measured downward from a plane or surface, or inward from a plane or surface. For the measurement or extension through or between opposite surfaces, prefer "thickness," although usage overlaps.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/191dd4c1-a9d2-4045-aef7-52910a4bd180">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/7cc462a5-db43-4b25-a748-99892eba26aa"/>
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f04947ea-ae1d-4e63-9245-dfab10303e23">
+    <skos:prefLabel xml:lang="en">Mercury (Hg)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Hg</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">60</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/f04947ea-ae1d-4e63-9245-dfab10303e23</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/882336f3-a87d-4902-bb36-437f67a529fb">
+    <skos:altLabel xml:lang="en">Pa</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Protactinium (Pa)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/882336f3-a87d-4902-bb36-437f67a529fb</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">82</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f4643b7d-2710-4aca-8892-c0eeed02dfe9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417227</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/80028d07-9c98-48cf-84db-f77bc01c8bbc"/>
+    <skos:prefLabel xml:lang="en">alternate titles</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Titles that vary from the primary title. Distinguished from "alternative titles."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2ab5c7a0-d903-4d2d-bf47-1d866d78f170">
+    <skos:prefLabel xml:lang="en">location of creation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/2ab5c7a0-d903-4d2d-bf47-1d866d78f170</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/90dbeb41-afa5-4e24-ba2c-bbc04779130d">
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300189630</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">print groupings</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Prints collected and grouped together, and that are usually related in theme.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d2ecdb4f-eca9-4407-953e-50fdf9f711b0">
+    <skos:prefLabel xml:lang="en">assignat (system of money)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412157</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Currency issued by the French revolutionary government between 1789 and 1796, in the form of paper money and based on the security of the state lands.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7a18d2f2-e8d2-4ae7-a7ce-e4d02083149e">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025949</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+    <skos:scopeNote xml:lang="en">Commercial organizations or certain administrative units of government that provide a service.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">agencies</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9d84c6cb-70b1-4607-a035-2175a18f1991">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/9d84c6cb-70b1-4607-a035-2175a18f1991</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for dimension</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/66254b9a-26b4-44f7-8f66-26a11b1d8d03">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404764</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">sources (general concept)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/69abe4f9-f16f-47bf-8fdf-ccce67a18e5d"/>
+    <skos:scopeNote xml:lang="en">The originating cause or substance of some material thing or physical agency, or the conceptual inspiration for a conceptual thing.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7f675a9f-975b-4313-87bf-32d6ed32c22c">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026687</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">acknowledgments</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b"/>
+    <skos:prefLabel xml:lang="de">Danksagung</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Schriftliche Anerkennung für Handlungen oder Leistungen.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Written recognitions of acts or achievements.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/68236382-7c0b-495b-a0c3-ad694e87914e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">56</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/68236382-7c0b-495b-a0c3-ad694e87914e</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">physical object part of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bd84c2be-3cab-44ec-952d-8316f6098d9e">
+    <skos:prefLabel xml:lang="en">location</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/cd093911-f1e1-4abb-bbb2-fcaea3ca03ab</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/38729dbe-6d1c-48ce-bf47-e2a18945600e">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388277</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Englisch</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">anglais</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">West Germanic language of the Indo-European language family that is closely related to Frisian, German, and Dutch (in Belgium called Flemish) languages. It is spoken in England and also used in many varieties throughout the world.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">English (language)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4a07b2a8-c879-43f4-9691-612335fb09d1">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">source reference for destruction event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">71</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/4a07b2a8-c879-43f4-9691-612335fb09d1</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/825d0d98-cdd9-461e-8e96-609159286bd9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="en">Latin (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">latin (language)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The Indo-European language in the Italic group that was originally spoken by small groups of people living along the lower Tiber River, and later spread around the world with the increase of Roman political power The oldest existing example of Latin dates to the 7th century BCE.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Latein</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388693</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2f7aa8c7-8162-41a2-a742-92103bc838e2">
+    <skos:scopeNote xml:lang="en">Process of analysis done by transversing the scanned subject by a detector or an electromagnetic beam; scanning is done to determine the nature, qualities, measurements, etc. of an object, living subject, area, or other thing; the analysis may involve the recording of information derived from the scanning.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">scanning</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/641c4612-732b-48c3-b958-3af2c5c3f647"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417742</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5bf90b5e-37eb-45af-b326-e4609208fcb0">
+    <skos:prefLabel xml:lang="en-US">Joining as Participant</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/5bf90b5e-37eb-45af-b326-e4609208fcb0</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/1ad61b29-95db-4885-a5ad-0d037e609488"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7762b31f-73da-4c5f-8c4c-11909b946f50">
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">period of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/70847092-39b5-4620-97ed-2ec6e1a14c21</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cc1e74e4-131e-4ca8-aeee-e7c300093da4">
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f95fd4f0-31e5-42ff-b8b0-5fe5fea34c65">
+    <skos:prefLabel xml:lang="en">Polonium (Po)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">78</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/f95fd4f0-31e5-42ff-b8b0-5fe5fea34c65</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Po</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a45e32f8-3025-49d7-9ad3-f0f960b4f772">
+    <skos:prefLabel xml:lang="en">proceedings (reports)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Records of meetings, conferences, learned societies, or other organizations, usually published, and frequently accompanied by abstracts or reports of papers presented. </skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Bericht über die Sitzungen einer Konferenz, Gesellschaft oder anderen Organisation, der normalerweise veröffentlicht wird, meist mit Kurzfassungen oder Berichten über die gehaltenen Vorträge.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027316</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">actes</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:prefLabel xml:lang="de">Tagungsbericht</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/23e4a3b3-ad56-456f-b9ae-88211f0dc40d">
+    <dcterms:identifier>http://localhost:8000/23e4a3b3-ad56-456f-b9ae-88211f0dc40d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/07e8d7a0-551f-4200-8c71-8a03e1f02d36"/>
+    <skos:prefLabel xml:lang="en">contact point</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/58e0487d-3421-41ef-ab8e-4a635eb40e9d">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412190</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Danish rigsdaler (system of money)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">General term for several currencies used in Denmark until 1875.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/62793e6b-097a-4045-be89-bcb0b4bc5cef">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300266190</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e"/>
+    <skos:scopeNote xml:lang="en">The smallest units of an electronic display of digital imagery. In a black and white display this unit registers as either on or off. With a color display, the number of colors that may be displayed are limited by the screen's 'pixel depth,' measured in bits. The resolution of computer displays is also measured in pixels: the higher the number of pixels, the greater the resolution of the image displayed.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">pixels</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Bezieht sich auf das Maß der kleinsten Einheit einer elektronischen Anzeige von computererzeugten Bildern. Auf einem Schwarz-Weiß-Monitor ist diese Einheit entweder an oder aus. Bei einer Farbanzeige wird die Anzahl der Farben, die angezeigt werden können, durch die "Pixeltiefe" beschränkt, die in Bit gemessen wird. Die Auflösung des Computerbildschirms wird ebenfalls in Pixeln gemessen: je höher die Anzahl der Pixel, desto größer ist die Auflösung des gezeigten Bildes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Pixel</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d4e4db86-a948-4d6a-b89f-d1682d038afe">
+    <skos:scopeNote xml:lang="en">The rigid, calcareous material that is white in color and forms the skeleton of vertebrates; primarily composed of calcium hydroxyapatite with smaller amounts of calcium carbonate, calcium fluoride, magnesium phosphate, and ossein, a high molecular weight protein. Bones have a concentric structure with central lymphatic canals surrounded by a spongy lamellar region protected by a dense outer cortex. Bone has been carved and used since ancient times for many purposes, including fish-hooks, spear heads, needles, handles, and art objects. Bones were also burnt to produce bone black and boiled to produce bone glue. Bone can be distinguished from ivory by being generally whiter, more porous, and less dense.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Knochen</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="pt">osso</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">bone (material)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011798</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">os</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4a492b33-7021-4a9f-83ef-299de029158b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/93dc2aa7-a6d9-4a93-93dc-0752b890beb7">
+    <skos:prefLabel xml:lang="en">Canadian</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The culture and nationality of the people in the current nation of Canada.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300107962</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="fr">canadienne</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e1411d6d-0e6e-49ba-b677-58f0e377dd2e">
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f24f177f-9849-48d9-ba67-621d577f71e9"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bc5364c9-6179-429f-b643-88889e0291f1">
+    <skos:inScheme rdf:resource="http://localhost:8000/b27ffefc-18a1-468f-8923-87530b6f5943"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">management</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054594</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Functions including organizing, supervising, and carrying out the activities of a person, group, organization, or enterprise, and controlling its human and material resources, involving primarily the application rather than the formulation of policy. When the formulation of policy is the primary aspect, use "administration."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a5ae03f5-d2c0-4336-b170-2019d7cae51b">
+    <skos:scopeNote xml:lang="en">Discourses advancing an original point of view as a result of research, especially as a requirement for an academic degree.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028028</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:prefLabel xml:lang="fr">thèses</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ae0239c0-1f46-46c1-9821-616824e6cb8d">
+    <dcterms:identifier>https://afs.test.fargeo.com/ae0239c0-1f46-46c1-9821-616824e6cb8d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <skos:prefLabel xml:lang="en">location of formation event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c19fd08b-6aed-4535-83a0-b80ff2655475">
+    <dcterms:identifier>https://afs.test.fargeo.com/c19fd08b-6aed-4535-83a0-b80ff2655475</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <skos:prefLabel xml:lang="en">has modification activity</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/493e8f0d-2e89-439a-9e8d-f1e813388f3b">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/bbf81641-b1dd-4ddf-858d-7e8ca823d385">
+        <dcterms:title>TimeSpan Types - Overall</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Units of time equivalent to the 24-hour time interval between midnights, or the period of one full rotation of the Earth on its axis. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">days (units of time)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379242</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/855d9e88-1368-489a-893c-47f2a31db561">
+    <skos:prefLabel xml:lang="en">parent project</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/855d9e88-1368-489a-893c-47f2a31db561</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cd093911-f1e1-4abb-bbb2-fcaea3ca03ab">
+    <skos:prefLabel xml:lang="en">location</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/cd093911-f1e1-4abb-bbb2-fcaea3ca03ab</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a795a0c7-7643-4748-94a1-70e45cbd65e5">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of death of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/a795a0c7-7643-4748-94a1-70e45cbd65e5</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/96ff3fba-60d2-4d7e-ba2e-5b7e47bf7617">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/7e932636-476c-41f5-99d3-2e13615d024f</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">40</arches:sortorder>
+    <skos:prefLabel xml:lang="en">owner</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/36c303a8-d7fb-4030-93a4-3a874cf70034">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011021</dcterms:identifier>
+    <skos:prefLabel xml:lang="pt">ouro</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Pure metallic element having symbol Au and atomic number 79; a soft, inert, shiny reddish yellow metal that is very malleable and ductile. Gold has been highly valued and found in artifacts dating to before 5000 BCE. Native gold, found in quartz veins (vein gold) and alluvial deposits (placer gold), generally contains some silver and copper. Gold is purified by dissolution in mercury or cyanide solutions, by melting, or by electrodeposition. The purity of commercial gold is expressed in karats which is the number of parts of gold in 24 parts of the alloy. Today gold is primarily used for monetary systems and for jewelry.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="en">gold (metal)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Gold (metal)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">or (metal)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/58b2a731-e2f9-4925-b950-c4e0a908821d">
+    <skos:prefLabel xml:lang="en">Strontium (Sr)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">98</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/58b2a731-e2f9-4925-b950-c4e0a908821d</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Sr</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dfd2f1ed-4af4-4fcc-8dac-a001a0ddc523">
+    <skos:inScheme rdf:resource="http://localhost:8000/de10c1c8-a3a4-43e0-8afc-43720a9ad3a9"/>
+    <dcterms:identifier>http://localhost:8000/dfd2f1ed-4af4-4fcc-8dac-a001a0ddc523</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">conception</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4c10d2b0-92c1-4752-a991-c6c051c3d9c2">
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+    <skos:scopeNote xml:lang="en">Includes offers by one person or organization to another of terms and conditions with reference to some work or undertaking and plans or schemes put forward for consideration, discussion, or adoption.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">proposals</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027261</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/75e01ae4-4659-4d3b-85a5-4d7386fd9c29">
+    <skos:prefLabel xml:lang="en">brief text</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300418049</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+    <skos:scopeNote xml:lang="en">Documents comprising texts that are relatively short in length, sometimes but not always abbreviated versions of longer texts.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/144a0f7b-8c64-4454-b5b0-e441772a95f2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">creator</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/00a828d4-74d8-45ed-b4ec-cf6f709bb693</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2c276821-6d7b-421d-bea4-814669f7aa7f">
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379098</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">In the metric system, units of length equal to 1/100 of a meter, or .3937 (nearly 2/5) of an inch. </skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en-US">centimeters</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7a2954a9-df05-40e4-9630-dabdf41903dc">
+    <dcterms:identifier>https://afs.test.fargeo.com/7a2954a9-df05-40e4-9630-dabdf41903dc</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object used in part removal event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">61</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9c9ea021-34bc-4f4d-9b19-baff24198e36">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417643</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/5f7df45b-31ae-44ce-a8cc-55ccdafa019d"/>
+    <skos:scopeNote xml:lang="en">Method of acquiring property through bidding at an auction.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">auction (method of acquisition)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/81a2eb6c-33d2-4ab6-b044-0974eb6dffb6">
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/525aee44-e205-4684-9218-b5c4f39397ee">
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/525aee44-e205-4684-9218-b5c4f39397ee</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">parent digital resource</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0870ac7d-edd3-4214-ba2b-185396528024">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389336</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Swedish (language)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">suédois</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Schwedisch</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5d34bcba-7196-44ea-94c1-6180a0bb5927">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300266477</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">terabytes</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Unit of measurement for computer file storage equal to approximately one trillion bytes. Specifically, 1,099,511,627,776 bytes.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f727ef24-5040-430b-975b-741eb542cd2d">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">européenne</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <skos:scopeNote xml:lang="en">Styles, periods, and cultures of the continent of Europe, which is in the northern hemisphere, is bounded by the Arctic Ocean, the Atlantic Ocean, and the Mediterranean Sea, and is generally considered to be delimited on the east by the Ural Mountains.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">European</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300020656</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6574ad8a-e271-49ee-8853-640db00a8ec2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">has influence on set removal event of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/6574ad8a-e271-49ee-8853-640db00a8ec2</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/14aaf84d-4bd1-40c4-8f6e-6e0e368a49d4">
+    <skos:prefLabel xml:lang="en">diagrams</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Grafischer Entwurf, der eher erläutert denn darstellt.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Graphic designs intended to explain rather than simply represent. For example, in geometry, a diagram may be a figure composed of lines, serving to illustrate a definition or statement, or to aid in the proof of a proposition. In other contexts, a diagram may be any illustrative figure which, without necessarily representing the exact appearance of an object, gives an outline or general scheme of it, so as to explain or exhibit the shape and relations of its various parts.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Diagramm</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300015387</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9830adca-4ef8-4088-8cff-cae89a8af60c"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6a7d74ed-b78a-4e98-abe6-d0a967b42702">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300015342</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">mosaics (visual works)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:scopeNote xml:lang="de">Bild oder Muster, das aus kleinen, gleichmäßig geformten Stücken aus dauerhaftem Material, gewöhnlich Stein oder farbiges Glas, zusammengesetzt ist. Zu unterscheiden von "Opus sectile", das aus individuell geformten Stücken aus dauerhaftem Material, gewöhnlich Stein oder Glas, zusammengesetzt wird, die sich der Darstellung oder dem Muster anpassen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Mosaik</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Images or patterns composed of small, regularly shaped pieces of durable material, usually stone or colored glass. Distinguished from "opus sectile," which is composed of individually shaped pieces of durable material, usually stone or glass, which conform to the design or pattern.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f3725a5c-4f37-4142-b252-86bdd125988a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Superintending or managing the collections, exhibitions, research activities, and personnel of a museum, art gallery, zoo, or other place of exhibit; also, the superintending or managing of a single collection or subject of study in such an institution.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054277</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/74760cd2-f255-474c-87d5-2e1c5394d11e">
+        <dcterms:title>Curation Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:prefLabel xml:lang="en">curating</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c948c069-5765-4202-bcab-a8be73e7cc4a">
+    <skos:inScheme rdf:resource="http://localhost:8000/e17c5d7f-eaf2-4e7d-9490-a3e362f74bdc"/>
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a40d51c0-1106-410c-b3d6-f3c56f775806">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404764</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The originating cause or substance of some material thing or physical agency, or the conceptual inspiration for a conceptual thing.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+    <skos:prefLabel xml:lang="en">sources (general concept)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fc767b12-ec83-49a9-bf4e-dc11d1d63bc9">
+    <skos:prefLabel xml:lang="en">laboratory notes</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027202</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Labornotiz</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Notes made in the course of scientific inquiry conducted in a controlled environment.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Notiz, die bei einer wissenschaftlichen Untersuchung in einer kontrollierten Umgebung verfasst wird.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/99a73d48-8bda-42f3-aefb-cffbbba2a7fa">
+    <skos:inScheme rdf:resource="http://localhost:8000/c8261144-c750-4f64-8980-e50f762b21a5"/>
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6bf01a01-4055-417a-b814-5a8051125697">
+    <skos:altLabel xml:lang="en">Lv</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Livermorium (Lv)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">54</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/6bf01a01-4055-417a-b814-5a8051125697</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0c9ac7fb-b8ea-4759-aefd-7d76d13cc82f">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">45</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for contact information</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/05137059-4a6c-4bf5-934d-c1ca7378246d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/10a215ed-a80c-4974-82a0-68766141b434">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/10a215ed-a80c-4974-82a0-68766141b434</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Helium (He)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">He</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">42</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9605ed38-f319-4678-8976-a1502c241ca4">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">location of set removal event of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/9605ed38-f319-4678-8976-a1502c241ca4</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">38</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6ecfc5d9-6082-465b-8294-670ad9c9270e">
+    <skos:prefLabel xml:lang="de">Druckgrafik</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc"/>
+    <skos:scopeNote xml:lang="en">Refers to the activity of producing prints as works of art; for the specific processes employed, use such terms as "intaglio printing" or "mezzotint." For the production of other types of printed material, use "printing."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300131119</dcterms:identifier>
+    <skos:prefLabel xml:lang="en-US">printmaking</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/535e70a2-5dca-4796-bbd4-35a4f4b4d33f">
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:prefLabel xml:lang="en">3D Printer</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Machines used to create a physical object from a three-dimensional digital model, typically by laying down thin layers of a material in succession.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">imprimante 3d</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300391466</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f2ba0472-18f6-40b8-bd0a-2c07bb641f8d">
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f6ae1e05-4657-464d-858e-f1426de3e9d3">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+    <skos:scopeNote xml:lang="en">Groups who work to promote or accomplish stated goals through projects or other activities.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">initiatives (groups)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300443859</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/23a1a57e-b3c1-40e6-a0f2-e662d3964f11">
+    <skos:prefLabel xml:lang="en">source reference for creation of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/6398dee0-6c11-40aa-97ef-496009784adb</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a0e209ae-85c5-4e8c-98ab-05710b356471">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ca9e81f3-471d-4d1f-b323-edc816b1c522"/>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0d660e45-fde0-47d8-b0c8-949a9ad397ef">
+    <dcterms:identifier>http://localhost:8000/0d660e45-fde0-47d8-b0c8-949a9ad397ef</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">land registry ID</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/c8261144-c750-4f64-8980-e50f762b21a5"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/da640a1f-6adf-4498-aeef-419267508376">
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c000d8be-cc35-430b-b250-5105395204d0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">group titles</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Titles applied to archival groups, which are aggregates of items that share a common provenance.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417216</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/324861e0-21c5-4bb4-9702-2ff478038a2e">
+    <skos:prefLabel xml:lang="en">fiber optics reflectance spectroscopy (FORS)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a8e8388-0bb9-42f2-bc77-fc5a1c640589"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/324861e0-21c5-4bb4-9702-2ff478038a2e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/23da916d-1424-44f5-a85e-e5dacbcce27a">
+    <skos:inScheme rdf:resource="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">two-spirit</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300438744</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">A broad term used for a variety of non-binary sexual expressions of individual indigenous North American people. More specific terms are unique to language groups.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c77f3f92-ee00-4875-a404-50a8a9ea7dc1">
+    <skos:prefLabel xml:lang="en">Erbium (Er)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Er</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/c77f3f92-ee00-4875-a404-50a8a9ea7dc1</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2405aba5-e27c-42e6-9bd2-f6faf5e97369">
+    <dcterms:identifier>https://afs.test.fargeo.com/2405aba5-e27c-42e6-9bd2-f6faf5e97369</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">output of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d94192dd-b513-443e-b20f-b5002aba0176">
+    <dcterms:identifier>https://afs.test.fargeo.com/d94192dd-b513-443e-b20f-b5002aba0176</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">location of group leaving event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cead6e47-d4b2-42fe-84b6-42bca2857d11">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/cead6e47-d4b2-42fe-84b6-42bca2857d11</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object used in creation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3738060e-8206-49ea-8b3d-79757c01e037">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">35</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/8e6005a1-849d-426e-b657-5907b817d79b</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object used in professional activity</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b391c967-2a6b-4972-9289-17130cf96557">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300056240</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/c9e838f8-7660-4701-821c-721dac98a10b"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">weight (heaviness attribute)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Measurement of the relative heaviness of an object or other body; the force with which a body is attracted toward the earth or a celestial body by gravity.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/96151ca8-8e58-4e07-a490-c6152e2c5048">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379226</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+    <skos:prefLabel xml:lang="en">kilograms</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Metric units of mass equal to about 2.205 pounds. One kilogram is approximately equal to the weight of 1000 cubic centimeters of water. The kilogram is the base unit of mass in the International System of Units (SI) (the Metric system); defined as being equal to the mass of the International Prototype of the Kilogram. It is the only SI unit that is still directly defined by an artifact rather than a fundamental physical property that can be reproduced in different laboratories.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/56e7adac-4b55-46d6-9f8a-0283a4ffdd8a">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/5f6772d0-149d-42b1-9e76-56fe018d7380">
+        <dcterms:title>Activity Identifier Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d1b6852a-95cf-4ceb-a4de-78096e48b457">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+    <skos:prefLabel xml:lang="en">publication starts after event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/d1b6852a-95cf-4ceb-a4de-78096e48b457</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4a313fdf-bad8-47a3-a0f3-3918de7d5920">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">location of part removal event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/4a313fdf-bad8-47a3-a0f3-3918de7d5920</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b1bcc89f-22bd-42d3-bfc8-e694d5f8d460">
+    <skos:inScheme rdf:resource="http://localhost:8000/db261e02-be27-4a99-b9c1-875375103a1d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">data specialist</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/b1bcc89f-22bd-42d3-bfc8-e694d5f8d460</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/58a9665f-e444-445a-8736-b76641edccbe">
+    <skos:prefLabel xml:lang="de">Karton (Papier)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300014224</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">cardboard</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">A type of stiff pasteboard that is thicker than 0.006 inches, typically consisting of good-quality chemical pulp or rag pasteboard, and varying greatly in type and stability. High quality archival cardboard is made from rag pulp and has a low acid content, used for mounting prints, drawings and watercolors. Other grades of cardboard is used for cards, signs, printed materials, and high-quality boxes. Inferior grades of cardboard, such as corrugated board, are made from coarsely ground sulfite treated wood pulp; for this board, use "corrugated board." The first carboard box was produced in England in 1817. Corrugated cardboard was patented in 1871.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">carton (papier)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/18610abd-e0e5-48bb-9a7a-3830d75755d0">
+    <dcterms:identifier>http://localhost:8000/18610abd-e0e5-48bb-9a7a-3830d75755d0</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">primary title</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/80028d07-9c98-48cf-84db-f77bc01c8bbc"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5067abda-bc6a-47cb-9daf-08af69ad6f75">
+    <dcterms:identifier>https://afs.test.fargeo.com/24f4f6ae-ca63-4559-bfec-f50ab6c8346b</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">33</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location of production event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/74ecdce5-765d-4de1-9a62-a24bd47f5b79">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="en">canvas (textile material)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300014078</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">toile (matériau textile)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Closely woven textile made in various weights, usually of flax, hemp, jute, or cotton, used especially for sails, tarpaulins, awnings, upholstery, bags, and as a support for oil painting. </skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Leinwand</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f8cc9721-cbab-4d76-a588-4a76c220687d">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Scandium (Sc)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">92</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/f8cc9721-cbab-4d76-a588-4a76c220687d</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Sc</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9659eadc-6219-47fa-b9da-5132dd3e7cb8">
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f24f177f-9849-48d9-ba67-621d577f71e9"/>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ea09fcb2-3405-4a60-84fc-cfedfe1886a0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/2ab5c7a0-d903-4d2d-bf47-1d866d78f170</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">location of creation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/766e82a0-e03d-4d62-9c45-37efea98c8cd">
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ac05986c-ffe8-4910-a73e-6efe0d451eda">
+    <skos:scopeNote xml:lang="en">Regarding personal names, last names held by a woman prior to marriage, at which time she may adopt her husband's last name.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404682</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663"/>
+    <skos:prefLabel xml:lang="en">maiden names</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ffbc9e3b-2a37-4664-8c50-678ca67e84b7">
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/25fcee5d-e563-470f-beb3-c85fc33f56ff">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object used in curation event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/25fcee5d-e563-470f-beb3-c85fc33f56ff</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b9c2b0a7-88b8-40d5-b605-0f74e4e0da61">
+    <skos:inScheme rdf:resource="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663"/>
+    <skos:prefLabel xml:lang="en">common names</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404687</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Names for people, places, or things that are commonly used, but not necessarily the official version of the name.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8be4ac1b-581b-4967-b7d6-5e2fe36fadb6">
+    <dcterms:identifier>https://afs.test.fargeo.com/8be4ac1b-581b-4967-b7d6-5e2fe36fadb6</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of creation</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/98cffed5-2102-45fb-ba12-7b287fd2e8f3">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411998</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The standard unit of currency of the United Kingdom.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <skos:prefLabel xml:lang="en">pound sterling (system of money)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/26b5a060-eddb-4e4a-a98c-98abc6272296">
+    <skos:prefLabel xml:lang="en">deleting (information handling)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/51e3963f-00b3-4a62-8704-5c89822555de">
+        <dcterms:title>Event Types - Set Removal</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">The process or function of subtracting material or records.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417258</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/942bdfe3-53ec-43e8-a474-822ea48d7e80">
+    <skos:prefLabel xml:lang="en">has influence on</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/f62ccd87-14d8-48b9-9114-b8f752b6d999</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/080cc639-4eef-4eef-80aa-8bc022e7c92b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/080cc639-4eef-4eef-80aa-8bc022e7c92b</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <skos:prefLabel xml:lang="en">group part of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fb173f25-ffe6-46a2-9bc9-daa4a6a21fb1">
+    <skos:prefLabel xml:lang="en">influence on curation event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/fb173f25-ffe6-46a2-9bc9-daa4a6a21fb1</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8b7bd8bb-b228-4d0d-91a8-038f202d9f51">
+    <skos:altLabel xml:lang="en">Na</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/8b7bd8bb-b228-4d0d-91a8-038f202d9f51</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Sodium (Na)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">97</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/271a4bf1-5743-488d-9405-c857f6fad2bc">
+    <skos:prefLabel xml:lang="en">location of professional activity</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/6046ddcf-6698-4e9f-8c04-7459109d04e3</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d17fc127-2d45-4805-9647-576b1c8e0f65">
+    <skos:prefLabel xml:lang="en">set member of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/5bd80233-7f66-41a1-bc32-2e9b49126bef</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">69</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d8f9f8d4-aa37-4e7c-a979-bb5c83954060">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/8f3bebaa-3ee9-41a8-bbed-f484d2efc300</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <skos:prefLabel xml:lang="en">location of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/52454dff-1c2b-4e39-9c1b-0879993cf08f">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">50</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/52454dff-1c2b-4e39-9c1b-0879993cf08f</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Lanthanum (La)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">La</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2755659d-2ec5-4ec5-872a-2fcd30238133">
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f61056d0-07cf-40da-8694-e23c2deb3bd5">
+    <dcterms:identifier>https://afs.test.fargeo.com/f61056d0-07cf-40da-8694-e23c2deb3bd5</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <skos:prefLabel xml:lang="en">influence on professional activity</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/63107356-a1bb-4d75-88af-6879974f02f7">
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e17c5d7f-eaf2-4e7d-9490-a3e362f74bdc"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/35159c58-3b68-4f2f-b6f6-10c2a873d5d7">
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054107</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The deterioration of metal or other substances by chemical or electrochemical reaction resulting from exposure to weathering, moisture, chemicals, or other agents.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">corrosion (condition changing process)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7efca7ef-8ab1-4bb6-8b72-d93f4b9f46be">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300235507</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">céramique (material)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">ceramic (material)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to any of various hard, brittle, heat-resistant and corrosion-resistant materials made by shaping and then firing a nonmetallic mineral, such as clay, at a high temperature.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/544bdec1-d2ba-4de6-bbdc-78b038834695">
+    <skos:prefLabel xml:lang="en">Russian (culture or style)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Russia, or to the cultures that have occupied the principal lands of historic Russia in eastern Europe and northern and western Asia. It may also be used to refer to the larger group of cultures controlled by the historic Soviet Union.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="fr">russe</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111276</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bd6d0d34-a399-4b19-98e3-f19dd1ba50ea">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">depicts</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/bd6d0d34-a399-4b19-98e3-f19dd1ba50ea</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6398dee0-6c11-40aa-97ef-496009784adb">
+    <dcterms:identifier>https://afs.test.fargeo.com/6398dee0-6c11-40aa-97ef-496009784adb</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for creation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4dcf0ed7-5679-4ef0-b793-07d25ad55f5b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:scopeNote xml:lang="en">All examples of a set number or amount of multiples, such as coins, notes, stamps, prints, copies of a newspaper, books, periodicals, etc. that were issued at one time or otherwise sharply distinguished in pattern, design, color, or identifying numbers from those issued at another time.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300312349</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">issues (object groupings)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b53e679f-73d0-4933-a39c-facf23ce0c49">
+    <skos:prefLabel xml:lang="fr">philippine</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the hybrid style and culture of the Philippines reflecting the region's influx of trade and exchange with Chinese, Islamic, and Hindu cultures. Domestic folk arts of the archipelago nation reflect Indianized geometric motifs in textiles, weapons, and containers. Pre-colonial architecture featured megalithic monuments similar to late Tantric east Javanese tjandis. Painting and sculpture in the region reflect Indian erotic imagery, Buddhist images, and ornamental, curvilinear designs. Ceramic styles were often imitations of Chinese Sung Dynasty designs. As a result of Spanish colonialism from the 16th to 19th centuries, art later predominantly reflected Spanish Christian iconography in painting and colonial churches and cathedrals in Neo-Byzantine and elaborate, flamboyant designs. Secular art gained prominence in the later 19th century and followed European or international business aesthetics.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <skos:prefLabel xml:lang="en">Philippine</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300018772</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bb798e77-861d-47d8-a19b-5e9b25b6633d">
+    <skos:scopeNote xml:lang="en">Persons' names written in their own hand.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <skos:prefLabel xml:lang="en">signatures (names)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Der eigenhändig geschriebene Name einer Person.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Unterschrift</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028705</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5627a014-3495-4d24-9543-21a577adaaaf">
+    <skos:prefLabel xml:lang="en">ISBN</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea">
+        <dcterms:title>Identifier Types - Textual Work</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417443</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">In bibliography, 10- or 13-digit number assigned before publication to a book or edition, which identifies the work’s national, geographic, language, or other convenient group and its publisher, title, edition, and volume number.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ac043ac3-12ef-4047-b4cf-cd3c32f26c16">
+    <skos:prefLabel xml:lang="en">influence on creation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/4455ae0b-c49e-4940-b43a-4b818848fdd4</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa1e1e2e-0d45-4453-b874-8a459715685d">
+    <skos:prefLabel xml:lang="en">Flerovium (Fl)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Fl</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">33</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/fa1e1e2e-0d45-4453-b874-8a459715685d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a23008bd-df63-4d01-a3c7-e22e0f34ad80">
+    <skos:scopeNote xml:lang="en">Groups of persons delegated to consider, investigate, or take action upon and usually to report concerning some matter or business.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025980</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">committees</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/31dc6e79-9812-4768-b267-ba8c6ce6e11c">
+    <skos:inScheme rdf:resource="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/df1fc10d-ac86-4424-8ac6-50f9b7250f09">
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">44</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/35e06abe-f5a1-471e-ba9b-9b4611d5e717">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">82</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7f3ae088-5b8d-4085-b5d7-7c91d37d9fbd">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">physical object used in creation</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/af047bfd-5454-41ef-812a-9fbf6ad9a0ac</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fb43fbb6-409f-4f48-aee6-c0b686ccee4b">
+    <dcterms:identifier>https://afs.test.fargeo.com/46123a1f-6786-4cef-8193-c1f72e67cc5c</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">member of set</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">39</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/911f6feb-7c1c-4d67-a86d-333e70aa77b5">
+    <skos:altLabel xml:lang="en">Tb</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">104</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/911f6feb-7c1c-4d67-a86d-333e70aa77b5</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Terbium (Tb)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e1c820af-96ad-41c0-97f1-80db421bb2ea">
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/80249c96-22e0-4ef5-bc2c-711ef1dbf6ad">
+    <dcterms:title>Name Types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/f162c061-09a7-4338-8564-84e531bad5e5">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Curium (Cm)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/f162c061-09a7-4338-8564-84e531bad5e5</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Cm</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/392e4a35-2710-4467-86f9-650f5aea9630">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Method of acquiring funds or property through transference of ownership from one party to another as a free gift.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5f7df45b-31ae-44ce-a8cc-55ccdafa019d"/>
+    <skos:prefLabel xml:lang="en">donation (method of acquisition)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417638</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4583a363-ad2d-4dd9-8c7c-b1a433f53079">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="en">pounds (units for weight)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379254</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">In avoirdupois measure, standardized units of weight and mass equal to 16 ounces (7000 grains, exactly 0.45359237 kg). The pound was originally made up of 12 ounces, as in the system of troy weight which is still used in stating the weight of precious metals.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/905f6f3e-9cc0-479e-9e7d-e313a14f3297">
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404022</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">groups (archival divisions)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Archival groups are aggregates of items that share a common provenance. Archival groups may range in size from several thousand items (e.g., the entire body of drawings, models, and written documents from an architect's office) to just a few items (e.g., a handful of surviving drawings from one architectural project). Group-level cataloging focuses on the description of coherent, collective bodies of works. The description emphasizes the characteristics of the group as a whole, and highlights the unique and distinctive characteristics of the most important works in the group. Groups are usually defined by repositories, and may have several subgroups that are established by archival principles of provenance. The catalog record for a group normally corresponds to a physical group as it currently exists and is stored by the repository; however, historical groups may also be described. Groups may be divided into subgroups.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/51eb7a71-66e1-45ba-97c7-f92edcf4cdec">
+    <skos:prefLabel xml:lang="en">institutions (organizations)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Formally structured organizations, establishments, or associations created for the promotion of a specific benevolent public or private objective, usually a religious, charitable, or educational objective, such as a church, school, college, hospital, asylum, reformatory, mission, or the like.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026004</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c3e6c25d-0ea2-44e9-ba4c-8faf4397ec06">
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <skos:prefLabel xml:lang="en">has digital encoding</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/c3e6c25d-0ea2-44e9-ba4c-8faf4397ec06</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2f3620a3-2d8e-4e87-a274-3d56995e5685">
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <skos:altLabel xml:lang="de">Provenienz</skos:altLabel>
+    <skos:altLabel xml:lang="fr">provenance</skos:altLabel>
+    <skos:scopeNote xml:lang="en">The history of the ownership and transmission of an object, including previous locations of a work. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">provenance statement</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055863</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/759dc20a-0658-4913-9d60-5f8b8a1c23a3">
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/64fec2d2-89dd-43e8-985d-3b380ad69186">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Sg</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/64fec2d2-89dd-43e8-985d-3b380ad69186</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">93</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Seaborgium (Sg)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/19b0fa01-3d14-43c5-afde-0662376fb3f2">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300189559</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Referring to the sex that in reproduction normally produces sperm cells or male gametes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">male</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f7cd5a85-2b8d-42ec-9566-57a59af9c8c8">
+    <skos:prefLabel xml:lang="en">Gallium (Ga)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">37</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/f7cd5a85-2b8d-42ec-9566-57a59af9c8c8</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Ga</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/aa93ddb3-c3bc-4508-bf1c-bb592bfeb975">
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/2e0fefb8-7556-4ffb-b946-e3546bac2e72</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">actor in</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4ddf7134-357f-4a39-8804-36b791b9c61f">
+    <skos:prefLabel xml:lang="en">modification activity procedure</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/4ddf7134-357f-4a39-8804-36b791b9c61f</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/237f9065-c319-4c54-a8b5-065fd0fb7f92">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/237f9065-c319-4c54-a8b5-065fd0fb7f92</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for dissolution event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fe1fdf56-9669-401e-824c-0ff7368bdcaa">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/fe1fdf56-9669-401e-824c-0ff7368bdcaa</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Niobium (Nb)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">68</arches:sortorder>
+    <skos:altLabel xml:lang="en">Nb</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7d8aa2f8-f8a0-4d0d-a2a8-2fa8d64ae16b">
+    <skos:scopeNote xml:lang="en">The action of cutting, clipping, or dividing something with scissors or a similar tool.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="en">snipping</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053073</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fea87de8-c1e5-4978-aa18-7df19382d7d6">
+    <skos:prefLabel xml:lang="en">Turkish (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">turc</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Türkisch</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389470</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/654d8f80-ed8c-42a9-a085-f9afc9d76493">
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/654d8f80-ed8c-42a9-a085-f9afc9d76493</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object observed</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3a0ae954-8622-4dc6-a8ae-bdfbb8036783">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:prefLabel xml:lang="en">parent project</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/855d9e88-1368-489a-893c-47f2a31db561</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5ab6901a-1d94-4769-9a8c-3ca83d9aa519">
+    <skos:prefLabel xml:lang="de">Tamil</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389365</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Tamil (language)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">tamoul</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6d997904-184c-4825-8807-83e2dddb124f">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388486</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">East Asian language spoken primarily in Japan. Held by many modern scholars to be a member of the Japonic (or Japanese-Ryukyuan) family of languages, while others maintain that it is a language isolate.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Japanisch</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Japanese (language)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">japonais</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/546e7e19-54c6-44ed-8a81-3da08e275009">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The function, act, and process of making a new, amended, improved, or up-to-date version of something, such as data, a document, building plan, etc.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300191071</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/51e3963f-00b3-4a62-8704-5c89822555de"/>
+    <skos:prefLabel xml:lang="en">revising</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a6b75972-d4f5-47b3-9b15-e8edacfa910d">
+    <dcterms:identifier>https://afs.test.fargeo.com/a6b75972-d4f5-47b3-9b15-e8edacfa910d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <skos:prefLabel xml:lang="en">observation activity procedure</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4bb2e7b9-54aa-481e-abbe-a25381edef0e">
+    <skos:prefLabel xml:lang="fr">argile</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">clay</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Naturally occurring sediments that are produced by chemical actions resulting during the weathering of rocks. It is often the term applied to all earths that form a paste with water and harden when heated.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300010439</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/085e2a58-ecaf-4f67-a8f7-5eafc905bbe0">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:prefLabel xml:lang="en">influence on production event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/085e2a58-ecaf-4f67-a8f7-5eafc905bbe0</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/340a38a7-8ed9-4a07-a4a4-a28c8fe77b28">
+    <skos:inScheme rdf:resource="http://localhost:8000/5f3c2407-2e22-4022-9795-2f3ef963d5aa"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">exact</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/340a38a7-8ed9-4a07-a4a4-a28c8fe77b28</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/edc6ad13-8a1f-412e-8913-a711231d5640">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"/>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1b162cc8-1f31-4fb3-81f9-2479b21d01aa">
+    <skos:prefLabel xml:lang="en">copyright/licensing statement</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">A formal statement of the copyright or licensing of a work, and/or any restrictions placed on it. </skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435434</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/477438d2-c018-456e-8513-ae7f563a66c5">
+    <skos:inScheme rdf:resource="http://localhost:8000/8dc4c1ac-aae5-41f6-817b-9ee5fef855fe"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300424602</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">document numérique</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/135ccd63-25ca-4e3e-919f-ff09bf062274">
+    <skos:prefLabel xml:lang="de">Sanskrit</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">sanskrit</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389205</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Sanskrit (language)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cb4cc06d-3d14-480f-aab1-b02c28042946">
+    <skos:prefLabel xml:lang="en">source reference work for creation event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/cb4cc06d-3d14-480f-aab1-b02c28042946</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/759cca44-5219-4074-beda-214a81c201b0">
+    <skos:scopeNote xml:lang="de">Wird in Bezug auf eine Gruppe von Gegenständen verwendet, die zusammen benutzt oder betrachtet werden soll.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300133146</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Set (Objektgruppe)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Assemblies of items that the creator intended to be kept or seen together, cuch as a tea set, a desk set, or a pair of terrestrial and celestial globes. A set differs from a collection in that it is typically smaller and it was intended by the creator to be grouped together. It is useful to catalog the set as a whole when the items in the set will not be cataloged separately or when there are characteristics of the whole set that may not be apparent in the individual records for the parts. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">sets (groups)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/facf36fa-b7ab-4307-bd1e-9471e37fde9e">
+    <skos:prefLabel xml:lang="en">influence on set addition event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/facf36fa-b7ab-4307-bd1e-9471e37fde9e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cb2341f0-6120-4a75-85fd-9fe200a7a111">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">producer of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/bcea7794-7ce8-4f82-882a-3aa6b083a275</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">68</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b7465fec-27aa-48fd-a428-4927a397c0e5">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/b7465fec-27aa-48fd-a428-4927a397c0e5</dcterms:identifier>
+    <skos:prefLabel xml:lang="pt">cerâmica</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">poteries (œuvres visuelles)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Generally, all ware made of ceramic, which is any of various hard, brittle, heat-resistant and corrosion-resistant materials made by shaping and then firing a nonmetallic mineral, such as clay, at a high temperature. In specialized usage, it typically does not include porcelain, which is a type of ceramic ware made of a refractory white clay, or "kaolin," and a feldspathic rock, that react when fired so the clay serves to hold the shape of the object and the rock fuses into a natural glass.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:scopeNote xml:lang="pt">Geralmente, todos os utensílios de cerâmica, que são vários materiais duros, quebradiços, resistentes ao calor e à corrosão, feitos moldando e depois queimando um mineral não metálico, como argila, a alta temperatura. Em uso especializado, normalmente não inclui porcelana, que é um tipo de louça de cerâmica feita de argila branca refratária, ou "caulino", e uma rocha feldspática, que reage quando queimada, de modo que a argila serve para manter a forma do objeto e a rocha se funde em um copo natural.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">pottery (visual works)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ecc650ae-ab21-4e48-b0c7-3a8b915a6bb4">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">37</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">location of set removal event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/ecc650ae-ab21-4e48-b0c7-3a8b915a6bb4</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b655bf98-5a16-4641-8362-c78624d8d171">
+    <skos:scopeNote xml:lang="de">Dokument, der Öffentlichkeit durch Verkauf oder sonstige Eigentumsübertragung oder durch Miete, Leasing oder Kredit zugänglich.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Documents distributed to the public by sale or other transfer of ownership, or by rental, lease, or lending.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Veröffentlichung</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+    <skos:prefLabel xml:lang="en">publications (documents)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111999</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6ea6fd8e-e234-49d2-9edf-03786847c836">
+    <skos:inScheme rdf:resource="http://localhost:8000/69abe4f9-f16f-47bf-8fdf-ccce67a18e5d"/>
+    <skos:prefLabel xml:lang="de">Danksagung</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written recognitions of acts or achievements.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026687</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">acknowledgments</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Schriftliche Anerkennung für Handlungen oder Leistungen.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3b515129-0c9e-4471-b2e0-2d64231a8e43">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">creation starts after event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/3b515129-0c9e-4471-b2e0-2d64231a8e43</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bbb94e5c-2e82-46d1-bc97-a0423d3fb2d7">
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:prefLabel xml:lang="de">Manuskript (Dokumentengattung)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028569</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Handgeschriebenes Dokument, vor allem Bücher und andere Dokumente vor der Erfindung der Druckmaschine. Die Bezeichnung kann auch verwendet werden, um bestimmte Dokumente von veröffentlichten oder anderweitig gedruckten Dokumenten zu unterscheiden, wie in den Fällen von persönlichen Briefen oder mit der Scheibmaschinen geschriebenen Dokumenten, aus denen später gedruckte Ausgaben entstanden.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">manuscripts (documents)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">manuscrits</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Handwritten documents, particularly books and other documents created before the invention of the printing press. May also be used to distinguish certain documents from published or otherwise printed documents, as in the cases of typed personal letters or a typescript from which printed versions are made.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ba1c2229-fd11-4e00-ac4a-f19c476bc8bb">
+    <skos:inScheme rdf:resource="http://localhost:8000/5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"/>
+    <skos:scopeNote xml:lang="de">Kurze Angabe über eine Tatsache oder ein Erlebnis, niedergeschrieben zur Überprüfung oder als Erinnerungshilfe, oder um jemand anderen zu informieren; schließt auch kurze, formlose Briefe mit ein.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Brief statements of a fact or experience, written down for review, or as an aid to memory, or to inform someone else; also includes short, informal letters.</skos:scopeNote>
+    <skos:altLabel xml:lang="de">Notiz (Dokumentengattung)</skos:altLabel>
+    <skos:prefLabel xml:lang="en">note</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027200</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f37e69ea-ce89-4a5c-924b-172a2ac7e9a0">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300312281</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Eine Einrichtung, in denen Objekte von Wert wie Kunstwerke, Antiquitäten, wissenschaftliche Präparate oder andere Artefakte bewahrt und für die Öffentlichkeit ausgestellt werden. Eine Einrichtung, die sich mit der Sammlung, der Pflege, der Dokumentation, dem Studium und der Präsentation von Objekten von überdauerndem Interesse und Wert beschäftigen. </skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+    <skos:prefLabel xml:lang="de">Museum (institution)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">museums (institutions)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Institutions that maintain places where objects of value such as works of art, antiquities, scientific specimens, or other artifacts are housed and displayed for public benefit. An institution devoted to the procurement, care, documentation, study and display of objects of lasting interest or value.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f8004550-b659-4647-bc2c-d969b68c5714">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">staining (coloring)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Process of applying a coloring matter that tinges and penetrates or combines with the substance.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053058</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3e29bed6-4503-41ca-b5fe-ba92f158a5d9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/3e29bed6-4503-41ca-b5fe-ba92f158a5d9</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">location of curation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2ff81125-8e3f-43fc-a92a-75baed7639e3">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/2ff81125-8e3f-43fc-a92a-75baed7639e3</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Potassium (K)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">K</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">79</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b544f43a-f685-4091-bf79-f50191c0c32a">
+    <skos:prefLabel xml:lang="fr">albâtre</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011101</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Alabaster (mineral)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Fine-grained marblelike variety of gypsum that is easy to carve but is rather fragile; it has been used as a sculpture material, ornamental building work, vases, small decorative carvings, and powdered for use as a paper filler and paint pigment called mineral white or terra alba. Alabaster is usually a translucent white or pink but may also be a muted red, yellow or gray. It is soft and can be scratched slightly with a fingernail. It also dissolves slowly in wet environments.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">alabaster (mineral)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d52bc3d2-4933-48a0-ae88-998b576a8e85">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/d52bc3d2-4933-48a0-ae88-998b576a8e85</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <skos:prefLabel xml:lang="en">sample created</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/46ded2f4-2147-4136-92ed-1fa178f79b10">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <skos:prefLabel xml:lang="en">sampling procedure used</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/46ded2f4-2147-4136-92ed-1fa178f79b10</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8485c6d0-bed5-4af6-84da-3f294dd9cb1c">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411780</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="en">description</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written, digital, spoken, or signed representations of the attributes or qualities of something or someone.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a9cda9b2-9379-4626-9ed7-d6ef44bf13b5">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027268</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">administrative reports</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verwaltungsberichte</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Official or formal records outlining administrative details, or events sucha as functions, proceedings, or investigations.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">compte rendu administratif</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4efbc0b2-ccba-455c-ae24-2ff73f348cd0">
+    <dcterms:identifier>https://afs.test.fargeo.com/8be4ac1b-581b-4967-b7d6-5e2fe36fadb6</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of creation</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0dfb95af-dcd3-4edd-8763-a3939e65f1e7">
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389525</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">vietnamien</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Vietnamese (language)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Vietnamesisch</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/775271df-a7dc-4158-9eea-425ed089728d">
+    <skos:scopeNote xml:lang="en">The standard unit of currency of France prior to adoption of the Euro.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">French franc (system of money)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412016</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ba723d66-715f-49f3-b3d2-40c9f20510f1">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/ba723d66-715f-49f3-b3d2-40c9f20510f1</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Beryllium (Be)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Be</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b42fd6eb-b396-4ae0-926c-09f9a516f873">
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026096</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Ausstellungskatalog</skos:prefLabel>
+    <skos:prefLabel xml:lang="en-US">exhibition catalogs</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Publications that document the works displayed in an exhibition.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Druckwerk, das die in einer Ausstellung gezeigten Werke dokumentiert.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5bd80233-7f66-41a1-bc32-2e9b49126bef">
+    <skos:prefLabel xml:lang="en">set member of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/5bd80233-7f66-41a1-bc32-2e9b49126bef</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/77617e19-4102-4f2c-9a8c-4bb118d0d61d">
+    <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
+    <skos:altLabel xml:lang="de">Biografie (Dokument)</skos:altLabel>
+    <skos:scopeNote xml:lang="en">Written accounts of the lives of individuals. For the genre regardless of medium, prefer "biography (general genre)."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300080102</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Schriftlicher Bericht über das Leben einer Person.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7ebce11e-ee7e-475a-a36e-2b38f7d1d984">
+    <skos:prefLabel xml:lang="en">Cerium (Ce)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/7ebce11e-ee7e-475a-a36e-2b38f7d1d984</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Ce</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6a86dfe8-4cca-409f-9fbe-95dd3e1c5a16">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/6a86dfe8-4cca-409f-9fbe-95dd3e1c5a16</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">has observation activity</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/93c026d3-22d5-45a3-847b-4767d49a5bbf">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/93c026d3-22d5-45a3-847b-4767d49a5bbf</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">preventative conservation</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/b3d6e036-e788-4c85-a1f0-3aa35f0a82f2"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/db499c64-e4fa-4b38-846e-7066796eabe1">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/db499c64-e4fa-4b38-846e-7066796eabe1</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">influence on group joining event of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/283aec4b-cdeb-4a9f-bc12-f64fb6bacc14">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">64</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/283aec4b-cdeb-4a9f-bc12-f64fb6bacc14</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object used in set addition event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/85e3eee2-24cc-4adc-9fd9-6e2444beaafb">
+    <dcterms:identifier>https://afs.test.fargeo.com/85e3eee2-24cc-4adc-9fd9-6e2444beaafb</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">60</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object used in part removal event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/427a808f-e289-46e0-986c-58eeb697d884">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028744</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Standardized symbols, notations, or other markings applied to objects during or after creation, conveying information such as the object's origin or maker, its authenticity, or a change in its official status. For lettering marked on something for documentation or commemoration, use "inscriptions." For marks inherent in the paper support, not applied as part of the image or work, use "watermarks."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <skos:prefLabel xml:lang="en">marks (identifying markings)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">marques (symbols)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/feabbbcb-92a4-4c1f-b4cd-d4ad84802a88">
+    <dcterms:identifier>https://afs.test.fargeo.com/feabbbcb-92a4-4c1f-b4cd-d4ad84802a88</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">has influence on publication event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/116ca9ed-f735-4642-9338-0c1c9e9f55c8">
+    <dcterms:identifier>https://afs.test.fargeo.com/de8785a1-26e0-47f6-8612-a1909d88f55e</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of creation</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6186c844-0f95-4c21-926e-87347b45df8a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">63</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Neodymium (Nd)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Nd</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/6186c844-0f95-4c21-926e-87347b45df8a</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/191c70d0-82cd-4eeb-8a71-48f794f15211">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The length of a straight horizontal line extending from one side to the other of a form. For the measure or distance of the extent across a surface, prefer "breadth," although usage overlaps.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055647</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/c9e838f8-7660-4701-821c-721dac98a10b"/>
+    <skos:prefLabel xml:lang="en">width</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d6efe5ae-b804-4a4f-a64e-c6609c385c04">
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e17c5d7f-eaf2-4e7d-9490-a3e362f74bdc"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9d5fbc19-ceda-4c9b-89b8-c6826d53edd9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">has influence on</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/f62ccd87-14d8-48b9-9114-b8f752b6d999</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a470419e-e8a2-4fd7-98f2-7b8d5bf3bf2a">
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f3e8cc93-09ea-448d-9bae-d33a1c396919">
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Euro (system of money)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411996</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The standard unit of currency of the Eurozone, comprising member states of the European Union.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/11ad6581-394d-4120-bc72-6270fbeb82de">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">location</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/cd093911-f1e1-4abb-bbb2-fcaea3ca03ab</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/66d75c7b-cafc-4740-87ab-1d9ce3f755ea">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:altLabel xml:lang="en">Al</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/66d75c7b-cafc-4740-87ab-1d9ce3f755ea</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Aluminum (Al)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/598ce9bd-a5d6-4fd8-886f-7f45d99f1d57">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412169</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Reichsmark (system of money)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <skos:scopeNote xml:lang="en">From 1924 to 1948, used as the official designation of the German currency. Later historical use chiefly refers to this official designation during this period.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4a7ec821-f41e-4f5b-bec0-2e81f1ae3f20">
+    <skos:prefLabel xml:lang="en">source reference for group joining event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">39</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/4a7ec821-f41e-4f5b-bec0-2e81f1ae3f20</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9a51d30b-48e8-4f94-9344-cd2bb1d4b33a">
+    <skos:prefLabel xml:lang="en">description</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written, digital, spoken, or signed representations of the attributes or qualities of something or someone.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411780</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e9235c71-08a8-448d-850d-5b99b405f25e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="en">writing (processes)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Forming or producing letters to record the ideas which characters and words express or to communicate the ideas by visible signs.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054698</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fd14346d-4f3b-4cc3-aa40-195bbd2633b2">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/f24f177f-9849-48d9-ba67-621d577f71e9"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/339e769f-4259-450c-8572-903858343869">
+    <skos:altLabel xml:lang="en">As</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Arsenic (As)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/339e769f-4259-450c-8572-903858343869</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ff671512-6b50-4ae5-a609-a83c1fedf967">
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">53</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b759fb17-8868-45f9-889a-c4550b324e7c">
+    <skos:prefLabel xml:lang="de">Stadt (Siedlung)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Distinctions among villages, towns, and cities are relative and vary according to their individual regional contexts. Generally, cities designate large or important communities with population, status, and internal complexity greater than most towns in the region.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/09f4f591-5654-4518-931b-7ab382fbc100"/>
+    <skos:prefLabel xml:lang="en">cities</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Die Unterscheidung zwischen Dorf, Kleinstadt und Stadt ist relativ und variiert je nach dem individuellen, regionalen Kontext. In der Regel bezeichnet man als "Stadt" ein Gemeinwesen von erheblicher Bedeutung im Hinblick auf Einwohnerzahl, rechtlichen Status und innerer Komplexität, wenn diese Siedlung mit den meisten "Kleinstädten" in ihrer unmittelbaren Umgebung verglichen wird.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300008389</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2480537d-2dee-4ebe-8dad-fec0c8bb04a4">
+    <skos:altLabel xml:lang="en">Cn </skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/2480537d-2dee-4ebe-8dad-fec0c8bb04a4</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Copernicium (Cn)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8af67f6d-3f1b-4313-9668-d3969a0c5469">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:prefLabel xml:lang="en">oeuvre</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300070186</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The works produced by an artist or composer regarded collectively. For the collective body of works by a writer, use "corpora."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fdaa29fa-ac94-4c3a-802f-6a6b37f596fa">
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Spain, or in general to the cultures that developed on the Iberian Peninsula in southwestern Europe.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">espagnole</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Spanish (culture or style)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111215</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7655e50b-5fbe-4d1c-91ac-2f22592d8dff">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/7655e50b-5fbe-4d1c-91ac-2f22592d8dff</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of birth event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b2e43183-4bda-4baf-8d30-99752d5ff0e1">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435448</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">creation place description</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <skos:scopeNote xml:lang="en">A concise description of the location where the creation, design, or production of the work or its components took place, or the original location of the work. </skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7e932636-476c-41f5-99d3-2e13615d024f">
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/7e932636-476c-41f5-99d3-2e13615d024f</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">owner</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2b91123c-3263-48a5-8abf-55a9a6234665">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Actinium (Ac)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/2b91123c-3263-48a5-8abf-55a9a6234665</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Ac</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9648ddf9-9ec2-47a2-8235-f757af9193ff">
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Schriftliche Anerkennung für Handlungen oder Leistungen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Danksagung</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written recognitions of acts or achievements.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026687</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">acknowledgments</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e5d01387-04a8-4ceb-bff2-2de515b5e089">
+    <skos:prefLabel xml:lang="en">sources (general concept)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404764</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f44f7240-35c5-49e8-a0e3-2ffe308f0862"/>
+    <skos:scopeNote xml:lang="en">The originating cause or substance of some material thing or physical agency, or the conceptual inspiration for a conceptual thing.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/45290c05-28b7-447e-bc6d-d8cf3c86a748">
+    <skos:prefLabel xml:lang="en">location of birth of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/45290c05-28b7-447e-bc6d-d8cf3c86a748</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a440773e-a140-4e8e-9fa7-2773b1c88f25">
+    <skos:prefLabel xml:lang="en">pixels per inch</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300410391</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The resolution of electronic imaging devices such as computer monitors, digital cameras, televisions, or scanners, expressed as the number of pixels per linear inch. Pixels per centimeter also describes the resolution of image files.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2ebb9a11-2d7d-47de-90da-e728635cb76b">
+    <skos:prefLabel xml:lang="en">columns (layout features)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300200012</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/fd0222dd-bd50-4597-b092-d124833176b3"/>
+    <skos:scopeNote xml:lang="en">Vertical lists of items or vertical sections into which the text of a manuscript or printed page are divided, separated by rules or blank spaces. For texts written from side to side across the page, use "long line format."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e4362f02-74d1-4229-a33c-06aac1540e65">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">occurs after event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/e4362f02-74d1-4229-a33c-06aac1540e65</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/507664bb-567a-4833-a142-52358ec05b7d">
+    <dcterms:identifier>https://afs.test.fargeo.com/507664bb-567a-4833-a142-52358ec05b7d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <skos:prefLabel xml:lang="en">parent textual work</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c1684495-03dd-4070-9921-a050e6a7a632">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="en">project managers</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">People who oversee, coordinate, and otherwise projects, generally as a professional position.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417573</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/db261e02-be27-4a99-b9c1-875375103a1d"/>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/a373aabe-bba3-4c41-a363-d8f879c2f7ff">
+    <dcterms:title>Means Types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/1f2a382b-d892-4a20-a128-5604e972079e">
+    <skos:prefLabel xml:lang="en">ink</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">A fluid medium used for drawings or tracings. An opaque, usually black, pigment is mixed with a vehicle such as water to produce a fluid which can be applied with a pen or brush. Through the end of the 19th century, ink was supplied dried in stick or block form which was ground and mixed with water as needed. At the beginning of this century prepared ink became popular.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300015012</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="fr">encre</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8907399d-9e31-4026-8ce9-7be964908a91">
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:scopeNote xml:lang="en">A concise description of the location where the creation, design, or production of the work or its components took place, or the original location of the work. </skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435448</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">creation place description</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3c7aa4ea-8857-4ba8-8d58-d58fa18aaf10">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389724</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Condition is the overall state of an object, being, or environment, including physical characteristics such as appearance, pristineness, level of damage, completeness, working order, or quality.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <skos:prefLabel xml:lang="en">condition</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9038c161-43ac-4567-abae-9bb546e7898a">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379799</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31"/>
+    <skos:prefLabel xml:lang="en">chopping</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The activity of cutting with a quick and heavy blow with a hewing, hacking instrument, such as an ax, cleaver, sword, or the like.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8ca43306-a4ee-426f-967f-12f327ead6a2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/8ca43306-a4ee-426f-967f-12f327ead6a2</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">influence on group leaving event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c76477b1-17e6-4886-ae4f-f1143642956e">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">source reference for professional activity of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">43</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/d3e16385-0bb4-4940-b9b7-780d305d1592</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7f0239ab-5241-44e2-b295-537e51a80c52">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Rg </skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/7f0239ab-5241-44e2-b295-537e51a80c52</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Roentgenium (Rg)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">87</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6c77fa92-dd5d-4a95-8ce9-55f9a0aead45">
+    <skos:prefLabel xml:lang="en">Chromium (Cr)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/6c77fa92-dd5d-4a95-8ce9-55f9a0aead45</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Cr</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a00d55b2-147d-4a50-a233-f330120ab4d1">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">35</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Francium (Fr)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/a00d55b2-147d-4a50-a233-f330120ab4d1</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Fr</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4d2e8c94-7536-4067-ae2f-2e52b337fa0b">
+    <skos:prefLabel xml:lang="en">promised gift (method of acquisition)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435595</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Promises by one party to make a gift or gifts to another party at some future time. To be legally enforceable, a promised gift requires three elements: donative intent, delivery, and acceptance.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/5f7df45b-31ae-44ce-a8cc-55ccdafa019d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c04aea65-b394-4e04-bdf6-9db678eafbdc">
+    <skos:prefLabel xml:lang="en">location of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/8f3bebaa-3ee9-41a8-bbed-f484d2efc300</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a5538b87-8a0b-43a2-b4cf-e3fda813d888">
+    <skos:prefLabel xml:lang="en">configuration</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/a5538b87-8a0b-43a2-b4cf-e3fda813d888</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ec0f84da-5fff-44d0-a539-ed7099fb75ce">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers broadly to the Romance language that developed from Vulgar Latin with contributions from the pre-Roman languages that were spoken in the territory of the Astures, an ancient tribe of the Iberian peninsula. It is now spoken in Spain and as a first language by around 360 million people worldwide. Given that the Castilian dialect is the source from which modern standard Spanish developed, this language overall may be called "Castilian"; however, for the dialect spoken in Castile and elsewhere in northern and central Spain, use "Castilian Spanish."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Spanish (language)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="fr">espagnol</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389311</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Spanisch</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a942b167-ede3-475b-ace1-a8fd4de4daf8">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/169ec513-9931-462e-9d64-433a8919a798</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+    <skos:prefLabel xml:lang="en">Archival Resource Key (ARK)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f7dda933-9221-4555-a828-493962ab9411">
+    <skos:scopeNote xml:lang="en-US">No AAT Identifier yet</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/f7dda933-9221-4555-a828-493962ab9411</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/5da484cb-7537-43be-91cb-dc28c4369efb"/>
+    <skos:prefLabel xml:lang="en-US">Spreadsheet</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/14197ada-900e-4783-94b7-454707317007">
+    <skos:prefLabel xml:lang="fr">abrasion (condition or effect)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Rubbed or scuffed areas caused by a gradual loss of material on the surface due to rubbing, wearing, or scraping of an object or material against itself or another usually harder object or material. Abrasion may be a deliberate attempt to smooth, clean, or polish a surface. It may also be a deteriorative process that occurs over time as a result of weathering or handling.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Abrieb</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053077</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+    <skos:prefLabel xml:lang="en">abrasion (condition or effect)</skos:prefLabel>
+    <skos:prefLabel xml:lang="pt">abrasão</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2b43ddad-7ab5-44c8-b943-020f7771de06">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389115</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="en">Portuguese (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">portugais</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Portugiesisch</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9d733804-5991-4980-a476-5d714f08d5d9">
+    <skos:prefLabel xml:lang="en">source reference for publication event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/9d733804-5991-4980-a476-5d714f08d5d9</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">36</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1059072b-a459-42f4-9b3c-feda8a87d702">
+    <skos:scopeNote xml:lang="en">Documents comprising texts that are relatively short in length, sometimes but not always abbreviated versions of longer texts.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">brief text</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/52c977b9-3ee6-415c-ad88-70e01c72fd38"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300418049</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/84123513-2b77-4050-b1dc-4fcd1269d83f">
+    <skos:prefLabel xml:lang="en">preserving</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The process of performing actions to halt damage or to keep any object, material, or system from injury or destruction. For example, it may refer to the preservation of food or an ecological system. For the function of preservation, use "preservation (function)" or a specific type of preservation, such as "historic preservation." For the discipline of involving treatment and long-term preventive care of cultural and natural heritage objects and systems, use "conservation."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300266154</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e3a980ee-faa4-4ac9-b0cd-c567ce0d22ce">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300266192</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Technique of scattering a monochromatic light, such as a laser, changing the vibrational, rotational, or electronic energy of a sample, the results of which help determine its molecular structure. Discovered by Indian physicist Sir Chandrasekhara Venkata Raman (1888-1970).</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a8e8388-0bb9-42f2-bc77-fc5a1c640589"/>
+    <skos:prefLabel xml:lang="en">Raman spectroscopy</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8ba7ae28-7ab0-409c-9259-023ddb0c44b5">
+    <dcterms:identifier>http://localhost:8000/8ba7ae28-7ab0-409c-9259-023ddb0c44b5</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/07e8d7a0-551f-4200-8c71-8a03e1f02d36"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">participant</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1421293e-ad4d-4166-a199-d076622b2596">
+    <skos:prefLabel xml:lang="en">first names</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">In the context of personal names, particularly in western culture, a first name is the name given to a person at birth or an early period of life, historically at baptism and historically chosen to signify or honor a saint, an earlier family member, or a personal characteristic. In modern western usage, a first name is combined with a family name or other names to distinguish between multiple people having the same first name. In other traditions, such as Islamic tradition, the first name may be a religious name or another sort of name.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404651</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/b5dfd5e3-779d-4b94-8552-c539e352fd68"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c7406ab4-e50c-47d2-8459-636186e25ebe">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location of dissolution of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/c7406ab4-e50c-47d2-8459-636186e25ebe</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6b389a46-6dcf-4ea0-af15-f11bae6fa6e2">
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="pt">carvalho roble (madiera)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">chêne (bois)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300012264</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Wood of trees belonging to the genus Quercus, of the beech family. It is a durable wood that has a distinctive coarse grain, used in cabinetry, flooring, paneling, musical instruments, ship interiors and moldings, panel painting, and sculptures. </skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Eichen (Holz)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:prefLabel xml:lang="en">oak (wood)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2e0fefb8-7556-4ffb-b946-e3546bac2e72">
+    <skos:prefLabel xml:lang="en">actor in</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/2e0fefb8-7556-4ffb-b946-e3546bac2e72</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e518447a-c5a2-485f-926d-c854f65e88ec">
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411994</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The standard unit of currency of the United States of America, containing 100 cents.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <skos:prefLabel xml:lang="en">United States dollar (system of money)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa287b94-0e82-4ba1-8d78-08fb9b5173ba">
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0e95cff7-5df1-4281-a896-d3bbb295b11e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300228062</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The process of altering, injuring, or consuming something by fire or heat. For events where something is totally or partially consumed by fire, whether intentionally or by accident, use "fires."</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+    <skos:prefLabel xml:lang="en">burning</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a6ba28bd-1f01-4509-8925-00dd02446c6e">
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5397e821-84c9-4a55-8691-714aa9e167e0">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b8dced33-c032-4dfc-a72d-1df8bb185760">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">94</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/b8dced33-c032-4dfc-a72d-1df8bb185760</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Selenium (Se)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Se</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fde9f103-4536-4d8d-8882-9efb5084362c">
+    <skos:prefLabel xml:lang="en-US">display title</skos:prefLabel>
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms/object/titles/display-title</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/62f83f13-058e-4c73-a0b0-4f1816780f52">
+    <skos:scopeNote xml:lang="en">Identification numbers or alphanumeric codes assigned to, and usually posted on, buildings or plots located on a thoroughfare.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">street numbers (address elements)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300419272</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/639b8e22-9565-4fa4-92d8-50c28d1df17d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/58800805-b0f0-4a6b-947a-8b98fec4c33a">
+    <skos:prefLabel xml:lang="de">Register (list)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:scopeNote xml:lang="en">Official lists of entries of any information considered sufficiently important to be exactly and formally recorded, typically maintained in numerical or chronological order in a regular manner.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">registers (lists)</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Offizielle Liste von Einträgen mit Informationen, die als wichtig genug erachtet werden, um genau und in formeller Weise verzeichnet zu werden, in der Regel in numerischer oder chronologischer Reihenfolge.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027168</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/27accee4-1e73-4ead-b108-4c3428161f6e">
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="en">Chinese (culture or style)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The cultures, styles, and periods characteristic of China. To specifically refer to the cultures of ancient Chine, use "Ancient Chinese."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300018322</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">chinoise</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/90d6139d-46e4-46ca-8d92-a339a8092056">
+    <skos:altLabel xml:lang="en">Cd</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/90d6139d-46e4-46ca-8d92-a339a8092056</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Cadmium (Cd)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f72e688f-855b-43d1-92aa-11aa679b01e6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">gender-fluid</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The state or condition of identifying outside a male/female gender binary, specifically people who do not identify with a single fixed gender; having or expressing a fluid or unfixed gender identity or fluctuating between gender and expressions.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300438737</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/291354a2-c0b8-4143-baaf-534a9fae15a9">
+    <dcterms:identifier>https://afs.test.fargeo.com/291354a2-c0b8-4143-baaf-534a9fae15a9</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for production of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2c1b54ac-bcba-48bc-975c-108961fe3036">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300060417</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:prefLabel xml:lang="en">monographs</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:scopeNote xml:lang="en">Separate treatises on a particular subject, typically written expositions of a subject narrow enough in scope to exclude all but a single aspect of the subject, for example, a study of the works of a single artist. In book cataloging, non-serial bibliographic items complete in one part or in a finite number of separate parts.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f16e685d-fa8a-4670-8707-99448fe2a791">
+    <skos:prefLabel xml:lang="en">engineers</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Persons trained in a branch of engineering. In some jurisdictions the designation is legally restricted in technical use to persons who have completed a prescribed course of study and complied with requirements concerning registration or licensing.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025063</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/db261e02-be27-4a99-b9c1-875375103a1d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c939adea-2e59-461e-b3a9-73fd0ac2636f">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Darmstadtium (Ds)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/c939adea-2e59-461e-b3a9-73fd0ac2636f</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Ds </skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/00000000-0000-0000-0000-000000000007">
+    <skos:prefLabel xml:lang="en-US">is related to</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/00000000-0000-0000-0000-000000000007</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/00000000-0000-0000-0000-000000000005">
+        <dcterms:title>Resource To Resource Relationship Types</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/54d2f763-34aa-4830-bc1d-f9ed627cf164">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/26d7ce44-20e5-44fb-a3c1-dfbe6bdd521b">
+        <dcterms:title>Event Types - Project</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300048788</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">projets</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">project</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Artistic concepts comprising proposed undertakings or creations, including the creation of works of art or architecture, or for the actual carrying out of such proposals. When emphasis is on specific conceptual schemes for the organization or appearance of graphic works, objects, structures, or systems, use "designs." For visual works and other physical items that are used to carry out the project, use "projects (object groupings)."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa855ab3-215b-4b2e-b314-11364d9b6cb3">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053885</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Process of adding heat in order to raise the temperature.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/a9e75b55-78b9-46a6-8cb2-aee3f5b5003e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">heating (physicochemical process)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4455ae0b-c49e-4940-b43a-4b818848fdd4">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <skos:prefLabel xml:lang="en">influence on creation of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/4455ae0b-c49e-4940-b43a-4b818848fdd4</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/082b3c01-0c6a-43e6-bac5-7ce2bdbcdeec">
+    <skos:inScheme rdf:resource="http://localhost:8000/3a8e8388-0bb9-42f2-bc77-fc5a1c640589"/>
+    <skos:scopeNote xml:lang="en">In science, business, policy, and other fields, a careful item-by-item comparison of two or more comparable characteristics, alternatives, processes, products, qualifications, sets of data, or other features.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379522</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">comparative analysis</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a949df20-5c8c-4ad9-b2f4-03dc9b8d09ee">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">influence on group joining event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/a949df20-5c8c-4ad9-b2f4-03dc9b8d09ee</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dcda4cdf-7024-4d25-8ad8-da4aa909c506">
+    <skos:prefLabel xml:lang="en">copyright/licensing statement</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">A formal statement of the copyright or licensing of a work, and/or any restrictions placed on it. </skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435434</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b5c6f06d-d6a6-482a-bebf-83c6da262e10">
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">creator in production event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/b5c6f06d-d6a6-482a-bebf-83c6da262e10</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/94d5c83b-a55b-4d87-80cd-bfad1c9e717c">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">O</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Oxygen (O)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/94d5c83b-a55b-4d87-80cd-bfad1c9e717c</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">73</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3737266f-33a8-454e-98cb-34734756ec9c">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300010669</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">A baked or semi-fired material that is usually a mixture of clay, grog, and water; it has been used for pottery, statuettes, lamps, roof tiles, and cornices since ancient times. It may be glazed prior to firing. To produce an item, terracotta is molded or shaped, dried for several days then fired to at least 600 C. It is fireproof, lighter in weight than stone, and usually brownish red in color.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34</arches:sortorder>
+    <skos:prefLabel xml:lang="en">terracotta (clay material)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/03c51652-484f-4b24-98ea-f3bf5bcf2d7c">
+    <skos:prefLabel xml:lang="en">leader</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/07e8d7a0-551f-4200-8c71-8a03e1f02d36"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/03c51652-484f-4b24-98ea-f3bf5bcf2d7c</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/088f5808-875b-4c0d-830f-993125748a15">
+    <skos:prefLabel xml:lang="en">influence on professional activity</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/f61056d0-07cf-40da-8694-e23c2deb3bd5</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5da14416-2e56-4426-b4a8-86601b428ab4">
+    <skos:prefLabel xml:lang="en">formerly had member</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/5da14416-2e56-4426-b4a8-86601b428ab4</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/56c052f1-df82-432b-a915-99a6a42e5c94">
+    <skos:scopeNote xml:lang="en">Units of length in the imperial and United States customary systems of measurement, the twelfth part of a foot, 1/36 of a yard. Derived from the Old English ince, or ynce, and from the Latin unit uncia, one-twelfth of a Roman foot, or pes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">inches</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379100</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0fa2731d-a349-4cf4-979c-3a3de0375a79">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025979</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Accumulated groups of objects or materials having a focal characteristic and that have been brought together or are maintained by a corporate body.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:prefLabel xml:lang="en">corporate collections</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/869e8898-2636-487b-9f17-8782778e570b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Digital Object Identifier (DOI)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Unique alpha-numeric strings assigned by a regsitration agency to identify content and provide a persistent link to a location on the Internet.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417432</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/60b354e4-52fd-4c7b-9fc8-83350e894738">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/60b354e4-52fd-4c7b-9fc8-83350e894738</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">physical object used in group joining</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fbd4a835-713e-421a-9f0e-466b2b3845bf">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300386120</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <skos:prefLabel xml:lang="en">French-Canadian</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The culture of Canadians of French ancestry, or of early French settlers in Canada.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9e9677da-5452-46cc-9bd2-682f001c60fc">
+    <skos:prefLabel xml:lang="en">actor carrying out modification</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/9e9677da-5452-46cc-9bd2-682f001c60fc</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ea38dfaa-07ae-4963-9fbd-e4bc579b385c">
+    <skos:prefLabel xml:lang="en">acknowledgments</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written recognitions of acts or achievements.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026687</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Schriftliche Anerkennung für Handlungen oder Leistungen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Danksagung</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c51806d2-60fc-4ad9-a208-aebf61206dc4">
+    <skos:inScheme rdf:resource="http://localhost:8000/e17c5d7f-eaf2-4e7d-9490-a3e362f74bdc"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6c400200-8763-49ad-9928-8135a918b5d5">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Hungarian</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111195</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Hungary, or in general to the cultures that have occupied the area of modern Hungary in central Europe. More broadly, it may refer to the culture of the Magyars, a Finno-Ugric people who settled in the middle basin of the Danube River in the late ninth century CE.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/aec56d59-9292-42d6-b18e-1dd260ff446f">
+    <skos:prefLabel xml:lang="en">x-ray fluorescence</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300224161</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Fluorescence stimulated by x-rays; when the emissions are examined by spectrometry, useful in determining chemical composition of a substance.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a8e8388-0bb9-42f2-bc77-fc5a1c640589"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ff3918b4-ebf5-407b-9d9e-951532a6e55f">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">111</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">V</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/ff3918b4-ebf5-407b-9d9e-951532a6e55f</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Vanadium (V)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/693bf783-7cd9-4ce3-a7d2-fb59b80c1f2e">
+    <dcterms:identifier>http://localhost:8000/693bf783-7cd9-4ce3-a7d2-fb59b80c1f2e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/c372cf0b-f0f4-4730-a97d-c892dfbefcd7"/>
+    <skos:prefLabel xml:lang="en">art conservation</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/16710e30-dc18-4304-8025-fd976bbffac4">
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300107963</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">mexicaine</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Mexican</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Culture and nationality of the nation of Mexico or its people.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8f6fe6a0-f233-4ecb-95b6-b69fba491f4e">
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d40f903f-a691-465a-8129-47c28a9c951b">
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e04f3be0-f4e4-49c6-9330-00e4401d7c0e">
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="en">glass (material)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300010797</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:scopeNote xml:lang="en">An amorphous, inorganic substance made by fusing silica (silicon dioxide) with a basic oxide; generally transparent but often translucent or opaque. Its characteristic properties are its hardness and rigidity at ordinary temperatures, its capacity for plastic working at elevated temperatures, and its resistance to weathering and to most chemicals except hydrofluoric acid. Used for both utilitarian and decorative purposes, it can be formed into various shapes, colored or decorated. Glass originated as a glaze in Mesopotamia in about 3500 BCE and the first objects made wholly of glass date to about 2500 BCE.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">verre (material)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d49cabd7-bbbc-4cba-8d61-23c3a794ac59">
+    <dcterms:identifier>https://afs.test.fargeo.com/d49cabd7-bbbc-4cba-8d61-23c3a794ac59</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">location of group leaving event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6e490484-d436-45d2-aa77-dcab8acb0db0">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fbdb5700-5af7-4bab-babb-94e57bfb7fda">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Hassium (Hs)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Hs</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">41</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/fbdb5700-5af7-4bab-babb-94e57bfb7fda</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a10b8a26-d50d-41ac-b827-7fb149c9f70d">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/88e8a379-1609-432d-8667-9f0c0d427a82">
+    <skos:scopeNote xml:lang="en">General term for the method of acquiring property through transference by one person or institution to another person or institution, voluntarily and without any payment required.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5f7df45b-31ae-44ce-a8cc-55ccdafa019d"/>
+    <skos:prefLabel xml:lang="en">gift (method of acquisition)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417637</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fca71ae7-a01e-4b69-8bd8-4d5f11c74057">
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/4096365e-4fe7-412d-906c-16f3d356e8be"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8d1180e7-b308-4402-b2a4-ed5322c2a90c">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300010358</dcterms:identifier>
+    <skos:altLabel xml:lang="fr">matériaux (materials concept)</skos:altLabel>
+    <skos:prefLabel xml:lang="en">materials / media</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The matter or substance from which a thing is or may be made; the tangible substance that goes into the makeup of an art work or other physical object. Physical substances, either naturally or synthetically derived, range from specific materials to types of material. Materials may be designated by their properties, or by function or form. Included are raw materials and processed materials.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/faeabbb9-5cca-43e1-a0d7-bdbc15873d75">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">36</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3827d4c2-b2b8-483a-b232-2717505d81a4">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">49</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b4d7567c-09f8-4039-b15f-67cada5cb57d">
+    <skos:prefLabel xml:lang="en">catalogues raisonnés</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026061</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Complete, systematic, and critical listings of all the known works of a single artist, providing comprehensive information, including provenance, for each work.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Werkverzeichnis</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Vollständiges, systematisches und kritisches Verzeichnis aller bekannten Werke eines einzelnen Künstlers, das ausführliche Informationen über jedes Einzelwerk bietet, einschließlich seiner Herkunft.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4a3a2e3f-35ac-4ed4-994d-12e4c12b9bdc">
+    <dcterms:identifier>https://afs.test.fargeo.com/4a3a2e3f-35ac-4ed4-994d-12e4c12b9bdc</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">used set</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddac2d30-4d8e-4c37-bb13-a8a32ee7b924">
+    <skos:inScheme rdf:resource="http://localhost:8000/b3d6e036-e788-4c85-a1f0-3aa35f0a82f2"/>
+    <skos:scopeNote xml:lang="en">Interdisciplinary study of the maintenance, care, and protection of art, architecture, and other cultural works.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379510</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">conservation science (cultural heritage discipline)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9070fa70-e4f9-4597-bed8-9c67a5d76d9a">
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d12c085c-fa9a-4cc6-83b7-15031ce63c19">
+    <skos:prefLabel xml:lang="en">sampling motivation</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/69abe4f9-f16f-47bf-8fdf-ccce67a18e5d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/d12c085c-fa9a-4cc6-83b7-15031ce63c19</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/32c7ac9c-9ab0-445b-b0c7-e08f65850356">
+    <skos:prefLabel xml:lang="en">mailing</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/4a4050e9-00a8-42f5-9c7e-cf754060cd95"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300077526</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Sending through a postal service.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d81a34d7-5653-4592-9b1c-44856cac6021">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/d81a34d7-5653-4592-9b1c-44856cac6021</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">has sampling activity</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/795ed653-676b-4057-b468-fcbe1a4ec8c5">
+    <dcterms:identifier>https://afs.test.fargeo.com/795ed653-676b-4057-b468-fcbe1a4ec8c5</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object used in publication event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6b2d815b-ddd3-4552-85aa-992b463c3ea0">
+    <skos:scopeNote xml:lang="en">Action or process of creating illumination, which comprises paintings and other adornments applied to books, scrolls, or other document types for the purpose of illustrating or decorating the text. </skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300220539</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">illumination (image-making process)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9966b87c-8914-472c-ac0c-cc5378c7127d">
+    <skos:inScheme rdf:resource="http://localhost:8000/273d0839-8911-468f-9eb1-b0cc3507b6e7"/>
+    <dcterms:identifier>http://localhost:8000/9966b87c-8914-472c-ac0c-cc5378c7127d</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">historical events</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/62867f7c-93a9-447f-8cac-0066e587956a">
+    <skos:prefLabel xml:lang="en">classification (category)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435444</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Indication of the placement of a work of art or architecture within a classification scheme that groups other, similar works together on the basis of similar characteristics</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c897e183-1f0d-4b47-83d4-5c7a49bb6b5b">
+    <dcterms:identifier>https://afs.test.fargeo.com/c897e183-1f0d-4b47-83d4-5c7a49bb6b5b</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of production event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ce16480a-2466-4409-ab0e-459b406bfaaf">
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/dor-id</dcterms:identifier>
+    <skos:prefLabel xml:lang="en-US">Getty Digital Object Repository (DOR) Integer Identifier (ID)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1635bf19-34b2-4f52-b2dd-f67116830f05">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:scopeNote xml:lang="en">General term for false or ficticious names or appellations used instead of personal names, place names, and other names. When adopted for personal names, pseudonyms may be used to conceal the real identity of the person, for example, as used by authors and artists.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">pseudonyms</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404657</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b30bcc05-bf01-47e8-b863-29103cf3b52c">
+    <skos:prefLabel xml:lang="en">causally relevant to formation of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/b30bcc05-bf01-47e8-b863-29103cf3b52c</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/24ce7a28-25c7-4037-907e-319edad7f474">
+    <skos:prefLabel xml:lang="en">actor carrying out observation</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/24ce7a28-25c7-4037-907e-319edad7f474</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7baa8baa-38a4-4f83-a96a-1a18bd751c36">
+    <dcterms:identifier>http://localhost:8000/7baa8baa-38a4-4f83-a96a-1a18bd751c36</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">total payment</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/02dc399d-9c8c-406d-a4bf-56817eb03449"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9d612a11-accb-4476-8eaa-fb3222a34682">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/9d612a11-accb-4476-8eaa-fb3222a34682</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">event causal to production</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/198c9b4e-f3bd-4312-99cd-de73783686d7">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/198c9b4e-f3bd-4312-99cd-de73783686d7</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">formation event period</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fc49c02e-42cf-4ebb-8952-ddd323c4dd7f">
+    <skos:prefLabel xml:lang="en">procedure used in</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/fc49c02e-42cf-4ebb-8952-ddd323c4dd7f</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7eeebd93-5204-4f01-b63c-12f296029aee">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">source reference work for statement</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/6748d659-f49e-4abb-b383-d97dfe6cc368</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5435fb76-946f-414d-ad14-57a6b552c5d2">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300024548</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">lasers (optical instruments)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Laser</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Devices that generate electromagnetic radiation in the ultraviolet, visible, or infrared spectrum, in the form of a very narrow continuous or intermittent beam. Originally an acronym for "light amplification by stimulated emission of radiation;" the first functional laser was built by Theodore H. Maiman (1927-2007), and demonstrated in 1960. Lasers have multiple applications: they are used as components in information retrieval and transmission devices and systems, cutting, measuring, and medical tools, and as entertainment devices.</skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Gerät zur Erzeugung permanenter oder intermittierender elektromagnetischer Erzeugung eines dünnen Lichtstrahls im ultravioletten, im sichtbaren oder im infraroten Bereich des Spektrums. "Laser" ist ein Akronym für „light amplification by stimulated emission of radiation"" (Lichtverstärkung durch stimulierte Emission von Strahlung). Das erste funktionale Laser-Gerät wurde von Theodore H. Maiman (1927-2007) konstruiert und im Jahr 1960 vorgestellt. Laser werden in vielen Bereichen eingesetzt, als Komponenten für den Abruf oder die Wiedergewinnung elektronischer Informationen, in der Produktion zum Schneiden oder Messen, als medizinisches Werkzeug oder in der Unterhaltungselektronik.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f8ba2d38-fd38-4130-91cd-543686b61003">
+    <skos:scopeNote xml:lang="en">A metamorphic, hard, dense, crystalline stone primarily composed of calcium carbonate; it is limestone or dolomite that has been metamorphosed with heat and pressure. Pure calcite marble is white, but impurities produce a wide variety of coloring and patterns. It is finely grained and polishes to a smooth, high gloss. It is used primarily for statuary and buildings. Marble has been quarried from sites around the world since at least the 7th century BCE. The term can also refer more broadly to any crystallized carbonate rock, including true marble and certain types of limestone, that will take a polish and can be used for architectural and ornamental purposes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">marble (rock)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011443</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">marbre (roche)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Marmor</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/09c5997e-86f4-4689-bc6e-169e299acb9b">
+    <dcterms:identifier>http://localhost:8000/09c5997e-86f4-4689-bc6e-169e299acb9b</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">primary name</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8df4c6af-184f-45bb-aa68-d0ff6e6a9c63">
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">52</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/15d1dcd4-054f-44ab-b64e-75e659513d80">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">103</arches:sortorder>
+    <skos:altLabel xml:lang="en">Ts</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/15d1dcd4-054f-44ab-b64e-75e659513d80</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Tennessine (Ts)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d7352ca3-5f0d-4c55-95f5-59eb4a8e65aa">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Fermium (Fm)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/d7352ca3-5f0d-4c55-95f5-59eb4a8e65aa</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Fm</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9db724b9-b3c7-4761-9a50-673d64a15bd8">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028875</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">samples</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:scopeNote xml:lang="en">A sample is a part of anything taken or presented for inspection or shown as evidence of the quality or composition of the whole. For instances that represent a class, use "specimens."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/203d8caa-92d1-4d47-a14c-a377658a7ffe">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">46</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/203d8caa-92d1-4d47-a14c-a377658a7ffe</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of part removal event of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d2d7ac19-a9b6-436c-936a-3c6f314b2742">
+    <skos:scopeNote xml:lang="en">Numbers that firms such as commercial art dealers or galleries may assign to objects when taking them in to stock. These are typically written or affixed on the objects themselves, and can be used to associate particular objects with entries in a stock or sales book. These numbers are not necessarily unique, and objects may have multiple stock numbers.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412177</dcterms:identifier>
+    <skos:prefLabel xml:lang="en-US">Object Stock Number</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a842d507-d64c-482d-95d7-18d6e02d0ca6">
+    <skos:prefLabel xml:lang="en">inscriptions</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Inschrift</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Words, texts, lettering, or symbols marked on a work, including texts, legends, documentation notes, or commemoration. For standardized symbols or notations on objects that convey official information, use "marks (symbols)."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300028702</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Beschriftung, mit der etwas markiert wird, insbesondere zur Dokumentation oder zum Gedenken. Bei einer Drucksache ist dies eine spezielle, in Buchstaben aufgedruckte Information, die für gewöhnlich nicht Teil eines größeren Textes ist. Bezüglich antiker Texte werden damit die meisten erhaltenen schriftlichen Äußerungen jeder Länge, außer Papyri, bezeichnet. Für standardisierte Symbole oder Bezeichnungen auf Objekten, die wichtige Informationen enthalten, siehe "Zeichen (Symbol)".</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c64fe7b5-1fca-4de8-8562-cdc32fc26c98">
+    <skos:prefLabel xml:lang="en">owner of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/c64fe7b5-1fca-4de8-8562-cdc32fc26c98</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f62ccd87-14d8-48b9-9114-b8f752b6d999">
+    <dcterms:identifier>https://afs.test.fargeo.com/f62ccd87-14d8-48b9-9114-b8f752b6d999</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">has influence on</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4476323a-0bdc-4931-a22d-1a857c7257a4">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/4476323a-0bdc-4931-a22d-1a857c7257a4</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Radon (Rn)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Rn</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">84</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b441941d-8d0d-4db3-9a99-cd28886d500a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300418049</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f44f7240-35c5-49e8-a0e3-2ffe308f0862"/>
+    <skos:scopeNote xml:lang="en">Documents comprising texts that are relatively short in length, sometimes but not always abbreviated versions of longer texts.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">brief text</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7962e30a-76e0-4eee-b85b-58c8c1a75141">
+    <skos:prefLabel xml:lang="fr">réfractomètre</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Gerät, das auf verschiedene Weise den Brechungsindex von Stoffen misst.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Refraktometer</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:scopeNote xml:lang="en">Instruments used to measure the index of refraction of substances in any of several ways.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">refractometers</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300201594</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/480abea1-f508-4129-af86-52a4358b0e8a">
+    <dcterms:identifier>http://localhost:8000/480abea1-f508-4129-af86-52a4358b0e8a</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Getty Guide Title</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7d34406f-fa99-4613-a4e7-5bf6ff8322c8">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Einsteinium (Es)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/7d34406f-fa99-4613-a4e7-5bf6ff8322c8</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Es</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fba4c751-5b18-4080-929c-5336f772e31c">
+    <dcterms:identifier>https://afs.test.fargeo.com/6398dee0-6c11-40aa-97ef-496009784adb</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">source reference for creation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1c09bed5-8ef4-4d1d-9b29-3764bdb8c14b">
+    <dcterms:identifier>http://localhost:8000/1c09bed5-8ef4-4d1d-9b29-3764bdb8c14b</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/02dc399d-9c8c-406d-a4bf-56817eb03449"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">first installment</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3077e707-7e96-4370-9e88-08d38a4e6fad">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/3077e707-7e96-4370-9e88-08d38a4e6fad</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5b2324ed-1afc-4e69-8edc-4547fe2166bc">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404678</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663"/>
+    <skos:prefLabel xml:lang="en">pen names</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Regarding personal names, assumed names used by authors rather than their real names.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/62fdcff5-5abc-4477-a916-bbae886f38af">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">inputting</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/641c4612-732b-48c3-b958-3af2c5c3f647"/>
+    <dcterms:identifier>http://localhost:8000/62fdcff5-5abc-4477-a916-bbae886f38af</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8362bfe2-eb98-4445-a18d-609f1515879f">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300222980</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The degree to which an image is distinct in its details as a function of the spacing of individual optical elements, such as grains of light-sensitive chemicals in a photograph or pixels in an electronic image; an important factor affecting image quality.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/c2788105-d184-4192-b19f-7d504f43d7b0"/>
+    <skos:prefLabel xml:lang="en">resolution (optical concept)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/aaf5444e-3e94-4f4b-905c-c5c5c7c35ec8">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300265869</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Unit of storage measurement, specifically a collection of 8 bits, in digital technology, or computers. It represents a value, or code, for an individual character or typographic symbol.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">bytes</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fbce0059-bdb8-45fc-a0ea-e12ab79b2554">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404764</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The originating cause or substance of some material thing or physical agency, or the conceptual inspiration for a conceptual thing.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/52c977b9-3ee6-415c-ad88-70e01c72fd38"/>
+    <skos:prefLabel xml:lang="en">sources (general concept)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/96e707d2-c133-4f2b-ab79-311d4345657b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">58</arches:sortorder>
+    <skos:altLabel xml:lang="en">Mt</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/96e707d2-c133-4f2b-ab79-311d4345657b</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Meitnerium (Mt)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6f88b717-088e-48cd-9c4a-f3c08c5ed8fd">
+    <skos:scopeNote xml:lang="en">Various means of reproducing identical copies of graphic matter in a fixed form. Processes by which an image, pictorial or textual, is transferred, usually to paper or cloth, most often by means of a plate, block, stone, or screen. Use also for the making of photographic prints and, with computers, for the production of a paper copy of stored data. For the production of prints in a fine arts context, prefer "printmaking." </skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053319</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/641c4612-732b-48c3-b958-3af2c5c3f647"/>
+    <skos:prefLabel xml:lang="de">drucken</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">printing (process)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">impression (printing)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/411adaa3-0663-4d73-b83a-88cb6629ed88">
+    <skos:prefLabel xml:lang="en">alternate titles</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Titles that vary from the primary title. Distinguished from "alternative titles."</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417227</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a23a8cda-73a8-4a44-922b-f05882fa797b">
+    <skos:prefLabel xml:lang="en">procedure</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/a23a8cda-73a8-4a44-922b-f05882fa797b</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/907d7730-1c16-4c56-b3f0-a95894aa39f7">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Photographs in which the tones or colors are reversed from their appearance in nature, usually on a transparent support of celluloid, acetate, or on paper, intended for the purpose of producing positive prints. For finished prints in which tones or colors are reversed, see "negative prints." When a glass plate is painted or drawn on and a photographic print made from it, use "clichés-verre." </skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300127173</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Fotografie, meist auf einem durchsichtigen Träger, bei der die Töne und Farben entgegengesetzt zu ihrem natürlichen Auftreten erscheinen. Für Drucke, bei denen die Töne und Farben entgegengesetzt erscheinen, siehe “Negativdruck”. Wenn auf einer Glasplatte gemalt oder gezeichnet wurde und ein fotografischer Abzug davon gemacht wird, siehe “Glasklischee”.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Negativ (Fotografie)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">negatives (photographs)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">négatifs</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4490453e-608e-40d6-9e39-79af0f1cc9fe">
+    <skos:inScheme rdf:resource="http://localhost:8000/8b7faa16-3846-4360-b767-bb2c823b6550"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300137570</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Recognizing or establishing someone or something as being a particular person or thing.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">identification</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2023db9b-d735-4ecf-91be-ef1fcf7110bc">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300014109</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Papier</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers generally to all types of thin matted or felted sheets or webs of fiber formed and dried on a fine screen from a pulpy water suspension. The fibers may be animal, such as hair, silk or wool, or mineral, such as asbestos, or synthetic. However most paper is made from cellulosic plant fiber, such as from wood pulp, grass, cotton, linen, and straw.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">paper (fiber product)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="fr">papier</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/28e25c2d-2a00-440d-8cac-3f357dd737c9">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388191</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Tschechisch</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">tchèque</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="en">Czech (language)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/eaea40ec-8d19-4cc6-ae36-7ad042d50e3b">
+    <skos:prefLabel xml:lang="en">source reference work for set addition event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">85</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/eaea40ec-8d19-4cc6-ae36-7ad042d50e3b</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/edcb51e8-6c01-440f-8ace-d707c352148a">
+    <skos:scopeNote xml:lang="en">Gathering things in order to retain them.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/cde31c5b-8ab2-4fbe-9b55-11eed1d478f7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300077121</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">collecting</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/43a271b6-28f3-4524-b497-2d3e0902b6ca">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+    <skos:scopeNote xml:lang="en">A lightened or whitish area in layer of paint or varnish layer due to microscopic defects (voids, granules, etc.) that develop within a film layer as it ages. The defects can scatter light making the affected area appear lighter than the surrounding areas. It is distinguished from bloom, which is a surface phenomenon.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300252414</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">blanching (clouding condition)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b8bff485-6f60-45ea-a9bc-32861ade7861">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <skos:prefLabel xml:lang="en">subgroups (archival divisions)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:scopeNote xml:lang="en">In archival description, subordinate groups or subdivisions of a group; archival groups that are parts of larger groups.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404023</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6444d3a3-f9bd-42e4-9c62-ea3fb2cd4f90">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300137819</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">General term for the gathering, organization, description, provision of access, storage, and overall maintenance of a collection of objects, documents, or other materials.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">gestion des collections</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">collections management</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Sammlungsverwaltung</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3949f930-cb20-4cc0-b914-77e399bbb3a2">
+    <skos:prefLabel xml:lang="de">Collage</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">collages (visual works)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Works in two dimensions or very low relief that were made by gluing paper, fabrics, photographs, or other materials onto a flat surface</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:scopeNote xml:lang="de">Zweidimensionales Werk oder mit sehr flachem Relief, das durch Kleben von Papier, Stoff, Fotografien oder anderen Materialien auf eine flache Oberfläche hergestellt wurde.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300033963</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ae38a9a6-5e28-41ff-957d-f9527a07a57a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">group joined</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/ae38a9a6-5e28-41ff-957d-f9527a07a57a</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/41bc72c3-eb83-42b6-96c3-639bc9888ed6">
+    <skos:prefLabel xml:lang="en">Latino</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300386381</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">As a general term, belonging to Spanish-derived culture, especially referring to those of Spanish origin in North, Central, or South America.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/59876638-1ca6-43b6-b4ec-f4318ec2d927">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/cb4cc06d-3d14-480f-aab1-b02c28042946</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for creation event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/66f57ae1-a868-4ff5-85be-758b4c2620c7">
+    <dcterms:identifier>https://afs.test.fargeo.com/66f57ae1-a868-4ff5-85be-758b4c2620c7</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object added to collection</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">53</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/268fd523-ce84-4e91-923b-01766b28f628">
+    <skos:scopeNote xml:lang="en">Action or process of creating illumination, which comprises paintings and other adornments applied to books, scrolls, or other document types for the purpose of illustrating or decorating the text. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">illumination (image-making process)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300220539</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/c372cf0b-f0f4-4730-a97d-c892dfbefcd7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e77ea94b-c9c7-4e1f-879d-0916d1550d49">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053083</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">breaking</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Splitting into pieces or smashing into parts or fragments, typically by a blow or stress and with suddenness or violence.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e22afbaa-948c-4063-a4f9-8ea7ce5a35c7">
+    <skos:prefLabel xml:lang="en">purchase (method of acquisition)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Method of acquiring property by payment of funds.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417642</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f3eca78c-7547-4ca5-a7eb-b130391b40ed"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/22b51542-05e5-482f-97ba-0283336ef91b">
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:scopeNote xml:lang="de">Gruppe von separaten bibliographischen Objekten, miteinander in Beziehung stehend,durch die Tatsache, dass jedes zusätzlich zu seinen eigenen Titel einen Sammeltitel für die Gruppe als Ganzes enthält; sie werden sukzessive herausgegeben; in der bildenden Kunst wird der Begriff für eine Gruppe von Werken eines einzelnen Künstlers verwendet, die eine spezifische und sinnhafte Beziehung zwischen den Arbeiten besitzen.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">A conceptual grouping of visual arts works, literary works, or performance art created in succession by the same author, artist, or studio and intended by the creator(s) to be seen together or in succession as a cycle of works. Works in a series typically share the same or related subjects, the same or similar media, or other characteristics, but their defining characteristic is that they were intended to be conceptually related as a series. Individual items in a series may be cataloged separately and linked to the series. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">series (object groupings)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Serie (Gruppe)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">série</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027349</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2be75a62-6065-45e0-8660-dddeeaa2d685">
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="en">German (culture or style)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">allemande</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111192</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Germany, or in general to the cultures that have occupied the area of the modern nation in central Europe. More broadly, it can refer to the cultures of the ancient groups of related peoples who inhabited central and northern Europe, and who spoke dialects from which the Germanic or Teutonic languages developed.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cbf70ed1-44ea-4079-92b0-2c98834e808c">
+    <skos:prefLabel xml:lang="en">pages (components)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300194222</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Einzelne Seite eines Blattes, Vorderseite oder Rückseite; auch die einzelne Flächen nach dem Falten eines Blattes, kann aus Papier oder Pergament bestehen, unabhängig ob diese leer, beschrieben oder bedruckt sind. Unterscheidet sich von "Folio", da ein Folio nur auf der Vorderseite nummeriert wird.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Individual sides of a leaf, recto or verso; the individual sides of leaves resulting from folding a sheet, as of paper or parchment, whether blank or containing writing, printing, or other matter. Distinguished from a "folio" in that a folio is numbered on only the front side.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Seite (Buchbindung)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e49f5b60-0a84-4004-980d-a6635b2f7b0b">
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+    <skos:prefLabel xml:lang="en">ells (units of length)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412070</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Units of length, now obsolete, used in several European countries. In England, one ell corresponded to approximately 45 inches. In Scotland, 37.2 inches. The Flemish ell corresponded to 27 inches. </skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3efa527c-32e6-4a2a-84aa-b018ce0742f2">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">81</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/3efa527c-32e6-4a2a-84aa-b018ce0742f2</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Pm</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Promethium (Pm)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8ef8ade6-fcdd-4da6-a9f7-1fb9e9df86d0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Greek (modern)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264816</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:scopeNote xml:lang="en">Refers broadly to the culture and styles associated with the area of southeast Europe comprising the southern Balkan peninsula, Peloponnese, and various offshore islands, as well as other territories that were colonized or held by Greece during various periods of history.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f44390a8-b846-41ec-8e9f-0f58934010a2">
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ca9e81f3-471d-4d1f-b323-edc816b1c522"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bc56bd76-01b7-48e5-81d7-9753553196c6">
+    <skos:prefLabel xml:lang="en">set removal event carried out by actor</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">70</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/bc56bd76-01b7-48e5-81d7-9753553196c6</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/19b929c2-91ac-4d15-81c3-60b7f77322d9">
+    <dcterms:identifier>https://afs.test.fargeo.com/19b929c2-91ac-4d15-81c3-60b7f77322d9</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">influence on curation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/95d56de2-7c29-4a03-b0b1-4f8d5ea3aaed">
+    <skos:inScheme rdf:resource="http://localhost:8000/641c4612-732b-48c3-b958-3af2c5c3f647"/>
+    <dcterms:identifier>http://localhost:8000/95d56de2-7c29-4a03-b0b1-4f8d5ea3aaed</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">standardizing</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/268f603c-df0b-4477-8381-8ff20aa70410">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/4455ae0b-c49e-4940-b43a-4b818848fdd4</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">influence on creation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ed080f48-eafc-4b7f-b7f4-8ef01ddb7eba">
+    <skos:prefLabel xml:lang="en">source reference for statement about</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/ed080f48-eafc-4b7f-b7f4-8ef01ddb7eba</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1ff831dd-8f7a-4331-9579-51e513725ca3">
+    <skos:inScheme rdf:resource="http://localhost:8000/8b7faa16-3846-4360-b767-bb2c823b6550"/>
+    <skos:prefLabel xml:lang="en">technical analysis</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379518</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The application of testing methods to materials or objects in order to analyze their composition and manufacture. In a conservation science context, this may refer to movable art works and artifactual objects in a conservation lab. For a broader range of testing methods, prefer "scientific analysis." </skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e8d1a9bd-045a-4c96-9f9a-20944737ee83">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/e8d1a9bd-045a-4c96-9f9a-20944737ee83</dcterms:identifier>
+    <skos:altLabel xml:lang="en">F</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Fluorine (F)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4cd39562-1f73-4b78-9021-0b3a0e0be0e3">
+    <skos:scopeNote xml:lang="en">Records of established forms or methods for conducting the affairs of a business, legislative body, or court of law.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">procedures (documents)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Verfahrensweise (Lehrmaterial)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300109733</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Aufzeichnung über die etablierten Formen und Methoden der Geschäftsführung eines Unternehmens, eines gesetzgebenden Organs oder eines Gerichtshofes.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2703e524-b5ea-4548-bea7-7ce354e4e05a">
+    <dcterms:identifier>http://localhost:8000/2703e524-b5ea-4548-bea7-7ce354e4e05a</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">sample areas</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/799b403d-5c2d-4372-a160-e7581760eb72">
+    <dcterms:identifier>https://afs.test.fargeo.com/3c44d93c-01e5-4768-9b00-61db7f350d6a</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">influence on creation event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c0561406-3cd4-414d-9a64-d75abf6570be">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/92d3e507-9d66-4122-9cd6-36430cf36e3c"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300386983</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Particulars of the place where a person, organization, building, or monument can be found on a street or other thoroughfare; typically consisting of a number, street name, the name of the administrative area (a town or district), and often a postcode.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">street addresses</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d5c8c4b4-f569-4963-9f2b-b4869c768b7c">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Method of transferring loaned property back to the original owner or custodian.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">return of loan</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f3eca78c-7547-4ca5-a7eb-b130391b40ed"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300438467</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c1bfc243-1944-441f-9c8c-a3c5577acc37">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e17c5d7f-eaf2-4e7d-9490-a3e362f74bdc"/>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fbc6a24a-26d7-47fe-bd09-d283cba4348a">
+    <dcterms:identifier>https://afs.test.fargeo.com/fbc6a24a-26d7-47fe-bd09-d283cba4348a</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">observation used in</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bb65e31f-c9b0-49b9-b474-c8eb4a899886">
+    <skos:scopeNote xml:lang="en">Written, digital, spoken, or signed representations of the attributes or qualities of something or someone.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411780</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">description</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/52c977b9-3ee6-415c-ad88-70e01c72fd38"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cb051e82-7c14-4630-a08d-5892be6070cf">
+    <skos:prefLabel xml:lang="en">physical object modified</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/cb051e82-7c14-4630-a08d-5892be6070cf</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f9f84020-d138-420e-8efb-c6fa7a8edd6d">
+    <skos:scopeNote xml:lang="en">Committees, usually of experts or specialists, formed for analyzing, investigating, or solving a specific problem.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300150132</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+    <skos:prefLabel xml:lang="en">task forces</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5f105159-f651-43c3-9c2d-2f17a6230dde">
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+    <skos:scopeNote xml:lang="de">Kurze Angabe über eine Tatsache oder ein Erlebnis, niedergeschrieben zur Überprüfung oder als Erinnerungshilfe, oder um jemand anderen zu informieren; schließt auch kurze, formlose Briefe mit ein.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027200</dcterms:identifier>
+    <skos:altLabel xml:lang="de">Notiz (Dokumentengattung)</skos:altLabel>
+    <skos:prefLabel xml:lang="en">note</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Brief statements of a fact or experience, written down for review, or as an aid to memory, or to inform someone else; also includes short, informal letters.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bf09cd77-da89-4841-807b-6366305a4d63">
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7d9cbe24-312d-4042-a328-a8f70effb6e9">
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1682fbb6-52a3-46be-9488-8e50d1804172">
+    <skos:prefLabel xml:lang="en-US">infrared radiation</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to that portion of the electromagnetic spectrum beyond that visible to the human eye. Infrared radiation has waves longer than red light and shorter than the shortest microwaves. Though not visible, it may be detected as the sensation of heat.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">infrared radiation</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300225890</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/079561dc-4c8f-40db-b658-c2fd5acdb3f2"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/334a7923-2e3a-49f2-ab10-15ecbd3e6b2c">
+    <skos:prefLabel xml:lang="en">sources (general concept)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404764</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The originating cause or substance of some material thing or physical agency, or the conceptual inspiration for a conceptual thing.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ab02482d-e9e0-49ad-aac9-20d51ac99c15">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">77</arches:sortorder>
+    <skos:altLabel xml:lang="en">Pu</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/ab02482d-e9e0-49ad-aac9-20d51ac99c15</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Plutonium (Pu)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e76b7cc3-571e-467a-8cd5-4af617f5c227">
+    <skos:inScheme rdf:resource="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"/>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54"/>
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6ad4a9e8-b48e-4338-9fc4-fa7509dec88e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="en">linen (material)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300014069</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">General name for textile woven from the spun fiber of the flax plant.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">toile (linen)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1e4143ea-bd03-4b78-ab86-bf8223852d2b">
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/7cc462a5-db43-4b25-a748-99892eba26aa"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/91b85788-8a17-48ce-9572-80ef3cb51106">
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+    <skos:prefLabel xml:lang="en">uniform resource locators</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404630</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Unique resource locators that, in addition to identifying a resource, provide the address of the internet document according to one of a variety of protocols.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fbdf6081-0cfa-4594-aa96-1453e6b703d7">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">splicing</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a9e75b55-78b9-46a6-8cb2-aee3f5b5003e"/>
+    <skos:scopeNote xml:lang="en">The action of joining two discontinuous lengths of material together into one, as in weaving together two ends of rope, making a joint in magnetic tape or film, or lapping two pieces of timber into a continuous length.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053025</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2c7f2bb2-7527-438c-877b-90b1a5c67b83">
+    <skos:scopeNote xml:lang="en">General term for the method of acquiring property through transference by one person or institution to another person or institution, voluntarily and without any payment required.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417637</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/83dd1837-e399-469f-a073-cd76edff810c"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">gift (method of acquisition)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fea22f8d-3749-4c5b-8740-4f4768a10a89">
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d16b4b14-4c86-47de-9647-495833687298">
+    <skos:prefLabel xml:lang="en">Hydrogen (H)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">H</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/d16b4b14-4c86-47de-9647-495833687298</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">44</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2f54357f-8552-406a-b702-3dc31e24b788">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">45</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Indium (In)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">In</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/2f54357f-8552-406a-b702-3dc31e24b788</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c6a32789-73d3-450d-837c-dc4932716b61">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Occupations or other recurring activities that require an expert level of knowledge and achievement in some subject, field, science, or discipline, especially those activities that involve prolonged training and a formal qualification. For recurring jobs or livlihoods that do not necessarily involve this same high level of expertise, use "occupations."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">professions</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300393201</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/c82d6f85-ae67-4c28-b07a-c114f6d6ba50"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bf21abdf-897f-48c0-b9aa-c1f46502cdcc">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/bf21abdf-897f-48c0-b9aa-c1f46502cdcc</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">model number</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a7e17177-c533-4027-a66a-0c4fe961d7fc"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e0cb0905-bf56-488f-b682-4a14cc0afa49">
+    <skos:prefLabel xml:lang="en">gender non-binary</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Persons who gender-identify outside the male/female binary. This term may be used in addition to other gender identities.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300438736</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6696a427-b2ff-4fce-9f78-61861c063c37">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697"/>
+    <skos:prefLabel xml:lang="en">gender-neutral</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Suitable for, applicable to, or common to both males and females, not specifying gender. </skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417541</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d682b0f9-9916-4dec-bda1-670952c0a5e3">
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1ef7036c-3a2d-424c-90fd-45c66f713e5b">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d"/>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/93a715ef-5c16-4852-98c6-5d73d42633b6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The standard unit of currency of the Netherlands prior to adoption of the Euro.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Dutch guilder (system of money)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412019</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7ecee866-60e9-428d-85ef-c089ce047e2a">
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:prefLabel xml:lang="en">items (cataloging focus)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Individual objects or works. Most works in museums are cataloged as items. A stand-alone architectural work should generally be cataloged as an item. An item may be composed of multiple parts or components, and it may be desirable to catalog the parts separately, linking the records for the components to the record for the whole. An item differs from a component in that the component cannot stand alone as an independent work.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404024</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/20d28e7a-0d4f-4055-b1cd-cf6f264e8432">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="en">note</skos:prefLabel>
+    <skos:altLabel xml:lang="de">Notiz (Dokumentengattung)</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b"/>
+    <skos:scopeNote xml:lang="de">Kurze Angabe über eine Tatsache oder ein Erlebnis, niedergeschrieben zur Überprüfung oder als Erinnerungshilfe, oder um jemand anderen zu informieren; schließt auch kurze, formlose Briefe mit ein.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Brief statements of a fact or experience, written down for review, or as an aid to memory, or to inform someone else; also includes short, informal letters.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300027200</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8f00a23b-fd48-43e9-8ec2-59a60a7957c6">
+    <skos:prefLabel xml:lang="en">Molybdenum (Mo)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">61</arches:sortorder>
+    <skos:altLabel xml:lang="en">Mo</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/8f00a23b-fd48-43e9-8ec2-59a60a7957c6</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c0029e45-bd2d-42b5-b2a4-77b9d1219159">
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411912</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Collections, usually but not necessarily held by a public institution, that are made available for access by members of the public. The earliest recorded instance of a public body receiving a private art collection occurs in the 16th century, when the Grimani family gave their collection to the Venetian republic. For collections in private hands that are not available to the public, use "private collections." </skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:prefLabel xml:lang="en">public collections</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/038d2bdf-081d-4f53-8ace-305e68c10591">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">approximate</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/038d2bdf-081d-4f53-8ace-305e68c10591</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/5f3c2407-2e22-4022-9795-2f3ef963d5aa"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/77e3d54b-b98d-43da-9049-1725645308d6">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054277</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">curating</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <skos:scopeNote xml:lang="en">Superintending or managing the collections, exhibitions, research activities, and personnel of a museum, art gallery, zoo, or other place of exhibit; also, the superintending or managing of a single collection or subject of study in such an institution.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4975d51f-8f85-4f86-8047-cbd123f52df1">
+    <skos:prefLabel xml:lang="en">causally affected destruction of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/4975d51f-8f85-4f86-8047-cbd123f52df1</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c1b53f0c-f372-4094-b0cb-5be66a44cefe">
+    <skos:inScheme rdf:resource="http://localhost:8000/94343b71-a35a-4edd-8ffa-61c66ea8d417"/>
+    <skos:scopeNote xml:lang="en">The process or function of introducing new material or augmenting existing material.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">adding (information handling)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417256</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fd194f67-9432-451b-98dc-be6b76742965">
+    <dcterms:identifier>https://afs.test.fargeo.com/fd194f67-9432-451b-98dc-be6b76742965</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <skos:prefLabel xml:lang="en">related event causal to creation event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/32337acf-91a0-4f1c-ae5b-c14155d64941">
+    <skos:prefLabel xml:lang="en">sample area name</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/32337acf-91a0-4f1c-ae5b-c14155d64941</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c77e2081-79c6-41d5-bdde-6efe664fe4c5">
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a7e17177-c533-4027-a66a-0c4fe961d7fc"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ce042b1c-f512-4933-9aeb-0552974d51ca">
+    <dcterms:identifier>http://localhost:8000/ce042b1c-f512-4933-9aeb-0552974d51ca</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <skos:prefLabel xml:lang="en-US">method development</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f6b440d1-3cdd-4ea6-9c4b-03833da99307">
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a480c815-461a-470a-b012-81df75aef74e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Main divisions or sections of a book, typically designated in some way, such as with a special heading, title, number, or layout.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300311699</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:prefLabel xml:lang="en">chapters (layout features)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7151deec-9e15-48de-a9a2-8a7b36206729">
+    <dcterms:identifier>https://afs.test.fargeo.com/7151deec-9e15-48de-a9a2-8a7b36206729</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">annotator in part identifier assignment</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e9e3ddad-b36e-4d6f-8741-1c552978835d">
+    <skos:prefLabel xml:lang="en">actor carrying out set removal event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/e9e3ddad-b36e-4d6f-8741-1c552978835d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/623e0734-f769-4780-8c6a-7ff4fa3fb8c6">
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bf58c842-bace-497e-be04-b3b1f0f4b7d6">
+    <skos:inScheme rdf:resource="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"/>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/970f32df-c784-49e7-a83c-93174fd63cb3">
+    <skos:prefLabel xml:lang="fr">pierre (rock)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011176</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Allgemeine Bezeichnung für ein Steinobjekt, das abgeschnitten, geformt, zerkleinert oder anderweitig zur Verwendung in der Architektur oder für andere Zwecke zugearbeitet wurde. Der Begriff schließt auch die archäologischen und anthropologischen Steinobjekte ein, die verziert oder dekoriert wurden und bei rituellen Zeremonien Verwendung fanden. Diese Steine sind Regel nicht behauen oder bearbeitet und unterschieden sich daher von Steinskulpturen.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</arches:sortorder>
+    <skos:scopeNote xml:lang="en">General term for rock that has been cut, shaped, crushed, or otherwise formed for use in construction or other purposes. Includes the specific archaeological and anthropological sense of individual stones which may be decorated or ornamented and which may be used in ritual contexts. These are usually not carved or dressed, and so differ from sculptures made from stone.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Stein (Objekt)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">stone (worked rock)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/eb6d60b6-8c29-4423-b768-79fb1cd95601">
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">36</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e0b7f712-f47f-4353-a454-b8e61a31a66a">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/e0b7f712-f47f-4353-a454-b8e61a31a66a</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">used in group leaving event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">54</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4942787a-6681-4d14-be93-dc7edb58d5bf">
+    <dcterms:identifier>https://afs.test.fargeo.com/4942787a-6681-4d14-be93-dc7edb58d5bf</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">starts after creation of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">42</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0fff64d5-7aa5-4986-ae75-a684adec2dc6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:prefLabel xml:lang="en">rights statement</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Social science concepts related to law.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300055547</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59">
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0e8d874f-bec2-4d30-955a-8e9cb88fd003">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/6e229a28-05ae-483a-b6ec-16fb3f9af098</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of professional activity of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b5767b7c-6c4e-48bd-abfa-caf3ff139cc8">
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/b5767b7c-6c4e-48bd-abfa-caf3ff139cc8</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">used in</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4aff2b02-eee2-4076-9c56-47fe699a44b4">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">actor in set addition event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/4aff2b02-eee2-4076-9c56-47fe699a44b4</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e75d9fee-1b38-4c53-83e6-5fc3cf70ee69">
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c8613c26-82eb-485c-8854-7ccb619276ab">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location of death event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/c8613c26-82eb-485c-8854-7ccb619276ab</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/af047bfd-5454-41ef-812a-9fbf6ad9a0ac">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object used in creation</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/af047bfd-5454-41ef-812a-9fbf6ad9a0ac</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/50525207-905f-4e65-a816-9f024dfc67f7">
+    <skos:prefLabel xml:lang="en">Cesium (Cs)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Cs</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/50525207-905f-4e65-a816-9f024dfc67f7</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2507a724-9cb6-420d-8010-47a053c9bb5a">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">source reference for birth of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">36</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/2507a724-9cb6-420d-8010-47a053c9bb5a</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f7422ea0-8a1d-48c9-a3a8-c45904cfc74c">
+    <skos:prefLabel xml:lang="en">British (modern)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of the United Kingdom. It also refers to the cultures of historical nations that had Great Britain as the central ruling power. For the culture of the ancient Britons, who were those tribes that spoke the Celtic (Brythonic) language, use "Ancient British."</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111159</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">britannique</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6cc8d2de-439f-4345-8b99-fa42bc692d7e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2dfc02b9-8beb-4fed-9fe2-2c30865ac6f6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a7e17177-c533-4027-a66a-0c4fe961d7fc"/>
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/93dc6410-1d4f-4c8e-8652-497a4f9cec9f">
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for production event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/93dc6410-1d4f-4c8e-8652-497a4f9cec9f</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6bb65117-9c69-4aa7-a99b-fa1ad817495c">
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/79002668-68b7-4d4c-a5ae-e05007039bdd">
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2e45a071-47d0-4d6b-ba9d-9add9475a6d6">
+    <skos:inScheme rdf:resource="http://localhost:8000/69abe4f9-f16f-47bf-8fdf-ccce67a18e5d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300418049</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Documents comprising texts that are relatively short in length, sometimes but not always abbreviated versions of longer texts.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">brief text</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0c93221b-72e9-4732-9cc7-d06c1e7b2600">
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ca9e81f3-471d-4d1f-b323-edc816b1c522"/>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5b6e26ee-ce7d-41da-b9dd-ed75cec7f024">
+    <skos:inScheme rdf:resource="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/54e55a90-d134-40a5-a4f0-4b2dfdb86448">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">actor carrying out project</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/54e55a90-d134-40a5-a4f0-4b2dfdb86448</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/207a310b-14b6-4518-af42-79cc3900e8e6">
+    <skos:prefLabel xml:lang="en">Belgian (modern)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="fr">belge</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111156</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the culture of Belgium, usually the modern nation established in 1830 and defined as the Netherlandish provinces watered by the Meuse and Scheldt rivers.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/af775082-8a3d-464a-9f03-a8d9b6b26f10">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/af775082-8a3d-464a-9f03-a8d9b6b26f10</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Argon (Ar)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Ar</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ce7ad2f6-e99e-43b8-be84-98e4272c803f">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Christianity</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the world religion and culture that developed in the first century CE, driven by the teachings of Jesus Christ of Nazareth. Its roots are in the Judaic tradition and the Old Testament. The tenets include a belief in the death and redemptive resurrection of Jesus. The religion incorporates a tradition of faith, ritual, and a form of church authority or leadership.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300073711</dcterms:identifier>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/52fbf9cc-3027-4d5c-9439-1856bb6e68a5">
+        <dcterms:title>Visual Work Types - Subject</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2abe1ee8-c097-4a7d-8a20-457cda28fcc6">
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f5b916fc-e129-4391-9545-26871ddf3975">
+    <skos:inScheme rdf:resource="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc"/>
+    <skos:prefLabel xml:lang="en">illustrating</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/f5b916fc-e129-4391-9545-26871ddf3975</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/332218dd-7693-47fb-ae98-bc5c232b915c">
+    <skos:prefLabel xml:lang="en">dimensions description</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Information about the dimensions, size, or scale of the work, presented in a syntax suitable for display to the end-user and including any necessary indications of uncertainty, ambiguity, and nuance. It may include the scale of the work. It may also include the number of the parts of a complex work, series, or collection. </skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435430</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/781f6fcb-b1bd-4d39-8271-6faaea438a8e">
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">81</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/45843dac-a726-435b-bc77-f3132c328e63">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/45843dac-a726-435b-bc77-f3132c328e63</dcterms:identifier>
+    <skos:altLabel xml:lang="en">B</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Boron (B)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/73580ea6-d11a-415c-90cc-d2dc70bd7a68">
+    <skos:prefLabel xml:lang="en">source reference for dimension of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/d86b855e-6af4-402d-a94a-d13e36bddf8e</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">72</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d3d46855-a51c-4874-a88a-377ea8735624">
+    <skos:inScheme rdf:resource="http://localhost:8000/dca6a321-3ab9-42bc-ac80-2171789ae205"/>
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6748d659-f49e-4abb-b383-d97dfe6cc368">
+    <skos:prefLabel xml:lang="en">source reference work for statement</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/6748d659-f49e-4abb-b383-d97dfe6cc368</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3e308dfd-eb14-4ecf-842f-7a37c1baf89c">
+    <dcterms:identifier>https://afs.test.fargeo.com/3e308dfd-eb14-4ecf-842f-7a37c1baf89c</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of production of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5bc9dffc-74d9-42d1-8482-0bb9ba06c089">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/696fd77f-0181-4d00-9372-b395b2fde9b3">
+    <dcterms:title>Monetary Amount types (not currencies)</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/a4ed26e7-7da4-4f68-84aa-e4136f599263">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">creation ends before event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/a4ed26e7-7da4-4f68-84aa-e4136f599263</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0f572454-3e77-4d9e-8ea2-774e28469f3a">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379239</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Measurements of time equal to 1/60 part of a minute or 1/3600 part of an hour.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">seconds (units for duration)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/bbf81641-b1dd-4ddf-858d-7e8ca823d385"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/48905a90-6f06-42e3-b82c-e64729a69da3">
+    <dcterms:identifier>https://afs.test.fargeo.com/48905a90-6f06-42e3-b82c-e64729a69da3</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of set removal event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">51</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/17e15bb3-5bba-458d-a9ea-7372e35fb526">
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d60e5aa3-9c2b-40ad-bc12-c6c1fd030b78">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">40</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/904f4d83-449f-4848-8444-d19c598a70e5">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">actor in curation event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/904f4d83-449f-4848-8444-d19c598a70e5</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/68000b8c-5b5c-4718-9b0a-b70a08379f1f">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/68000b8c-5b5c-4718-9b0a-b70a08379f1f</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <skos:prefLabel xml:lang="en">digital resource used in observation</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4574d04f-cf3d-4c2f-91d7-0c50f3d7aa14">
+    <skos:prefLabel xml:lang="en">period of professional activity</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/4574d04f-cf3d-4c2f-91d7-0c50f3d7aa14</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/82cfbcd2-509d-4cdb-9da4-d6b713ac1bd5">
+    <skos:inScheme rdf:resource="http://localhost:8000/4096365e-4fe7-412d-906c-16f3d356e8be"/>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1914c881-21d4-4de3-8637-301b2178ebec">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">36</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Aquarell</skos:prefLabel>
+    <skos:prefLabel xml:lang="en-US">watercolor (paint)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="fr">aquarelle (peinture)</skos:prefLabel>
+    <skos:prefLabel xml:lang="pt">aguarela</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Transparent aqueous based paint produced by mixing ground pigments with water and, generally, gum arabic; paints made with vegetable gum binders were used by Egyptian, Greek, and Roman artists for wall paintings. Japanese and Chinese painters extensively used watercolor paints on silk panels and delicate paper scrolls. In the 16th through18th century, watercolor paints were used for miniature illustrations on porcelain, ivory, cards, books and manuscripts. By the 18th and early 19th centuries, watercolors rapidly increased in popularity due to the availability of small cakes of watercolor paints in metal pans, usually applied to a paper support by using a brush.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300015045</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/145c37a2-08d3-4f38-a4dc-7a141eb83bdc">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">photographie (process)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054225</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Fotographie</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">photography (process)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The art or process of making photographs, which are pictures produced by means of the chemical action of light on a sensitive film, glass, paper, metal, or by digital means.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6585f0e4-712a-4b88-81c8-7d8732f9fa78">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300079654</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">retrait</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">deaccessioning</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="de">ausscheiden</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/51e3963f-00b3-4a62-8704-5c89822555de"/>
+    <skos:scopeNote xml:lang="en">Permanently removing an object from a collection. In the context of public collections, it is generally done only with reference to a set of official criteria. Typically, the process is applied to art works, books, or other materials that are no longer appropriate, functional, or meeting the standards or objectives of the owner or repository.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1b8ef6a7-c0ed-4437-b836-16c3dec42ce9">
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/1b8ef6a7-c0ed-4437-b836-16c3dec42ce9</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">influence on activity</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c82c289c-2cbb-4788-83b6-e19253772cd5">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/cead6e47-d4b2-42fe-84b6-42bca2857d11</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object used in creation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0784c9bd-32c4-424f-a8cd-143b6f05703e">
+    <skos:scopeNote xml:lang="en">Documentation of examinations or inspections conducted in order to achieve a comprehensive view, as of a place, a group of related items, or to ascertain condition or value. For detailed lists of items on hand, or of items in a given category, use "inventories." For sets of questions submitted to a number of persons to obtain information, use "questionnaires."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">surveys (documents)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300226986</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/851c8546-9f11-4a8f-8c6c-2230b9a1c92d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d4f84f82-28bb-43bf-a973-203bf249a6b2">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">causally relevant to creation of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/61dfad8f-cd46-47fd-820f-3e69ac423cc6</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fe2241bd-9fa0-463b-aa69-f26aca86f3ee">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Bestandteil von Objekten oder Strukturen.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Constituent parts of a larger object. A component differs from an item in that the item can stand alone as an independent work but the component typically cannot or does not stand alone. Examples are a panel of a polyptych or a discrete architectural component such as a dome.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">components (objects parts)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300241583</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:prefLabel xml:lang="de">Bestandteil (Objekt)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fc0fb33a-63c1-4ada-af56-ab8956c127ea">
+    <skos:scopeNote xml:lang="en">Terms or names that are designated among all synonyms or lexical variants for a concept, to be used as the default term or name in displays and other situations; distinguished from "nonpreferred terms."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404670</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">preferred terms</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/de8785a1-26e0-47f6-8612-a1909d88f55e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/de8785a1-26e0-47f6-8612-a1909d88f55e</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of creation</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d231ce3a-9071-44e3-be9e-e4fe17721514">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/2224c58e-75aa-4da7-be59-05c984002196</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital reference for</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/03f3f737-5ba8-4a49-94a0-187325d0df24">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/03f3f737-5ba8-4a49-94a0-187325d0df24</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">approximates location</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ec551d7f-31d6-49ad-b812-38e5fc2a6436">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300014927</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+    <skos:prefLabel xml:lang="en">plaster of Paris</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:scopeNote xml:lang="en">Calcium sulfate hemihydrate, a white powder, which sets rapidly upon the addition of water; used for molds, sculpture, casts.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">plâtre de Paris</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9170c58d-7853-488c-bb56-af7cadc6eac2">
+    <skos:prefLabel xml:lang="en">creator</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/00a828d4-74d8-45ed-b4ec-cf6f709bb693</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/115aff8f-f29f-4536-9e83-973cbf18623c">
+    <skos:scopeNote xml:lang="en">General term for unit of currency of various values, used from the late 16th to the mid-19th centuries in various European countries, particularly in the Netherlands, the Holy Roman Empire, the Austrian Empire, Sweden, Denmark, and Scotland.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <skos:prefLabel xml:lang="en">Reichsthaler (unit of currency)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412170</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/68c7d1a5-862a-4c08-bd7e-9047c49b102d">
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:scopeNote xml:lang="en">In the strictest sense, refers to the cultures of the countries of South America, North America, Central America, and the Caribbean that were originally colonized by Spain. It may also refer more broadly to all the cultures of this region, including those that were originally colonized by the French or Portuguese.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Latin American</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300080819</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ac747098-0517-45b7-a311-808da9e96da6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/b3d6e036-e788-4c85-a1f0-3aa35f0a82f2"/>
+    <dcterms:identifier>http://localhost:8000/ac747098-0517-45b7-a311-808da9e96da6</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">software development</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c85793a7-86d1-45ae-92f9-913652c5b4c8">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379240</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/bbf81641-b1dd-4ddf-858d-7e8ca823d385"/>
+    <skos:scopeNote xml:lang="en">Units of time equal to 60 seconds or 1/60 of an hour. </skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">minutes (units for duration)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/59e115f2-0d6e-4bfb-81b2-794b9c74da97">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411780</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">description</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written, digital, spoken, or signed representations of the attributes or qualities of something or someone.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/929b011e-3cdb-449e-b155-8cd2808ed4c5">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300386741</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">governments (administrative bodies)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Bodies that exercise continuous authority on behalf of a nation, state, community, or other administrative entity over the actions of subjects or citizens, by authoritative direction or regulation.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f89a0022-ac64-45fd-aa77-5aab89eb77d3">
+    <skos:prefLabel xml:lang="en">hours (units of time)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379241</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Measurements of time equal to 60 minutes, 3600 seconds, or 1/24th of a solar day. </skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/bbf81641-b1dd-4ddf-858d-7e8ca823d385"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3c86859c-7cb7-4595-9c88-1c4780c19ee0">
+    <skos:prefLabel xml:lang="fr">images numérisées</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/5da484cb-7537-43be-91cb-dc28c4369efb"/>
+    <skos:scopeNote xml:lang="en">Images created using a binary numerical system electronically stored in the form of encoded picture elements, or pixels.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300215302</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital images</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3cde4823-e775-4ed1-9753-31b325593de1">
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7dcd9b95-ab41-4fb0-94ba-f6173d2e6e1a">
+    <skos:prefLabel xml:lang="fr">néerlandais</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388256</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Dutch (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Niederländisch</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">West Germanic language that is the national language of the Netherlands; it largely developed in the historical province of Holland. Although it is basically the same language that is, with French and German, one of the three official languages of Belgium, for the language as used in Belgium prefer "Flemish."</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5f0e4350-cacd-41d8-a2bb-5efbfa5915b5">
+    <skos:prefLabel xml:lang="en">design</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/5f0e4350-cacd-41d8-a2bb-5efbfa5915b5</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/de10c1c8-a3a4-43e0-8afc-43720a9ad3a9"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dfc9614b-86ea-4e07-bf9a-caa703058cee">
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379784</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">A device which operates as a feedback control system, emitting a signal that measures or detects a physical stimulus such as heat or motion to which it responds. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">sensors</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d5d44b26-05f9-4145-aa3a-0512fb5c4acf">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">76</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Platinum (Pt)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Pt</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/d5d44b26-05f9-4145-aa3a-0512fb5c4acf</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c53742f1-4a2d-4b63-be4f-4cacc9bc9319">
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">physical object used</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/c53742f1-4a2d-4b63-be4f-4cacc9bc9319</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/96caef6b-c991-445b-a9fc-edacf6772ca4">
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/96caef6b-c991-445b-a9fc-edacf6772ca4</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:prefLabel xml:lang="en">set used in</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/84a488d7-22bb-4805-9cde-ee5869931f45">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/c8261144-c750-4f64-8980-e50f762b21a5"/>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/02350960-6bac-47c9-abd9-5995ecfcd4da">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/02350960-6bac-47c9-abd9-5995ecfcd4da</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object used in group leaving event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6240617a-3bfc-49dc-8ad6-f271f75a9e7d">
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/688998b4-4abf-4b21-aa02-6a3a2ebd28e2">
+    <skos:prefLabel xml:lang="en">actor in curation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/688998b4-4abf-4b21-aa02-6a3a2ebd28e2</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/82944b56-ea3a-44e1-97d1-39fccf662d0e">
+    <skos:prefLabel xml:lang="en">accessioning (collections management)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cde31c5b-8ab2-4fbe-9b55-11eed1d478f7"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054626</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Recording the entry of items into a collection in the order of acquisition.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/60a64ca0-b6db-40da-b18c-6310515d22da">
+    <skos:prefLabel xml:lang="en-US">applied research</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/60a64ca0-b6db-40da-b18c-6310515d22da</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f54b7c1d-6fd2-4d10-8c64-01e8b9f74d63">
+    <skos:prefLabel xml:lang="en">period of birth of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/f54b7c1d-6fd2-4d10-8c64-01e8b9f74d63</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5d228ed2-d659-40ef-9f43-ca3209ea0896">
+    <dcterms:identifier>https://afs.test.fargeo.com/5d228ed2-d659-40ef-9f43-ca3209ea0896</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">related project</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dd1ea5a4-1740-4577-9983-f54ea56e8f95">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <skos:prefLabel xml:lang="en">sample area identified in</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/dd1ea5a4-1740-4577-9983-f54ea56e8f95</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/07a4fe8d-6f3f-4cf8-9263-5a24ae216a73">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+    <skos:scopeNote xml:lang="en">Unique resource locators that, in addition to identifying a resource, provide the address of the internet document according to one of a variety of protocols.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">uniform resource locators</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404630</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5705baac-66ca-4fc3-adce-acc997d16b1d">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111175</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="en">Dutch (culture or style)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of the Netherlands, or in general to cultures that have occupied the same area in northwestern Europe along the North Sea. It is often used to distinguish the culture of the northern historic Netherlands from "Flemish," which is the culture of the southern Netherlands or Flanders. It may also be used to refer in general to the culture of Germanic or Teutonic peoples; however, this meaning is seldom found in modern texts.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">hollandaise</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/55801709-9719-473f-9608-949f08b32eb7">
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2cef2cdf-cdda-4e25-a135-ef71a8305497">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412058</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9faa2596-258f-4a2f-a482-d07cb1e4126e"/>
+    <skos:prefLabel xml:lang="en">pixels per centimeter</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The resolution of electronic imaging devices such as computer monitors, digital cameras, televisions, or scanners, expressed as the number of pixels per linear centimeter. Pixels per centimeter also describes the resolution of image files.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/87429aa4-81ee-415e-87c2-8420089d53f4">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300386364</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/093ddd50-2a48-4d20-8b46-344ade2af30c"/>
+    <skos:prefLabel xml:lang="en">programs (organizations)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Organizations, agencies, departments, or other entities that coordinate, direct, and oversee the implementation of multiple interrelated projects or activities.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d7562d63-8f82-4c88-8b43-f5d81044721d">
+    <skos:prefLabel xml:lang="en">Polish (culture)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111204</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Poland, or in general to the cultures that have occupied the same area in central Europe south of the Baltic Sea.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f0cf2005-d8da-4dcd-b862-d215ab2ac8b9">
+    <skos:prefLabel xml:lang="en">location of set addition event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/f0cf2005-d8da-4dcd-b862-d215ab2ac8b9</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">36</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4359e806-8987-48fc-ae44-5695dac48fcf">
+    <skos:scopeNote xml:lang="en">Standards, codes, laws, rules, and principles that are considered proper, correct, or consonant with justice, and related uses regarding what is permitted and forbidden in a particular country, society, or community.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:prefLabel xml:lang="en">rights (legal concept)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417696</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c06853d6-857b-49e1-9ce4-e94e67d81554">
+    <dcterms:identifier>https://afs.test.fargeo.com/c06853d6-857b-49e1-9ce4-e94e67d81554</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of destruction event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">44</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/82535c52-9e39-428b-947d-f04ef5533a28">
+    <dcterms:identifier>https://afs.test.fargeo.com/82535c52-9e39-428b-947d-f04ef5533a28</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of birth event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5cae4306-ddf1-4e43-9e77-95e867c497d3">
+    <skos:altLabel xml:lang="en">Lu</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Lutetium (Lu)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">55</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/5cae4306-ddf1-4e43-9e77-95e867c497d3</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c9919492-9356-4d34-a8e8-4b12c0e4e53a">
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">33</arches:sortorder>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/465a8351-5ab1-4ffe-a768-57a08f44028e">
+    <skos:prefLabel xml:lang="en">Italian (culture or style)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Italy, or in general to cultures that have occupied the boot-shaped Italian peninsula in the Mediterranean Sea.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111198</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">italienne</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5a7c3476-2197-4277-b459-d4d8b95e730d">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object used in curation of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/5a7c3476-2197-4277-b459-d4d8b95e730d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/54f9c17b-c8b6-491c-9a3d-8527e0cfb635">
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/97c77b61-26be-4e34-8b03-0938feb915a3">
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054681</dcterms:identifier>
+    <skos:prefLabel xml:lang="en-US">case study</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Teaching methodology using cases as a pedagogical tool in fields such as law, business, medicine, and education. Cases may include real and imagined scenarios, critical incident analysis, case studies, vignettes, and anecdotal accounts.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cf46b58b-75e9-4c4f-bee7-4341f2db2629">
+    <skos:inScheme rdf:resource="http://localhost:8000/f44f7240-35c5-49e8-a0e3-2ffe308f0862"/>
+    <skos:scopeNote xml:lang="en">A formal statement of the copyright or licensing of a work, and/or any restrictions placed on it. </skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435434</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">copyright/licensing statement</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fe6ad26d-48c2-407d-b438-7859c5f1c301">
+    <skos:prefLabel xml:lang="de">drucken</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc"/>
+    <skos:prefLabel xml:lang="fr">impression (printing)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053319</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Various means of reproducing identical copies of graphic matter in a fixed form. Processes by which an image, pictorial or textual, is transferred, usually to paper or cloth, most often by means of a plate, block, stone, or screen. Use also for the making of photographic prints and, with computers, for the production of a paper copy of stored data. For the production of prints in a fine arts context, prefer "printmaking." </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">printing (process)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c64d26d1-d0b5-4a9a-9286-4942b915925d">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:altLabel xml:lang="en">C</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Carbon (C)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/c64d26d1-d0b5-4a9a-9286-4942b915925d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/05462259-cfc7-4c3b-ba2d-7f26c9a8ceec">
+    <skos:inScheme rdf:resource="http://localhost:8000/e17c5d7f-eaf2-4e7d-9490-a3e362f74bdc"/>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/26472e1f-7f73-4205-84e8-28c40b8e36ec">
+    <skos:prefLabel xml:lang="fr">calorimètre</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">calorimeters</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Kalorimeter</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:scopeNote xml:lang="en">Instruments for measuring heat quantities, such as the heat of combustion, specific heat, or vital heat in such processes as chemical reactions or changes of state.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300195893</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Gerät zum Messen von Wärmemengen, wie beispielsweise Verbrennungswärme, der spezifischen Wärme oder der bei chemischen Prozessen wie dem Wechsel von Aggregatzuständen entstehenden Wärme.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/07b8f16b-a024-4b5c-8178-b1bd0a0b1e03">
+    <skos:altLabel xml:lang="de">Biografie (Dokument)</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Schriftlicher Bericht über das Leben einer Person.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300080102</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Written accounts of the lives of individuals. For the genre regardless of medium, prefer "biography (general genre)."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/52c977b9-3ee6-415c-ad88-70e01c72fd38"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1d99debd-a046-4e56-8feb-e92945ab7734">
+    <skos:prefLabel xml:lang="en">period of production event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/c897e183-1f0d-4b47-83d4-5c7a49bb6b5b</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">47</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/95599e17-631b-429e-b9bf-e41717f85594">
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/5bd80233-7f66-41a1-bc32-2e9b49126bef</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">set member of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/48ded04e-6487-4640-b5e1-37818ce87ade">
+    <skos:scopeNote xml:lang="en">Appellations, words, or phrases that follow a personal name. For example words or numerals denoting family relationships, usually between members having the same first name, such as the senior and junior of two indicated persons.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/b5dfd5e3-779d-4b94-8552-c539e352fd68"/>
+    <skos:prefLabel xml:lang="en">suffixes (name additions)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404662</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/406d3dd2-2308-4bd8-9ad0-74ceeecd4e95">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/406d3dd2-2308-4bd8-9ad0-74ceeecd4e95</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for dissolution of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3ce7379e-24e2-4543-93be-d2a6353e197d">
+    <skos:inScheme rdf:resource="http://localhost:8000/e480165f-44d2-4ec4-b13a-f246270f06af"/>
+    <skos:prefLabel xml:lang="de">Artikel (Dokument)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">articles</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Literarisches Arbeit für die Veröffentlichung als eigenständiger Teil einer Zeitschrift, Zeitung, Enzyklopädie, oder andere Arbeiten vorbereitet.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300048715</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Literary compositions prepared for publication as an independent portion of a magazine, newspaper, encyclopedia, or other work.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e15a5258-c4c6-479f-bd0b-30e83ec5a3f1">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417261</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The process or function of copying or taking material or data from one place for use in another; for example, copying data out of a database for reconfiguration in a publication. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">extracting (information handling)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/51e3963f-00b3-4a62-8704-5c89822555de"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3a0c9fb7-375d-4444-8c0d-881288a0429a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="fr">images numérisées</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Images created using a binary numerical system electronically stored in the form of encoded picture elements, or pixels.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/8dc4c1ac-aae5-41f6-817b-9ee5fef855fe"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300215302</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital images</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8889c48f-504f-410d-8eb1-737f062d85f3">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The activity of creating "cartoons (humorous images)."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">cartooning</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053164</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/56f1db33-4d80-4871-bcb5-63ed73c67fec">
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+    <skos:scopeNote xml:lang="en">The art or process of providing drawings or other pictures intended to elucidate a description, story, or other written material, usually in a book or periodical.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054200</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">illustration (process)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5b8027bf-d85e-4801-8c9d-723f9b8d9fb5">
+    <skos:scopeNote xml:lang="en">Method of acquiring property by legally conferring existing ownership to another person or institution; it does not necessarily involve benefactors.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">transfer (method of acquisition)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417644</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/83dd1837-e399-469f-a073-cd76edff810c"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f3b7c256-d248-4fa1-a61f-00bbf541ba3a">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/cb4cc06d-3d14-480f-aab1-b02c28042946</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">37</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for creation event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6e229a28-05ae-483a-b6ec-16fb3f9af098">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/6e229a28-05ae-483a-b6ec-16fb3f9af098</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of professional activity of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/92be9ab3-7782-4633-adc3-c1fb4716fb83">
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/15f52617-f1cf-40c6-b31f-eccd2dc8c252">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Detailed examination principles and empirical processes of discovery and demonstration considered characteristic of scientific investigation, generally involving the observation, formulation of a hypothesis, experimentation, and development of a conclusion.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/8b7faa16-3846-4360-b767-bb2c823b6550"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379372</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">scientific analysis</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bb565261-55b7-4c1a-93aa-90ae78b28cee">
+    <skos:prefLabel xml:lang="en">approximate location</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/bb565261-55b7-4c1a-93aa-90ae78b28cee</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5bc20189-e804-45e2-bb65-b8d6c0ceda3b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/dor-id</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+    <skos:prefLabel xml:lang="en-US">Getty Digital Object Repository (DOR) Integer Identifier (ID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8f3bebaa-3ee9-41a8-bbed-f484d2efc300">
+    <dcterms:identifier>https://afs.test.fargeo.com/8f3bebaa-3ee9-41a8-bbed-f484d2efc300</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <skos:prefLabel xml:lang="en">location of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b7b40309-f000-41cb-bc1b-630487e657ee">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of creation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/b7b40309-f000-41cb-bc1b-630487e657ee</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7c53fb92-c967-4227-80a1-41904e4625ce">
+    <skos:inScheme rdf:resource="http://localhost:8000/52c977b9-3ee6-415c-ad88-70e01c72fd38"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435444</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Indication of the placement of a work of art or architecture within a classification scheme that groups other, similar works together on the basis of similar characteristics</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">classification (category)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/787614aa-a6b5-467d-8fc8-40aeea66a2d5">
+    <skos:prefLabel xml:lang="en">Bohrium (Bh)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Bh</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/787614aa-a6b5-467d-8fc8-40aeea66a2d5</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/87d354fd-8284-444e-a5ee-0718d4c84f56">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300224146</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">removing</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Taking away or getting rid of something.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/725a5deb-3ed2-4b66-9979-8590ad6a6d6e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">mailing addresses</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Addresses, not necessarily street addresses of the home or workplace, to which mail for a particular person, family, or corporate body is to be sent.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435687</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/92d3e507-9d66-4122-9cd6-36430cf36e3c"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a7cd7054-82e2-498d-a6cf-e63bdc310046">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">source reference work for set removal event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">86</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/a7cd7054-82e2-498d-a6cf-e63bdc310046</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/88e06b9f-1690-45cd-a8b7-99c2ebf011b8">
+    <skos:scopeNote xml:lang="en">Works of art in any medium, including performance art. A work of art may exist as a part of a larger object, e.g., a mural painting or a painting on a piece of furniture. When referring to the study or practice of the fine arts or the fine and decorative arts together, use "art." In reference to pieces of fine or decorative arts as collectables rather than museum objects, in English use either "art objects" or the French term "objets d'art," which emphasizes this meaning.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">works of art</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300133025</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:prefLabel xml:lang="fr">œuvre d'art</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9035cf2b-2201-4686-ac53-0a53034288dc">
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms/object/producer-description</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:prefLabel xml:lang="en-US">producer description</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2640fcde-8949-4517-9bfd-d9b651b475a8">
+    <skos:prefLabel xml:lang="en">actor in</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/2e0fefb8-7556-4ffb-b946-e3546bac2e72</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1bef9076-8fcc-421f-9ac9-7efd152570ef">
+    <dcterms:identifier>http://localhost:8000/1bef9076-8fcc-421f-9ac9-7efd152570ef</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <skos:prefLabel xml:lang="en-US">fundamental methods research</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6ea01af9-52df-4ddf-bd9e-2efda73f574f">
+    <skos:prefLabel xml:lang="en">creator of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/6ea01af9-52df-4ddf-bd9e-2efda73f574f</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/714dc5b5-f2f3-4daa-9a6c-ed07c385aeec">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">translation (function)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The activity of comprehending, analyzing, and expressing written or spoken material in a different language from the original.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/de10c1c8-a3a4-43e0-8afc-43720a9ad3a9"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300069831</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5283f14c-71c8-4a02-803d-b98ddc78fe17">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">location of publication event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/5283f14c-71c8-4a02-803d-b98ddc78fe17</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/10871f3f-688c-400e-8e60-3e072457d782">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">source reference work for part removal event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/10871f3f-688c-400e-8e60-3e072457d782</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">83</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dec6b7b2-10e4-462d-bc53-6d16c2708bbb">
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9b44391d-c8df-43a8-b0e2-dc20b6feb881">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">33</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7a6103d8-a67f-4554-8147-9a7f8c61db5b">
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">88</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1c5ba628-5ab6-4ee7-946a-a4bdefee0919">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/1c5ba628-5ab6-4ee7-946a-a4bdefee0919</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Cobalt (Co)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Co</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9a5ed323-3f8c-427f-8cbc-900ee843aefe">
+    <skos:prefLabel xml:lang="en">painting (image-making)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054216</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The art and practice of applying pigments suspended in water, oil, egg yolk, molten wax, or other liquid to a surface to create an expressive or communicative image. Paint is usually, but not always, applied with a brush. For the application of paint primarily to protect a surface or add a general color, use "painting (coating)."</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/f0b85b97-f3ae-41dd-ac4e-6f1e249a9dbb"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/16ef6491-1bb6-42cf-ad67-ce870f97be25">
+    <dcterms:identifier>https://afs.test.fargeo.com/16ef6491-1bb6-42cf-ad67-ce870f97be25</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:prefLabel xml:lang="en">parent group</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8d57caff-b29f-407c-b2c9-6ad0d21ab80f">
+    <dcterms:identifier>http://localhost:8000/8d57caff-b29f-407c-b2c9-6ad0d21ab80f</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">ORCID iD</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/88acc148-088a-4161-8715-7fccf7d6fd5d">
+    <dcterms:identifier>https://afs.test.fargeo.com/88acc148-088a-4161-8715-7fccf7d6fd5d</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">instrument part of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/22abf1bc-1f3a-4458-a016-c92ab3b8e16c">
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"/>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c0b8274d-8e80-44bd-a58c-876bd8ee4d55">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/44230e61-1c33-47a2-a425-8089e09c060c">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412164</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">General term for the principal monetary unit of Denmark and of Norway.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <skos:prefLabel xml:lang="en">krone (unit of currency)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d7195ad5-217f-4a62-8cf2-2aac59cf88f5">
+    <skos:scopeNote xml:lang="en">Alphanumeric codes that are traditionally used to uniquely identify a given manuscript within a defined environment. Manuscript designations may be used as titles of manuscripts. An example would be "Ms. Ludwig II 7."</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">manuscript designations</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404013</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/086e109d-754f-4c4c-8d93-c1a6a83c904e">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">39</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fdc542c4-9009-4558-9e90-28ef26d70f80">
+    <dcterms:identifier>https://afs.test.fargeo.com/fdc542c4-9009-4558-9e90-28ef26d70f80</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <skos:prefLabel xml:lang="en">instrument used in observation</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1c9052ae-db51-4033-aba0-fc767330fd12">
+    <dcterms:identifier>http://localhost:8000/1c9052ae-db51-4033-aba0-fc767330fd12</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3534ed28-8baa-40f0-a4c2-97e23870cdb3"/>
+    <skos:prefLabel xml:lang="en">art collections</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b134d2a0-532a-42d5-b124-5a1710e39d65">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">89</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Ru</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/b134d2a0-532a-42d5-b124-5a1710e39d65</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Ruthenium (Ru)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/774a6a6e-66f0-4b6c-92de-ea1f8c0c1018">
+    <dcterms:identifier>https://afs.test.fargeo.com/774a6a6e-66f0-4b6c-92de-ea1f8c0c1018</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">observation instrument used in</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7d8df7e0-0a7f-49e1-961a-a6995058c3d3">
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/d86b855e-6af4-402d-a94a-d13e36bddf8e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for dimension of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cc84ea58-4e46-4c49-a043-eff30f663403">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Ytterbium (Yb)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/cc84ea58-4e46-4c49-a043-eff30f663403</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">114</arches:sortorder>
+    <skos:altLabel xml:lang="en">Yb</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/87bfe412-f950-46f1-b27f-0f9a1a56f4cf">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">physical object used in publication event of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/87bfe412-f950-46f1-b27f-0f9a1a56f4cf</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/51613e01-7a47-4bb9-b9ae-75d449dbcda7">
+    <dcterms:identifier>https://afs.test.fargeo.com/51613e01-7a47-4bb9-b9ae-75d449dbcda7</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:prefLabel xml:lang="en">event causal to destruction</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7db49ae3-80dd-4c2e-83f3-842446415f13">
+    <skos:inScheme rdf:resource="http://localhost:8000/ca9e81f3-471d-4d1f-b323-edc816b1c522"/>
+    <skos:prefLabel xml:lang="en">catalogue number</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/7db49ae3-80dd-4c2e-83f3-842446415f13</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/24110bd5-0f65-4754-bd7e-b19ccd35b973">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300010900</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:scopeNote xml:lang="en">Any of a large group of substances that typically show a characteristic luster, are good conductors of electricity and heat, are opaque, can be fused, and are usually malleable or ductile.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">métal</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">metal</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d8de88fc-19c6-4129-bcc2-7bb3ff8e841a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Literary genre based on the Biblical New Testament, comprising the stories and body of religious doctrine described as having been taught by Jesus and apostles.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404696</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">gospels</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/52fbf9cc-3027-4d5c-9439-1856bb6e68a5"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a019643e-9b29-4b5d-bed7-f2ecaa4e86f9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">actor in formation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/a019643e-9b29-4b5d-bed7-f2ecaa4e86f9</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c7376c39-6e1a-46f1-8bde-974ea63be6fe">
+    <skos:prefLabel xml:lang="en">is depicted by</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/c7376c39-6e1a-46f1-8bde-974ea63be6fe</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/30e313f2-5591-49b6-b3ce-b3227192684a">
+    <dcterms:identifier>https://afs.test.fargeo.com/1b8ef6a7-c0ed-4437-b836-16c3dec42ce9</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">influence on activity</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/75613ffa-549e-42cd-8a5a-b9ff66ae8c07">
+    <skos:inScheme rdf:resource="http://localhost:8000/8b7faa16-3846-4360-b767-bb2c823b6550"/>
+    <skos:prefLabel xml:lang="en-US">fieldwork (research)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Studying or investigating a particular subject in its natural setting.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300077463</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b727e4b6-3169-457d-ab05-5991bacb03cd">
+    <skos:prefLabel xml:lang="en">religions (belief systems, cultures)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Belief systems that encompass various personal and institutional relationships between human beings and what they regard as holy, sacred, or divine, usually but not always a deity, or a spiritual or occult force. Participation in a religion is typically manifested in obedience, reverence, and worship, often including group activities and alliance with a leader. Elements of a religion or similar belief system include doctrine, ritual, defined parameters of morality, and a code of living, often seen as a means of achieving spiritual or material improvement.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/52fbf9cc-3027-4d5c-9439-1856bb6e68a5"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300073708</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/63af640c-f979-47ad-9cb1-edb5e685d756">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">period of curation of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/63af640c-f979-47ad-9cb1-edb5e685d756</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b7efedcf-7a28-4d5d-9759-425cf9be88b9">
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/48b2dd36-2148-4ce6-a00a-40be229da73d">
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+    <dcterms:identifier>http://localhost:8000/48b2dd36-2148-4ce6-a00a-40be229da73d</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">formal title</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c24d6806-75bf-4127-9fd6-c870cc160063">
+    <skos:prefLabel xml:lang="en">sale record number</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/7cc462a5-db43-4b25-a748-99892eba26aa"/>
+    <dcterms:identifier>http://localhost:8000/c24d6806-75bf-4127-9fd6-c870cc160063</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1d6371b4-5b58-42bd-b293-04df3c531e82">
+    <skos:inScheme rdf:resource="http://localhost:8000/a16a4edc-c916-4293-af98-44d76ce6cba7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">materials/technique description</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435429</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">An indication of the substances or materials used in the creation of a work, as well as any implements, production or manufacturing techniques, processes, or methods incorporated in its fabrication, presented in a syntax suitable for display to the end-user and including any necessary indications of uncertainty, ambiguity, and nuance. For works on paper, descriptions of watermarks may also be included.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3e8eddb2-ac9d-4d43-8579-8c19ce783c46">
+    <skos:prefLabel xml:lang="en">source reference for production of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">76</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/291354a2-c0b8-4143-baaf-534a9fae15a9</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f0b690bb-9e27-433b-a614-87e32fc9e87b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">83</arches:sortorder>
+    <skos:altLabel xml:lang="en">Ra</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Radium (Ra)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/f0b690bb-9e27-433b-a614-87e32fc9e87b</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d6a36ca5-c661-4dfd-9903-6a502eb52bbb">
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+    <skos:prefLabel xml:lang="en-US">treatment study</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/d6a36ca5-c661-4dfd-9903-6a502eb52bbb</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5beec90d-bec1-447f-929b-1d42ccff221c">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">40</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/dfa3a38f-4f2b-4f85-a454-7ad200d0fcd0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/dfa3a38f-4f2b-4f85-a454-7ad200d0fcd0</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of curation event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/17a5481d-5595-46cf-b6a1-56b29103f739">
+    <skos:prefLabel xml:lang="en">rental (method of acquisition)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Method of acquiring property for temporary use under terms by which the party in possession of the property will pay a regular fee for having control of or occupying the property.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/f3eca78c-7547-4ca5-a7eb-b130391b40ed"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417649</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e6db9f29-4a2f-4393-97d2-0e9435ccff69">
+    <skos:altLabel xml:lang="en">Sb</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/e6db9f29-4a2f-4393-97d2-0e9435ccff69</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Antimony (Sb)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b16acdf3-a9c0-4c99-9ea1-dd17972cf288">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300266822</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Pertains to the style and culture of modern Iran. Although modern Iran was known as Persia until 1935, art and architecture of ancient Iranian civilizations dates back to prehistoric times.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Iranian</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c5b3f189-0445-4c79-836c-45ca54dae583">
+    <dcterms:identifier>https://afs.test.fargeo.com/2ab5c7a0-d903-4d2d-bf47-1d866d78f170</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location of creation of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9afbc9a7-f570-46b1-9055-80cc62bf82b3">
+    <skos:scopeNote xml:lang="en">Works of art in any medium, including performance art. A work of art may exist as a part of a larger object, e.g., a mural painting or a painting on a piece of furniture. When referring to the study or practice of the fine arts or the fine and decorative arts together, use "art." In reference to pieces of fine or decorative arts as collectables rather than museum objects, in English use either "art objects" or the French term "objets d'art," which emphasizes this meaning.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">works of art</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300133025</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/273d0839-8911-468f-9eb1-b0cc3507b6e7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8a5e1968-568d-485d-ad72-6d18a27037e5">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/c8261144-c750-4f64-8980-e50f762b21a5"/>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/efc51ec8-3d68-415b-b204-b106ce85a830">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">location of creation</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/de8785a1-26e0-47f6-8612-a1909d88f55e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bcea7794-7ce8-4f82-882a-3aa6b083a275">
+    <skos:prefLabel xml:lang="en">producer of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/bcea7794-7ce8-4f82-882a-3aa6b083a275</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f01f324e-a192-4aab-9bdb-9a2fd5c355a2">
+    <dcterms:identifier>http://localhost:8000/f01f324e-a192-4aab-9bdb-9a2fd5c355a2</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/94343b71-a35a-4edd-8ffa-61c66ea8d417"/>
+    <skos:prefLabel xml:lang="en">inserting</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2e20c0c0-154a-484f-9f2c-81e6dc680586">
+    <skos:prefLabel xml:lang="en">period of curation</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/2e20c0c0-154a-484f-9f2c-81e6dc680586</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f3f816cd-641e-4659-9243-0837a0b84238">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">actor in</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/2e0fefb8-7556-4ffb-b946-e3546bac2e72</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d9eba15b-b804-4be2-9d76-a71308a7a5dc">
+    <skos:prefLabel xml:lang="en">physical object removed by part removal event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">58</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/d9eba15b-b804-4be2-9d76-a71308a7a5dc</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5b9f4d60-f92a-4c79-9a84-84a3ce3c0562">
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">50</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c601ffd7-0ec9-4208-8591-756a0aa86755">
+    <dcterms:identifier>https://afs.test.fargeo.com/c601ffd7-0ec9-4208-8591-756a0aa86755</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">48</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">source reference work for group leaving event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/68e3884d-a4da-4a1c-9b41-853cdb59d5f9">
+    <skos:scopeNote xml:lang="en">Objects that occur in nature, not made by humans. Used primarily in the context of distinguishing man-made objects from natural objects.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/273d0839-8911-468f-9eb1-b0cc3507b6e7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404125</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">natural objects</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/eb6be2ac-e632-4855-a6d5-bc28ae9ee792">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/69abe4f9-f16f-47bf-8fdf-ccce67a18e5d"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435444</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Indication of the placement of a work of art or architecture within a classification scheme that groups other, similar works together on the basis of similar characteristics</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">classification (category)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d86b855e-6af4-402d-a94a-d13e36bddf8e">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <skos:prefLabel xml:lang="en">source reference for dimension of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/d86b855e-6af4-402d-a94a-d13e36bddf8e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8e6005a1-849d-426e-b657-5907b817d79b">
+    <skos:prefLabel xml:lang="en">physical object used in professional activity</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/8e6005a1-849d-426e-b657-5907b817d79b</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6cdda74a-33fe-4d48-bb2e-b552f35f20b1">
+    <skos:prefLabel xml:lang="en">creator of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/6ea01af9-52df-4ddf-bd9e-2efda73f574f</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fb28c2e9-7a94-4dc2-af72-7d1a076fe176">
+    <skos:altLabel xml:lang="en">Np</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/fb28c2e9-7a94-4dc2-af72-7d1a076fe176</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Neptunium (Np)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">65</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/abef629f-5d8c-45ef-be56-ab9d6f7c9ba4">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">38</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/abef629f-5d8c-45ef-be56-ab9d6f7c9ba4</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for death of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/21bbcd2d-84b8-4604-96aa-add5e2e84588">
+    <skos:scopeNote xml:lang="en">The process of extending something flexible, such as a cord or piece of fabric, from one point to another, across a space, or over a form, for the purpose of drawing it taut or rigid or for making it larger.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053142</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">stretching</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a9e75b55-78b9-46a6-8cb2-aee3f5b5003e"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a1887fd8-a032-4cc2-b3ae-d82779c7dbb3">
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/dor-uuid</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+    <skos:prefLabel xml:lang="en-US">Getty Digital Object Repository (DOR) Universally Unique Identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e610dcdc-0360-4a74-b927-81156b041c5d">
+    <dcterms:identifier>https://afs.test.fargeo.com/8be4ac1b-581b-4967-b7d6-5e2fe36fadb6</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of creation</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3e105447-bca4-4819-a674-e0773ce6df8e">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379517</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">collaboration</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to any venture in which individuals or organizations work together, especially in an intellectual endeavor.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/b27ffefc-18a1-468f-8923-87530b6f5943"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0bc8a3a2-baa2-4a32-9839-89b5bf917f3a">
+    <skos:prefLabel xml:lang="en">masculine</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Having chracteristics, qualities, attributes, or actions associated with the male sex.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300411836</dcterms:identifier>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/73a6d800-669d-48b7-a1fb-2ecdaa0a4827">
+    <dcterms:title>Object Part Types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/a17a13c9-58f0-4e66-8a73-bfae8f6247fa">
+    <skos:prefLabel xml:lang="en">cleavage</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af4360a2-0809-44a3-a72a-8a5f3c15ab31"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300220007</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Separation between layers, as between a paint or varnish film and other film layers, or between a film layer and its support, or separation along planes of weakness in crystalline materials.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/72c6bbfc-1e8d-43c0-b789-aafd0f8c2854">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">41</arches:sortorder>
+    <skos:prefLabel xml:lang="en">owner of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/c64fe7b5-1fca-4de8-8562-cdc32fc26c98</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/20d21d50-3650-44ed-8451-edee26ddc3f2">
+    <skos:scopeNote xml:lang="en">Units of time equivalent to nearly 365.25 days, 12 months, or the period of one full circuit of the Earth around the Sun. </skos:scopeNote>
+    <skos:prefLabel xml:lang="en">years</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/bbf81641-b1dd-4ddf-858d-7e8ca823d385"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379244</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2427e2f3-9599-4690-b5df-59acbec9d4c7">
+    <dcterms:identifier>https://afs.test.fargeo.com/4574d04f-cf3d-4c2f-91d7-0c50f3d7aa14</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of professional activity</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa5108b1-0643-4605-ad0d-e7a3c22e7fd6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/fa5108b1-0643-4605-ad0d-e7a3c22e7fd6</dcterms:identifier>
+    <skos:prefLabel xml:lang="en-US">crowdsourcing</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/35ed167d-ab89-4f38-b046-3349256be725"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f43bfa7f-e3de-4364-9735-0459b8ac5b8b">
+    <skos:scopeNote xml:lang="en">Creating and manipulating data in machine-readable form by means of computers, including inputting, storage, conversion, editing, and printing.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">data processing</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054636</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/38867773-6543-4a98-90cc-dc1c7bec3340"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e5893685-da04-4149-a184-efe51610d367">
+    <dcterms:identifier>https://afs.test.fargeo.com/b03fb895-dc2d-4643-a770-a59ff4161637</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">influence on professional activity of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/45ba0f19-5c56-4ed0-b408-667071af9b51">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">63</arches:sortorder>
+    <skos:prefLabel xml:lang="en">physical object used in production of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/45ba0f19-5c56-4ed0-b408-667071af9b51</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a3ddd46c-0aba-4ba0-a943-c9d793e1a9bc">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300419274</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/639b8e22-9565-4fa4-92d8-50c28d1df17d"/>
+    <skos:prefLabel xml:lang="en">postcodes</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Numeric or alphanumeric codes included in mailing addresses to facilitate the sorting and delivery of mail.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c6a2d92b-9eb4-407d-9dd9-b0ab0b0f6861">
+    <skos:prefLabel xml:lang="en">source reference for dimension of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/d86b855e-6af4-402d-a94a-d13e36bddf8e</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">33</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7bf9197c-f82d-4ce3-9e4d-2221c017d45b">
+    <skos:scopeNote xml:lang="en">Identification of a person with a particular state or nation. In a modern sense, the it is the legal status of being a citizen or subject of a particular state, usually involving mutual obligations of support and protection.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379842</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">nationality</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/c82d6f85-ae67-4c28-b07a-c114f6d6ba50"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/50ed9b8e-591b-4a63-a757-a757ee7fdb4b">
+    <skos:prefLabel xml:lang="en">influence on creation event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/3c44d93c-01e5-4768-9b00-61db7f350d6a</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1a9e5440-62f3-4327-854f-ed48feff25de">
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5957d1e1-64be-415a-aa72-653243364544">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of group leaving event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/5957d1e1-64be-415a-aa72-653243364544</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b7929847-1bff-4ca6-b3f3-488b4a37db81">
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes assigned when an art object, book, or other item enters the collection of a museum, library, or other repository. Such codes are unique within the set of codes, and specifically identify the particular item at hand. The numbers may be marked on the objects or not.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300312355</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Accession Number</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3db4ef7a-437d-48fb-8f34-422e226d49cd">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111259</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the island of Ireland, which is located west of England on the Irish Sea and is currently divided administratively between the Republic of Ireland and Northern Ireland. It often refers specifically to the Celtic culture of the island of Ireland.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="en">Irish</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/0f8d86b6-d2ae-45c4-927c-c07718fab46e">
+    <dcterms:title>Dissolution types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/941d2212-7f9a-46ce-8fc2-14ca6f068511">
+    <skos:prefLabel xml:lang="en">overall object sampled</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/941d2212-7f9a-46ce-8fc2-14ca6f068511</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4f364fad-a1ab-4956-a36e-204ed8bb2ca0">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/4f364fad-a1ab-4956-a36e-204ed8bb2ca0</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">112</arches:sortorder>
+    <skos:altLabel xml:lang="en">W</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Wolfram (W)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2ad60313-ba81-42a0-a18e-2058b41546aa">
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f913b688-45d3-4d9f-818b-081b9232ca4b">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">location of publication event of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/f913b688-45d3-4d9f-818b-081b9232ca4b</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/16cf5efc-6549-42e9-b306-6f30cb430103">
+    <skos:altLabel xml:lang="en">Re</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">85</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/16cf5efc-6549-42e9-b306-6f30cb430103</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Rhenium (Re)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3b20d306-21f5-473a-a012-8f9ba70742db">
+    <dcterms:identifier>https://afs.test.fargeo.com/3b20d306-21f5-473a-a012-8f9ba70742db</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <skos:prefLabel xml:lang="en">source reference work for group joining event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">47</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3b46f7de-75f7-4999-a0ab-3a8b6ca5b01a">
+    <skos:prefLabel xml:lang="en">female</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300189557</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Referring to the sex that normally produces eggs or female germ cells.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5a9349ec-e6fa-4e19-9343-058749886697"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/00d2b83d-3a29-44c0-81aa-8952e961934a">
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e26bc6aa-28c3-4462-8f15-5015ed64c3fe">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054196</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">drawing (image-making)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Producing visible forms primarily by delineation, usually by the direct application of material or instrument to the surface of the support.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a7cb9b76-59e2-47d4-8da6-52891ebbf4a5">
+    <skos:prefLabel xml:lang="en">source reference for contact information of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/a7cb9b76-59e2-47d4-8da6-52891ebbf4a5</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fb0a9c3f-02e5-44ac-8e39-266ac9460dcb">
+    <dcterms:identifier>http://localhost:8000/fb0a9c3f-02e5-44ac-8e39-266ac9460dcb</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/074dca4c-a3d3-4521-835d-f1fa1a9c775b"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">manufacturer information</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/262d850e-0eb6-4a58-b3d2-b44675801633">
+    <dcterms:identifier>https://afs.test.fargeo.com/262d850e-0eb6-4a58-b3d2-b44675801633</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">actor in part removal event of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/db62dc19-f356-410b-a309-474f5b59c767">
+    <skos:scopeNote xml:lang="en">Refers to the process or branch of fine art concerned with creating sculpture, which are three-dimensional works. It refers particularly to carving or engraving a hard material, or with molding or casting a malleable material, so as to produce designs or figures in relief, in intaglio, or in the round. It is typically used to refer to the production of large or medium-sized objects in stone, clay, or bronze. The production of small objects in bronze or stone is typically referred to by a specific term, such as "stone carving" or "die sinking." The production of sculpture in wood or ivory is typically referred to as "carving," even though the finished work in these materials may be called "sculpture (visual work)."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">sculpting</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264383</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/c372cf0b-f0f4-4730-a97d-c892dfbefcd7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1a7aa305-ab78-4ea3-abd2-16ac8d8ce10e">
+    <dcterms:identifier>https://afs.test.fargeo.com/1a7aa305-ab78-4ea3-abd2-16ac8d8ce10e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">digital carrier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bdb42273-5581-4554-956f-c8f41c67798d">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300388474</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">italien</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f7fc4f6d-fd46-4881-846f-4a08bc1a3fef"/>
+    <skos:prefLabel xml:lang="en">Italian (language)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Italienisch</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5c69a1f4-01ca-4ee1-8000-493bc6b9b28e">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <skos:prefLabel xml:lang="en">sampled by</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/5c69a1f4-01ca-4ee1-8000-493bc6b9b28e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d6fe21ba-9846-4bc5-b6ad-6c9f52e40162">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:scopeNote xml:lang="de">Schriftliche Anerkennung für Handlungen oder Leistungen.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300026687</dcterms:identifier>
+    <skos:prefLabel xml:lang="de">Danksagung</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Written recognitions of acts or achievements.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+    <skos:prefLabel xml:lang="en">acknowledgments</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b5b561eb-9935-40bf-ade0-5a576299c3d9">
+    <skos:prefLabel xml:lang="en">accelerated aging</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300226566</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a9e75b55-78b9-46a6-8cb2-aee3f5b5003e"/>
+    <skos:scopeNote xml:lang="en">Testing techniques that impose conditions on an object or material to cause it to age more rapidly than it would naturally.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e3c92bee-8df1-444f-899c-96d4fca1264d">
+    <skos:prefLabel xml:lang="de">Blei</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011022</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">lead (metal)</skos:prefLabel>
+    <skos:prefLabel xml:lang="pt">chumbo</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Pure metallic element having symbol Pb and atomic number 82; soft, dense ductile metal of a dull gray color, shiny when freshly cut, occuring naturally most often as a sulfide in the mineral galena. Other lead minerals include anglesite (lead sulfate) and cerussite (lead carbonate). Native metallic lead was found and used from about 3600-2600 BCE when the technique for obtaining lead from roasting the sulfide ore (galena) was discovered. Lead was used to make small cast items such as coins and statuettes, plumbing pipes, spires, statues, cisterns, gargoyles, pigments (lead white, litharge, orange mineral, etc.), as a component in pottery glazes, for roofing, flashing, stained glass windows, as a soft solder, and as radiation shielding.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="fr">plomb</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/55bda626-a4f8-4e30-82b8-ed438a02edc7">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/55bda626-a4f8-4e30-82b8-ed438a02edc7</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">influence on group leaving event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/12fbf8b0-6a96-4f44-96b3-0e7ef2fa5315">
+    <dcterms:identifier>https://afs.test.fargeo.com/35c808fa-3af2-4a8e-8d64-0f5d48dc2c59</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for identifier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4b220b03-17eb-44b8-b3db-3fa46f23697d">
+    <skos:prefLabel xml:lang="en">session number</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dca6a321-3ab9-42bc-ac80-2171789ae205"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/4b220b03-17eb-44b8-b3db-3fa46f23697d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e7801af8-3f25-4103-aef2-c5a023b1b15e">
+    <dcterms:identifier>https://afs.test.fargeo.com/e7801af8-3f25-4103-aef2-c5a023b1b15e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+    <skos:prefLabel xml:lang="en">text carried by digital resource</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bf286362-1a29-40c3-a244-0cd27dd3c99a">
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1b8bcbc1-60b1-4476-b52a-659a59f891ad">
+    <skos:prefLabel xml:lang="en">physical object removed by part removal event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/1b8bcbc1-60b1-4476-b52a-659a59f891ad</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">57</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d3e01a25-cbc3-422c-ab2a-b6ca1fe64f7b">
+    <dcterms:identifier>https://afs.test.fargeo.com/d3e01a25-cbc3-422c-ab2a-b6ca1fe64f7b</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">collection added to</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4013bc24-e4cf-479d-9ed9-775843ff259b">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Eisen</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">iron (metal)</skos:prefLabel>
+    <skos:prefLabel xml:lang="pt">ferro</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">fer</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011002</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Pure metallic element having symbol Fe and atomic number 26; metallic iron is silvery in color, lustrous, soft, ductile, malleable, and slightly magnetic; it rusts when exposed to moist air. It is rarely found as a native metal (telluric iron) except in meteorites (meteoric iron). Iron is most often found throughout the world as iron oxides (hematite, magnetite, limonite, and siderite) mixed with other ores.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4d85a589-3510-4a28-afec-7d9e31bb99eb">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for statement about</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/ed080f48-eafc-4b7f-b7f4-8ef01ddb7eba</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/abf7d596-9e36-4bbe-8b7c-f2b40fd5697b">
+    <skos:prefLabel xml:lang="en">Technetium (Tc)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Tc</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">101</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/abf7d596-9e36-4bbe-8b7c-f2b40fd5697b</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3dd3cdeb-070b-421d-be52-ae7580e1296c">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Explanation of what is not immediately plain or explicit, as in suggesting what meaning is to be found in a set of data or in a visual work.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300226183</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+    <skos:prefLabel xml:lang="en">interpretation</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a4011080-0aed-4320-a2c9-cd3fe7eb25e9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+    <skos:altLabel xml:lang="en">Dy</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/a4011080-0aed-4320-a2c9-cd3fe7eb25e9</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Dysprosium (Dy)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/760e3a5a-3401-43d2-90ef-1a2b97182131">
+    <skos:altLabel xml:lang="en">Gd</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Gadolinium (Gd)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">36</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/760e3a5a-3401-43d2-90ef-1a2b97182131</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a064d600-c179-4df7-9f1f-17f4b33472be">
+    <dcterms:identifier>http://localhost:8000/a064d600-c179-4df7-9f1f-17f4b33472be</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">image number</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ca9e81f3-471d-4d1f-b323-edc816b1c522"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/55949598-b28f-4e42-a286-1a1e9871fb09">
+    <skos:prefLabel xml:lang="pt">artistas</skos:prefLabel>
+    <skos:scopeNote xml:lang="pt">Pessoas que produzem trabalho nas artes visuais. Para aqueles nas artes cênicas, consulte "artistas performáticos".</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/db261e02-be27-4a99-b9c1-875375103a1d"/>
+    <skos:prefLabel xml:lang="en">artists (visual artists)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300025103</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">People who produce work in the visual arts. For those in the performing arts, see "performing artists."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/12aa5cea-0f98-4b10-8084-24795fe07813">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/12aa5cea-0f98-4b10-8084-24795fe07813</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">107</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:prefLabel xml:lang="en">Thulium (Tm)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Tm</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2147e9a7-d919-4b78-86fc-1da6bc501e65">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</arches:sortorder>
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9db5585c-df05-4f3e-b66f-ea8191a1717f">
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/4096365e-4fe7-412d-906c-16f3d356e8be"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/58c824cc-8ed7-4cd4-8431-125a7dc924e7">
+    <skos:prefLabel xml:lang="en">source reference for part removal event of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/58c824cc-8ed7-4cd4-8431-125a7dc924e7</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">75</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fba52c54-009d-4d0c-9192-8070686088aa">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b03fb895-dc2d-4643-a770-a59ff4161637">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:prefLabel xml:lang="en">influence on professional activity of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/b03fb895-dc2d-4643-a770-a59ff4161637</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bcf2a0c8-0eab-40bf-a005-f5323741e469">
+    <skos:prefLabel xml:lang="en">Arches Universally Unique Identifier (UUID)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f24f177f-9849-48d9-ba67-621d577f71e9"/>
+    <dcterms:identifier>http://localhost:8000/acce3a82-797a-4b75-b7d0-e7fcc82119bc</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/73014870-366d-4c86-ac23-d01d40801d75">
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Russia, or to the cultures that have occupied the principal lands of historic Russia in eastern Europe and northern and western Asia. It may also be used to refer to the larger group of cultures controlled by the historic Soviet Union.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111276</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Russian (culture or style)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/4d7dd282-959e-4bef-9b14-dc37a6470f7e"/>
+    <skos:prefLabel xml:lang="fr">russe</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249">
+    <skos:inScheme rdf:resource="http://localhost:8000/044b55b3-bd2b-4c66-bb92-f60d6a563e54"/>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/66a5028b-f43d-4637-b824-bb2d1952a8b8">
+    <dcterms:identifier>https://afs.test.fargeo.com/66a5028b-f43d-4637-b824-bb2d1952a8b8</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">publication ends before event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/698e6690-f9d5-46e0-aa53-da1d964eb050">
+    <skos:inScheme rdf:resource="http://localhost:8000/f44f7240-35c5-49e8-a0e3-2ffe308f0862"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435444</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Indication of the placement of a work of art or architecture within a classification scheme that groups other, similar works together on the basis of similar characteristics</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">classification (category)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2ffa50b7-29ca-43c2-b402-8511aa996ca6">
+    <dcterms:identifier>https://afs.test.fargeo.com/8f3bebaa-3ee9-41a8-bbed-f484d2efc300</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/ac85c692-0d2b-4132-8e5f-2ec3138294d5"/>
+    <skos:prefLabel xml:lang="en">location of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/72c057e2-39b9-4636-aab1-57e634744a3f">
+    <skos:prefLabel xml:lang="en">Dataset</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/b49383a7-a83e-4c1b-a705-e4c21d49ba17</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/798ecc23-2f34-4e13-94b4-b5a0831a2f3a">
+    <skos:prefLabel xml:lang="en">Nitrogen (N)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">69</arches:sortorder>
+    <skos:altLabel xml:lang="en">N</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/798ecc23-2f34-4e13-94b4-b5a0831a2f3a</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa579432-0d81-4d5e-a721-01015f8fbfe5">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404679</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">stage names</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/36169008-3624-4589-98f8-47653f6db663"/>
+    <skos:scopeNote xml:lang="en">Regarding personal names, assumed names used by actors and other performers rather than their real names.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5f4346f1-126a-47fe-bd67-57a30353ef8b">
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:prefLabel xml:lang="en">gold leaf</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300264831</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to sheets of gold that have been hammered or rolled very thin (typically around 0.1 micrometer, or 4 millionths of an inch, thick). In art, gold leaf has been applied to paintings, sculptures, manuscripts, and decorative arts since around 1500 BCE. In the 1920s, the process of creating gold leaf was successfully automated.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ad788cc5-c54a-4a46-9fa2-817ffd97be3c">
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:prefLabel xml:lang="fr">dessins</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Visuelles Werk, das durch Zeichnen hergestellt wurde, was das Auftragen von Linien auf eine Oberfläche ist, oft Papier, unter Verwendung eines Bleistifts, einer Feder, Kreide oder eines anderen Zeichenmittels, mit dem Schwerpunkt eher auf der Darstellung der Form als der Betonung der Farbe. Der Begriff wird oft allgemein definiert und auch auf computergenerierte Bilder angewendet.			&#13;
+</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Visual works produced by drawing, which is the application of lines on a surface, often paper, by using a pencil, pen, chalk, or some other tracing instrument to focus on the delineation of form rather than the application of color. This term is often defined broadly to refer to computer-generated images as well.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">drawings (visual works)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300033973</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ade10811-70ea-401c-b4f6-ea811592c4d9">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/ade10811-70ea-401c-b4f6-ea811592c4d9</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of group joining event of</skos:prefLabel>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/c53d3557-e033-4aa1-b020-0dc2b690025f">
+    <dcterms:title>TimeSpan types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/103f37b1-6d21-4889-99ad-2c82e8adf685">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/103f37b1-6d21-4889-99ad-2c82e8adf685</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">79</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for destruction event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f3100a7d-393e-43f8-bc20-80e1c09a078b">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111172</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Denmark, or in general to the cultures that have occupied the area of northwestern Europe, north of Germany. It is often used to refer specifically to the cultures of the historic Danes, a Scandinavian branch of the Teutons. It is also sometimes used to refer to the culture of all Scandinavians who invaded England from the 9th century to the 11th century CE.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:prefLabel xml:lang="en">Danish (culture or style)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0e121bc0-8eb3-4590-8626-945e07f18384">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">legacy identifier</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/407a6555-c7dc-498f-b152-cafb6c0b9777</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/38b89200-476b-490e-9e05-c0ce00b2041c">
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/113faf73-5893-4c1c-8bb4-4f95472a7891">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/fc49c02e-42cf-4ebb-8952-ddd323c4dd7f</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">procedure used in</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cf4707c0-4fbf-46a7-998c-fa04f9552a96">
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/411df452-e9ba-481a-89dd-3b65fb8f08fd">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Swedish (culture or style)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the modern nation of Sweden, or in general to cultures that have occupied the area of the eastern section of the Scandinavian peninsula in northwestern Europe.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111218</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/03099493-552a-44be-8421-ab327fae6874">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">72</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Osmium (Os)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/03099493-552a-44be-8421-ab327fae6874</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Os</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/545dd2fc-0d38-46de-8475-2a77ead4298e">
+    <skos:prefLabel xml:lang="en">Bohemian</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300266148</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">bohême</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Refers to the culture of the historical region, kingdom, and later administrative district of Bohemia. Often used as a synonym of 'Czech.' Bohemia ceased to be an autonomous administrative district in 1949, and in 1993 formed part of the modern Czech Republic. There is no cultural difference implied in the terms 'Czech' and 'Bohemian,' the distinction is more precisely a chronologic or historical one.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c2756c47-e26e-4136-97b3-42c4b26fc756">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">42</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c2bf4209-855e-40a2-8f75-70d34bd0eb8d">
+    <skos:prefLabel xml:lang="en">source reference work for dimension</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/9d84c6cb-70b1-4607-a035-2175a18f1991</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a978368f-4219-4c27-a3fe-42e543919f58"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/31dbfe57-3132-4bab-8c7c-eeccf0e7c3f5">
+    <skos:scopeNote xml:lang="en">Refers to the culture of the southern Netherlands, roughly corresponding to modern Belgium, Luxembourg, and part of France, particularly during the historical period when Flanders was an independent principality.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300111184</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Flemish (culture or style)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d81a487b-712e-46e9-851d-52674ecbf9ff">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/d81a487b-712e-46e9-851d-52674ecbf9ff</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of dissolution event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1441b79e-fed7-4a36-acc5-bb1b60d1976d">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">110</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">U</skos:altLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/1441b79e-fed7-4a36-acc5-bb1b60d1976d</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Uranium (U)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/147bb168-4bd4-4c99-a3dd-5e799e6cab0c">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/147bb168-4bd4-4c99-a3dd-5e799e6cab0c</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">has textual work part</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a2588fa8-5ae6-4770-a473-dec0c05fb175">
+    <skos:prefLabel xml:lang="en">analysis areas</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <dcterms:identifier>http://localhost:8000/a2588fa8-5ae6-4770-a473-dec0c05fb175</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/90cca4e4-b569-48bf-91de-b18a473d2deb">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379523</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The branch of conservation science involving treatment, preventive care, and research directed toward archaeological sites and materials.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">archaeological conservation</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/b3d6e036-e788-4c85-a1f0-3aa35f0a82f2"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/14808b22-a4f5-4c61-a2fb-447727f2d8cc">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404621</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ca9e81f3-471d-4d1f-b323-edc816b1c522"/>
+    <skos:prefLabel xml:lang="en">internal identifier</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes of various types assigned to an art object, book, other item, or group of works by the repository that holds that item or group. Any item or group in a repository may have multiple types of repository numbers. For numbers specifically assigned at the time of accession by a repository, prefer "accession numbers."</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/6d43f77b-4fa7-4913-9932-f5fdb606293e">
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c6df2fb1-861f-4a72-b6d3-baffae85c4e6">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300047090</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Three-dimensional works of art in which images and forms are produced in relief, in intaglio, or in the round. The term refers particularly to art works created by carving or engraving a hard material, by molding or casting a malleable material (which usually then hardens), or by assembling parts to create a three-dimensional object. It is typically used to refer to large or medium-sized objects made of stone, wood, bronze, or another metal. Small objects are typically referred to as "carvings" or another appropriate term. "Sculpture" refers to works that represent tangible beings, objects, or groups of objects, or are abstract works that have defined edges and boundaries and can be measured. As three-dimensional works become more diffused in space or time, or less tangible, use appropriate specific terms, such as "mail art" or "environmental art." </skos:scopeNote>
+    <skos:scopeNote xml:lang="de">Dreidimensionales Kunstwerk, in dem Bilder und Formen im Relief oder vollplastisch dargestellt werden. Der Begriff bezeichnet Werke, die durch Schnitzen oder Gravieren eines harten Materials, durch Gießen oder Formen weichen Materials (in der Regel später erhärtend) oder durch Montieren verschiedener Teile entstehen. Üblichweise wird der Begriff für groß oder mittelgroß dimensionierte Objekte aus Stein, Holz, Bronze oder anderem Metall verwendet. Kleinere Objekte werden in der Regel als "Environmens" oder mit anderen, geeigneten Begriffen bezeichnet. "Skulptur" bezieht sich auf Werke, die fassbare Wesen, Objekte oder Gruppen von Objekten darstellen oder auf abstrakte Werke, die definerte, messbare Kanten und Ausdehnungen besitzen. Dreidimensionale Werke, die unbestimmter im Raum und Zeit oder weniger greifbar sind, sollten mit entsprechend spezifische Begriffen wie "Mail Art" oder "Landart" bezeichnet werden.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/56991802-f539-4b22-b5a9-b1945fceb52b"/>
+    <skos:prefLabel xml:lang="en">sculpture (visual works)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">sculpture (œuvres visuelles)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Skulptur</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5cf7e8e1-8102-4580-a1bb-5cfdb8f2470e">
+    <dcterms:identifier>https://afs.test.fargeo.com/b5767b7c-6c4e-48bd-abfa-caf3ff139cc8</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">used in</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/34eae943-67d8-42f8-abeb-6131b2a95b43">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300024987</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/db261e02-be27-4a99-b9c1-875375103a1d"/>
+    <skos:prefLabel xml:lang="en">architects</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">People trained in or practicing architecture, which is the art of designing and building habitable structures, especially those considered to have aesthetic value.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Architekt</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1d62fff7-c49d-4f8e-9f0d-32a9ff063a90">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/1d62fff7-c49d-4f8e-9f0d-32a9ff063a90</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Md</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Mendelevium (Md)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">59</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/47fa0a9c-ff30-4e62-aad9-18863c1ee32e">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435444</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Indication of the placement of a work of art or architecture within a classification scheme that groups other, similar works together on the basis of similar characteristics</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"/>
+    <skos:prefLabel xml:lang="en">classification (category)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b011b4bf-b8b4-4bda-8633-3376b275184d">
+    <skos:prefLabel xml:lang="en">exchange (method of acquisition)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300263427</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Method of acquiring property by each party giving and receiving from the other party, usually regarding property of equal value. For example, an exchange may be made by individual authors, libraries, museums, and other institutions in which they exchange between or among each other their own publications or those of the institution with which they are connected, or duplicates from their own collections.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f3eca78c-7547-4ca5-a7eb-b130391b40ed"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cb280c17-f989-4db7-88de-000a59d1a33b">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">80</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/9d84c6cb-70b1-4607-a035-2175a18f1991</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference work for dimension</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d3057a9f-950c-47fc-b5a4-c6c963bb34f6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/8f3bebaa-3ee9-41a8-bbed-f484d2efc300</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b1eb4eb1-a848-45cb-8e8b-dbc6d33b51cb">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">113</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/b1eb4eb1-a848-45cb-8e8b-dbc6d33b51cb</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Xe</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Xenon (Xe)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c13e1882-c0c8-4044-8fff-1268ea9c721f">
+    <skos:scopeNote xml:lang="en">For art information, a brief statement indicating how the work came into the current or an earlier collection or how it came to be on view at the repository. </skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:prefLabel xml:lang="en">credit line</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435418</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/963f3f6a-c52e-4119-92fd-76d6fec9d31e">
+    <dcterms:identifier>https://afs.test.fargeo.com/963f3f6a-c52e-4119-92fd-76d6fec9d31e</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/67f13f49-946d-4eb7-acf9-1bea91c30874"/>
+    <skos:prefLabel xml:lang="en">parent instrument</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f56d47fa-10d9-4e37-a009-9b77a96e3f50">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054216</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">painting (image-making)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The art and practice of applying pigments suspended in water, oil, egg yolk, molten wax, or other liquid to a surface to create an expressive or communicative image. Paint is usually, but not always, applied with a brush. For the application of paint primarily to protect a surface or add a general color, use "painting (coating)."</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/a4095d09-de02-4675-ab63-42227d9e94bc"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/e8552ef1-a840-41c0-8653-37ced235c300">
+    <dcterms:title>Birth types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/b413ecb6-090a-42d0-ac17-5b3542a2d147">
+    <skos:prefLabel xml:lang="en">period of formation of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/b413ecb6-090a-42d0-ac17-5b3542a2d147</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/10d4f4dc-0326-43e7-9dd9-3e892fcc62d4">
+    <dcterms:identifier>https://afs.test.fargeo.com/10d4f4dc-0326-43e7-9dd9-3e892fcc62d4</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">has influence on production event of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/265b2804-4472-4540-b7bb-b81ced9e41fd">
+    <dcterms:identifier>http://localhost:8000/265b2804-4472-4540-b7bb-b81ced9e41fd</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:prefLabel xml:lang="en">VIAF</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d1f9674-3dbb-4da2-b107-c878eff13d5d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/47e940a3-b483-41c9-9430-34c990014764">
+    <dcterms:identifier>http://localhost:8000/47e940a3-b483-41c9-9430-34c990014764</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en-US">Joining as Contact Point</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/1ad61b29-95db-4885-a5ad-0d037e609488"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/79f44e59-670d-408d-9439-0c6810523d5e">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300266036</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">dimensions</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Measurable or spatial extent of any kind, such as length, breadth, thickness, area, volume, measure, magnitude, or size.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/90d7c629-8d3d-4814-9e53-697a7c82a030">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">causally related to production of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/90d7c629-8d3d-4814-9e53-697a7c82a030</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/88ab2b99-d06a-46a1-b886-c5fc2d16be37">
+    <skos:prefLabel xml:lang="en">period of destruction event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/88ab2b99-d06a-46a1-b886-c5fc2d16be37</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">43</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a3d990a9-1a2a-4314-91fb-57c6efa5e2e3">
+    <dcterms:identifier>http://localhost:8000/4b220b03-17eb-44b8-b3db-3fa46f23697d</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/f24f177f-9849-48d9-ba67-621d577f71e9"/>
+    <skos:prefLabel xml:lang="en">session number</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f4ea3658-51df-4475-aaf6-9bbdf384ed0c">
+    <skos:prefLabel xml:lang="en">web service</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/1230c0d7-ed5b-4f97-b54d-74bda170c7e3"/>
+    <dcterms:identifier>http://localhost:8000/f4ea3658-51df-4475-aaf6-9bbdf384ed0c</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ef7564e6-5728-418d-816c-b302a8013a91">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">primary (general designation)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Designation indicating something, someone, a characteristic, or an activity is the most important or fundamental, is occurring or existing first in a sequence, belonging to the beginning or earliest stage,is the original, or not subordinate to or derived from anything else.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/f24f177f-9849-48d9-ba67-621d577f71e9"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404450</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1df55246-26a7-4670-aa2b-efde7aff9fa6">
+    <skos:altLabel xml:lang="en">Th</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Thorium (Th)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">106</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/1df55246-26a7-4670-aa2b-efde7aff9fa6</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e1888665-101f-4307-9906-6d9df78bd88c">
+    <skos:scopeNote xml:lang="en">Titles or names that have been used to refer to the work in publications. For works of art and architecture, examples are titles or names in catalogs or journal articles that are not necessarily a title by which the work is normally known. For books, the term may be used to distinguish the final published title from an original unpublished or working title.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417206</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">published titles</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9f1cf9a8-ce65-455f-ab1e-a9b36e9e23ce"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8a8ee459-ed32-4bd5-9235-518529188060">
+    <dcterms:identifier>https://data.getty.edu/museum/ontology/linked-data/tms/object/producer-description</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+    <skos:prefLabel xml:lang="en-US">producer description</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f252adb6-3b7a-44ae-815d-10a72ff83666">
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/f252adb6-3b7a-44ae-815d-10a72ff83666</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">tool used in modification</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/33208a31-4e1b-4b72-877d-9a1b7d3db095">
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/4096365e-4fe7-412d-906c-16f3d356e8be"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5849a150-bf7b-4b68-937d-d22a52780eb9">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/5849a150-bf7b-4b68-937d-d22a52780eb9</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a9e75b55-78b9-46a6-8cb2-aee3f5b5003e"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">RH variation</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/98b2bf4b-4e12-4f13-ad89-f2f6b9623cb7">
+    <skos:prefLabel xml:lang="en">digital source</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/1f0d2c15-fdaa-4809-84f6-165cf66a1d3d</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b49383a7-a83e-4c1b-a705-e4c21d49ba17">
+    <skos:prefLabel xml:lang="en">Dataset</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/b49383a7-a83e-4c1b-a705-e4c21d49ba17</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/8dc4c1ac-aae5-41f6-817b-9ee5fef855fe"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7090abfd-2702-47b7-8a66-4186cb607197">
+    <skos:prefLabel xml:lang="en">period of group joining event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/7090abfd-2702-47b7-8a66-4186cb607197</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cbe9e968-f148-4abd-a463-dc0f4c213d08">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/79002668-68b7-4d4c-a5ae-e05007039bdd</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">digital source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bc52d52c-958e-4e6b-a247-e458f076b1bb">
+    <skos:prefLabel xml:lang="en">Brazilian</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/bc52d52c-958e-4e6b-a247-e458f076b1bb</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/ff5ed7bd-4b75-42a3-8361-ddfc1edc2875"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/50cbd32b-14d0-4ac4-ade4-629a3ad8c694">
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/50cbd32b-14d0-4ac4-ade4-629a3ad8c694</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">116</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Zinc (Zn)</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Zn</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b20770c0-7113-44ba-a4b8-7c1dd8799999">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/aaf58bb4-82c4-4aa6-b8c0-7755018217eb</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location of production of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/120c64e0-3f4a-4f2a-accb-8b9e1a6d6f37">
+    <skos:prefLabel xml:lang="en">copper (metal)</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Kupfer</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">cuivre (metal)</skos:prefLabel>
+    <skos:prefLabel xml:lang="pt">cobre</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011020</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:scopeNote xml:lang="en">Pure metallic element having the symbol Cu and atomic number 29; a reddish brown, ductile metal that is present in the earth's crust, occurring as a native metal and as ores of sulfide, sulfate and carbonate (azurite, malachite, etc.). It was the first metal used by humans, probably from about 8000 BCE, in the regions of Mesopotamia and India. By about 3800 BCE copper was made into bronze for weapons and knives. Today, copper is one of the most widely used metals because it has high electrical and thermal conductivity, can be easily fabricated, is ductile and polishes well. In moist air, copper forms a protective green film of basic carbonate. Metallic copper combines well with other metals to form alloys, most commonly brass and bronze. Copper and its alloys are used for wire, electrical devices, pipes, cooking vessels, ammunition, ornamental trim, roofing, grillwork, coins, musical instruments, jewelry, and sculptures.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/63c1e2a4-da7f-41a1-b6d1-57b92a7ced66">
+    <skos:scopeNote xml:lang="en">A paint made by grinding pigments with a drying oil such as linseed oil. After 1940 alkyd binders were often added to oil paint to provide faster drying times.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300015050</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">oil paint (paint)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:altLabel xml:lang="fr">peinture à l'huile (oil paint)</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2224c58e-75aa-4da7-be59-05c984002196">
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <skos:prefLabel xml:lang="en">digital reference for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/2224c58e-75aa-4da7-be59-05c984002196</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/30af05cf-3a15-4bb5-a0c9-a5f5f946e309">
+    <skos:prefLabel xml:lang="en">textual source for</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/30af05cf-3a15-4bb5-a0c9-a5f5f946e309</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a65becad-25b5-4039-8dc0-f8d8c04af227">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/a65becad-25b5-4039-8dc0-f8d8c04af227</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">location of part removal event of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/bfe0540e-72a5-4ee3-a224-78167f39b1b6">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300417645</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Method of acquiring property for temporary use, with or without the payment of interest.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">loan (method of acquisition)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/f3eca78c-7547-4ca5-a7eb-b130391b40ed"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/399f8888-2090-4290-a67e-61b5e59caeaf">
+    <skos:prefLabel xml:lang="en">has influence on part removal event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/399f8888-2090-4290-a67e-61b5e59caeaf</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/29ee707a-0b99-4286-bfc1-c0268a72b9ca">
+    <skos:prefLabel xml:lang="en">Iodine (I)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/29ee707a-0b99-4286-bfc1-c0268a72b9ca</dcterms:identifier>
+    <skos:altLabel xml:lang="en">I</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">46</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ede72541-33f5-4888-b084-1b9a74dd7374">
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5dc2c5f1-bccd-44e2-be0e-f34f3d1ac8db">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300412159</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Unit of French currency of varying value, known from the Middle Ages until the French Revolution. </skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">écu</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/9fe65e48-540c-4401-836d-947eb1878677"/>
+    <skos:prefLabel xml:lang="en">écu (system of money)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/371aae9e-044a-475b-8933-2275236232df">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other codes assigned to a thing, concept, person, or other entity in order identify it and distinguish it from other similar entities. Often a sequence of integers or characters arbitrarily devised.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/7a8d3213-0a64-4f31-92a4-191b41236ae9"/>
+    <skos:prefLabel xml:lang="en">identification numbers</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404626</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/be081cac-13ef-4370-ba34-457cb2d4a981">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">annotator in part identifier assignment of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/be081cac-13ef-4370-ba34-457cb2d4a981</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9ccbe2f5-53d7-4fce-8b74-eb72fd342e18">
+    <skos:inScheme rdf:resource="http://localhost:8000/a7e17177-c533-4027-a66a-0c4fe961d7fc"/>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/62e7809a-d1d3-4b1b-b242-e5c217503c77">
+    <skos:scopeNote xml:lang="en">Units of time equal to approximately 1/12th of a year or the 4-week time period of one full circuit of the Moon around the Earth.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/bbf81641-b1dd-4ddf-858d-7e8ca823d385"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379245</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">months</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7f4f7436-9a41-48ec-865a-c743e3ae9747">
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">73</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8078e585-b5bc-4016-ba55-8161b4cf4c41">
+    <dcterms:identifier>https://afs.test.fargeo.com/8078e585-b5bc-4016-ba55-8161b4cf4c41</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of group leaving event</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ca08a220-303e-4bee-92d9-8bd4f5302b49">
+    <skos:inScheme rdf:resource="http://localhost:8000/8b7faa16-3846-4360-b767-bb2c823b6550"/>
+    <skos:prefLabel xml:lang="en">examination (function)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300226216</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Scrutinizing a situation or object, usually in order to determine its nature, qualities, or current condition.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5061b3a0-2e10-4b74-909a-2a8bfa4e5192">
+    <skos:prefLabel xml:lang="en">has influence on set addition event of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/5061b3a0-2e10-4b74-909a-2a8bfa4e5192</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/71f67d9d-abed-43eb-a8b2-7eae4333e34c">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435423</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">citations</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">References to bibliographic sources, unpublished documents, or individual opinions that provides the basis for the information recorded.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e59715c4-875b-4b50-8bb9-9f0597a6d6fe">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300012862</dcterms:identifier>
+    <skos:prefLabel xml:lang="fr">charbon (charcoal)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">charcoal (material)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+    <skos:scopeNote xml:lang="en">A black, porous carbonaceous material comprising the carbon-containing residue from burned wood (e.g., willow, maple, beech, linden or plum) or other organic containing materials such as bone, plants or animals. It is used as a drawing material, for filtering liquids or air, and for other purposes.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/788d424d-8c43-4a3d-a8a1-0e3670774726">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</arches:sortorder>
+    <skos:prefLabel xml:lang="en">period of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/70847092-39b5-4620-97ed-2ec6e1a14c21</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ac1817e7-c027-4afe-bc83-fa0e5c0aaa78">
+    <skos:inScheme rdf:resource="http://localhost:8000/c8261144-c750-4f64-8980-e50f762b21a5"/>
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/3ff85615-be42-4e63-a92e-c0074717ecf2">
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/3ff85615-be42-4e63-a92e-c0074717ecf2</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">observed by</skos:prefLabel>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/6bdfcec3-0748-4380-befb-b75a4634d87e">
+    <dcterms:title>Payment types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/3e6defea-fff6-459a-ae5a-c71f849a362d">
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</arches:sortorder>
+    <skos:prefLabel xml:lang="en">location of death of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/3e6defea-fff6-459a-ae5a-c71f849a362d</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b1f6d85d-9ea2-4156-a3ca-e2a0965c0937">
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Ag</skos:altLabel>
+    <skos:prefLabel xml:lang="en">Silver (Ag)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/b1f6d85d-9ea2-4156-a3ca-e2a0965c0937</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">96</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/45b737dc-5f2a-4fdb-8ce2-5f97abaa3647">
+    <dcterms:identifier>https://afs.test.fargeo.com/6cc8d2de-439f-4345-8b99-fa42bc692d7e</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">textual source</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">35</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8433f1ad-7f2c-4271-a512-39e55f226d87">
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/892c52a6-0d81-4c5b-8e9f-dd7860276942"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2f3da2d3-1a5e-4603-ae2c-e716319ee226">
+    <skos:inScheme rdf:resource="http://localhost:8000/26d7ce44-20e5-44fb-a3c1-dfbe6bdd521b"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/2f3da2d3-1a5e-4603-ae2c-e716319ee226</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">initiative</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/176f9d09-0020-4913-bd6a-750b3eefe586">
+    <skos:prefLabel xml:lang="en">physical object used in set removal event of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">67</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/176f9d09-0020-4913-bd6a-750b3eefe586</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/31c1ced6-4b71-49e0-b947-236432483821">
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0ede5787-434b-4bf2-94d3-ac5ba80465b5">
+    <skos:prefLabel xml:lang="en">Iron (Fe)</skos:prefLabel>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/0ede5787-434b-4bf2-94d3-ac5ba80465b5</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <skos:altLabel xml:lang="en">Fe</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">48</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7d32eb46-20e6-4046-94b0-802247e7ea6d">
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/fd194f67-9432-451b-98dc-be6b76742965</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">related event causal to creation event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/77021141-5b6e-4e72-afe1-c65bb0878026">
+    <skos:inScheme rdf:resource="http://localhost:8000/fb8ccaf4-9d92-4150-b7cb-ed333ca767ea"/>
+    <skos:prefLabel xml:lang="en">catalog numbers</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404620</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Numeric, alphanumeric, or other identifying codes assigned when an art object, book, or other item is described or listed in a catalog, usually a published catalog. An example is an exhibition catalog. The numbers are typically not marked on the object itself. For numbers given to objects when they are acquired by a repository, prefer "accession numbers."</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d615bfb7-1503-42ab-8bdf-ab384ca24be6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">chemistry</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/c372cf0b-f0f4-4730-a97d-c892dfbefcd7"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054537</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Branch of physical science that deals with the composition and properties of the elementary substances of which all bodies are composed, the laws that regulate their combination, and the various phenomena that accompany their exposure to diverse physical conditions.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/67dd6dec-0e9d-40df-a651-6e74eca9ace6">
+    <dcterms:identifier>https://afs.test.fargeo.com/8f3bebaa-3ee9-41a8-bbed-f484d2efc300</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">location of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3a0ceee3-fe65-408c-970d-357dc535c594"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</arches:sortorder>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/1b18d01e-b99b-48e5-8b7b-3b925659933b">
+    <dcterms:title>Death types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/c5c0e276-be45-4691-bb29-e9cdbda0e15b">
+    <skos:prefLabel xml:lang="en">temporary number</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/4faa936a-69db-476a-ba11-708891fcd066</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/a7e17177-c533-4027-a66a-0c4fe961d7fc"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0cd2452d-daca-4cb1-bb15-d6aba7ca0b26">
+    <skos:prefLabel xml:lang="en">source reference work for professional activity</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">38</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/0cd2452d-daca-4cb1-bb15-d6aba7ca0b26</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/48e06dbc-c0ea-4cc7-9588-f1ac2b53b46e">
+    <skos:inScheme rdf:resource="http://localhost:8000/44295221-1215-4359-a079-234b317f65b7"/>
+    <skos:prefLabel xml:lang="en">grams (measurements)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">In the Metric System, units of mass or weight used especially in the centimeter-gram-second system of measurement. One gram is equal to 0.001 kilogram.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379225</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/11537dec-b641-4f82-b2f2-d219f4a741b7">
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dca6a321-3ab9-42bc-ac80-2171789ae205"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/66ac5ba5-c498-48fc-9a31-e132dce34883">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/26d7ce44-20e5-44fb-a3c1-dfbe6bdd521b"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300054687</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Conducting diligent and systematic inquiry or investigation into a subject or question, especially in order to discover or revise facts or theories.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">research task</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fcdb86a6-b128-4161-88e3-16a0e25e143b">
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">35</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5f20f94f-880a-4891-905a-48a2c4be1c73">
+    <skos:prefLabel xml:lang="en">related to set</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/5f20f94f-880a-4891-905a-48a2c4be1c73</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/61347e03-d8f5-49bc-9f5c-46f8c4fe59e6">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">classification (category)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Indication of the placement of a work of art or architecture within a classification scheme that groups other, similar works together on the basis of similar characteristics</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300435444</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/495fe7b2-5580-4489-8a66-fd50aea1c266"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e4e16e39-49c9-44dd-a618-b51b2f75be6b">
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">49</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/e4e16e39-49c9-44dd-a618-b51b2f75be6b</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">period of set addition event</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/c7613a4c-cce5-4709-b4f4-542909856180">
+    <skos:prefLabel xml:lang="en">period of dissolution of</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/c7613a4c-cce5-4709-b4f4-542909856180</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/275b805e-080b-42b9-8b54-67db5aaa9c2a">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/8455d232-8591-4e04-ac90-1f04ccd46f73</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">source reference for name of</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e416cd94-bddd-4f63-bb15-066400ece24d">
+    <skos:prefLabel xml:lang="en">source reference work for formation event</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/e416cd94-bddd-4f63-bb15-066400ece24d</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">35</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f1c3ef44-b865-4b46-bb97-4d3dc7fe1100">
+    <skos:inScheme rdf:resource="http://localhost:8000/dd2c84db-3b06-4443-8e55-514d7a412cb7"/>
+    <skos:prefLabel xml:lang="en">period of creation of</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/b7b40309-f000-41cb-bc1b-630487e657ee</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2ddfe0e3-e6de-4d0c-a521-389cbeb24955">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300226183</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Explanation of what is not immediately plain or explicit, as in suggesting what meaning is to be found in a set of data or in a visual work.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">interpretation</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/1adae7ea-4884-432f-af44-c9aea3a48a3d"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e5657d2a-4609-4c99-9131-12f91089b5b8">
+    <dcterms:identifier>https://afs.test.fargeo.com/e5657d2a-4609-4c99-9131-12f91089b5b8</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/af055b31-a7a9-493d-9497-c25c17203383"/>
+    <skos:prefLabel xml:lang="en">period of publication event</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/21200099-3708-41ce-b16b-3c81e0a4f8a0">
+    <skos:altLabel xml:lang="en">Og</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/e4cb1e47-b2d0-49b9-8899-1f1776ad1103"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">71</arches:sortorder>
+    <dcterms:identifier>https://afs.usw1.gci.fargeo.net/21200099-3708-41ce-b16b-3c81e0a4f8a0</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Oganesson (Og)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/37fc6edb-f957-483d-89df-c250a31cf8e4">
+    <skos:prefLabel xml:lang="en">occurs after</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <dcterms:identifier>https://afs.test.fargeo.com/ca1546cf-6ee5-428d-9728-b90fc8820baa</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b413f71d-9a93-474d-81f3-c5a457910d39">
+    <skos:inScheme rdf:resource="http://localhost:8000/54414cde-b8e6-4ab7-8b9e-cd3694f178d8"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">37</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference work for name</skos:prefLabel>
+    <dcterms:identifier>https://afs.test.fargeo.com/cf4707c0-4fbf-46a7-998c-fa04f9552a96</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/aa47dc9c-5e6a-41de-956b-8167560e1c99">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300404764</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+    <skos:scopeNote xml:lang="en">The originating cause or substance of some material thing or physical agency, or the conceptual inspiration for a conceptual thing.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/5d2357bf-4ac0-407f-ae2a-c8ac35dca0e9"/>
+    <skos:prefLabel xml:lang="en">sources (general concept)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/4e7a7cdf-2e4b-4ac7-995a-22d44d075115">
+    <dcterms:identifier>https://afs.test.fargeo.com/4e7a7cdf-2e4b-4ac7-995a-22d44d075115</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">parent project of modification</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/16b0e5b5-1870-439c-8f70-a65b47d71024"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/168ca043-1bd9-4bee-8eaa-6678ed61831a">
+    <skos:inScheme rdf:resource="http://localhost:8000/adc8937e-1259-45bd-af5e-ffe892eb1a88"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/c53742f1-4a2d-4b63-be4f-4cacc9bc9319</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">physical object used</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b019227c-dcb0-4fa1-a187-b15a5613ffab">
+    <skos:scopeNote xml:lang="en">Management of all stages of the life cycle of data assets.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300379871</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/b3d6e036-e788-4c85-a1f0-3aa35f0a82f2"/>
+    <skos:prefLabel xml:lang="en">data management</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e2d84949-963b-44de-9f1b-e9705f7eb451">
+    <dcterms:identifier>https://afs.test.fargeo.com/92be9ab3-7782-4633-adc3-c1fb4716fb83</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">41</arches:sortorder>
+    <skos:prefLabel xml:lang="en">source reference for identifier of</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/cb3e0447-a6f4-4137-b376-99c3c32bd4c6"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/07dbe013-7dcf-4dd7-9df1-e72a9a855da5">
+    <skos:prefLabel xml:lang="fr">bois</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The principal tissue of trees and other plants that provides both strength and a means of conducting nutrients. Wood is one of the most versatile materials known.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">wood (plant material)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">38</arches:sortorder>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300011914</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/9a2ee63b-d696-4686-979b-994597790289"/>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/98555065-476d-454d-93e9-e9a03cd57a27">
+    <dcterms:title>Production Techniques</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/48745a4f-0b07-4d44-9f24-f1d7922ed720">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/86176918-3ea5-4468-b477-3f82c6c1a249</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">universally unique identifier (UUID)</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/f4a87a34-8288-4cec-8e20-b28bd567ce0a"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/55a12730-d6e1-4809-81df-4973a723f5b1">
+    <skos:prefLabel xml:lang="en">physical object carrier</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/a3f6f8fc-2391-4559-9f0e-63aa5c4b7843"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">54</arches:sortorder>
+    <dcterms:identifier>https://afs.test.fargeo.com/55a12730-d6e1-4809-81df-4973a723f5b1</dcterms:identifier>
+  </skos:Concept>
+  <skos:ConceptScheme rdf:about="http://localhost:8000/0eb564f7-3ccb-4b13-aab1-307011c8610a">
+    <dcterms:title>Duration types</dcterms:title>
+  </skos:ConceptScheme>
+  <skos:Concept rdf:about="http://localhost:8000/c3bf842e-3c29-48da-9908-b4fc844ba2a6">
+    <skos:prefLabel xml:lang="en">handheld XRF spectrometers</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/c3bf842e-3c29-48da-9908-b4fc844ba2a6</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/3c4df3ee-bf83-4b3e-b2d1-0dc42baf6088">
+        <skos:narrower rdf:resource="http://localhost:8000/c3bf842e-3c29-48da-9908-b4fc844ba2a6"/>
+        <dcterms:identifier>http://localhost:8000/3c4df3ee-bf83-4b3e-b2d1-0dc42baf6088</dcterms:identifier>
+        <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+        <skos:narrower rdf:resource="http://localhost:8000/cf3ccbc1-5524-4c0b-a706-61dd71554742"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+        <skos:broader rdf:resource="http://localhost:8000/b2af20c9-e820-4db2-ad65-3744a4202d2d"/>
+        <skos:prefLabel xml:lang="en">X-ray fluorescence (XRF) spectrometers</skos:prefLabel>
+      </skos:Concept>
+    </skos:broader>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/5b5b8456-900a-4a9b-8382-ebb9390d5fc8">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536">
+        <dcterms:title>Visual Work Techniques</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/9d30b6a3-e948-4a87-97a8-f145984694bb">
+        <skos:narrower rdf:resource="http://localhost:8000/b1a3bc7a-441a-48c8-9cfa-d37627b021a5"/>
+        <skos:narrower rdf:resource="http://localhost:8000/96c6ba52-ac8b-4c26-a020-a8199a851e42"/>
+        <skos:prefLabel xml:lang="en">painting techniques</skos:prefLabel>
+        <skos:narrower rdf:resource="http://localhost:8000/07edfe46-dc43-40ab-aeec-3103e2673bab"/>
+        <skos:narrower rdf:resource="http://localhost:8000/cbc2485e-0e8b-4884-9045-e764078bbbb2"/>
+        <skos:narrower rdf:resource="http://localhost:8000/5b5b8456-900a-4a9b-8382-ebb9390d5fc8"/>
+        <dcterms:identifier>http://localhost:8000/9d30b6a3-e948-4a87-97a8-f145984694bb</dcterms:identifier>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+        <skos:narrower rdf:resource="http://localhost:8000/94bb858b-3d17-41c7-a145-d70fda1822c5"/>
+        <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+      </skos:Concept>
+    </skos:broader>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300067450</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:prefLabel xml:lang="en">pointillism (painting technique)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">pointillisme</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Painting technique whereby tones and hues are obtained by applying regular small dots or touches of unmixed pigment on the canvas so that they combine optically. The French critic Félix Fénéon coined the term "peinture au point" in 1886 after seeing Seurat's "La Grande Jatte." Paul Signac offered the alternative term of "divisionism" in his book "D'Eugène Delacroix au Néo-Impressionnisme (1899), although in modern usage "pointillism" is reserved for the technique involving dots applied in a controlled manner, while "divisionism" refers to use of marks of unmixed color in Italian painters’ works.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d1306dfd-05fc-47fc-83a5-ebc08fc67fe4">
+    <dcterms:identifier>http://localhost:8000/7ec8734d-8c9c-446c-a5df-13fa852c4a79</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/b2af20c9-e820-4db2-ad65-3744a4202d2d">
+        <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+        <skos:narrower rdf:resource="http://localhost:8000/3c4df3ee-bf83-4b3e-b2d1-0dc42baf6088"/>
+        <dcterms:identifier>http://vocab.getty.edu/aat/300203450</dcterms:identifier>
+        <skos:narrower rdf:resource="http://localhost:8000/e3193f72-3a4c-4d54-8294-6a1af433a886"/>
+        <skos:scopeNote xml:lang="de">Optisches Gerät zur Messung der Strahlungsintensitäten bei verschiedenen Wellenlängen oder der Richtungsablenkung durch beispielsweise ein lichtbrechendes Prisma.</skos:scopeNote>
+        <skos:scopeNote xml:lang="en">Optical devices for measuring radiant intensities at various wavelengths or the deviation of refracted rays, as from the angles of prisms.</skos:scopeNote>
+        <skos:prefLabel xml:lang="de">Spektrometer</skos:prefLabel>
+        <skos:prefLabel xml:lang="fr">spectromètre</skos:prefLabel>
+        <skos:narrower rdf:resource="http://localhost:8000/8201eb9f-7936-4220-8403-074ce3e9ea48"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</arches:sortorder>
+        <skos:narrower rdf:resource="http://localhost:8000/d1306dfd-05fc-47fc-83a5-ebc08fc67fe4"/>
+        <skos:narrower rdf:resource="http://localhost:8000/d29562a6-93e2-409e-9bb4-bcc58077113f"/>
+        <skos:prefLabel xml:lang="en">spectrometers</skos:prefLabel>
+      </skos:Concept>
+    </skos:broader>
+    <skos:prefLabel xml:lang="en">FT-IR microscopes</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/977c662f-c1d9-4a35-b556-696517e312ec">
+    <dcterms:identifier>Point XRF Measurement</dcterms:identifier>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/c6ad85c9-12a5-40f5-8773-9b513ded7585">
+        <skos:narrower rdf:resource="http://localhost:8000/b0f10e3b-6dc6-41a1-b3ac-204ba3f9b982"/>
+        <skos:prefLabel xml:lang="en">2D Data Measurement</skos:prefLabel>
+        <skos:narrower rdf:resource="http://localhost:8000/977c662f-c1d9-4a35-b556-696517e312ec"/>
+        <skos:narrower rdf:resource="http://localhost:8000/9ef07691-f751-415a-805e-6fc52fbdb5a1"/>
+        <skos:narrower rdf:resource="http://localhost:8000/2e3e64b3-c802-4bbc-b284-5dbcd50ee4da"/>
+        <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+        <dcterms:identifier>http://localhost:8000/c6ad85c9-12a5-40f5-8773-9b513ded7585</dcterms:identifier>
+      </skos:Concept>
+    </skos:broader>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7">
+        <dcterms:title>Event Types - Observation</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">Point XRF Measurement</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Point X-ray fluorescence spectroscopy (XRF) Measurement</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8331ba52-065a-4ab7-8883-f6cfc14e8a08">
+    <skos:prefLabel xml:lang="fr">chromatomètres</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Gerät zur Messung der Farbwahrnehmung.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">chromatometers</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:scopeNote xml:lang="en">Instruments for measuring color perception.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300195965</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Chromatometer</skos:prefLabel>
+    <skos:narrower>
+      <skos:Concept rdf:about="http://localhost:8000/84ac8add-974d-4e6e-a1b6-e0f3d50738fc">
+        <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+        <dcterms:identifier>http://localhost:8000/1364936b-f5bc-4fd3-b0db-6ef7efe3f08a</dcterms:identifier>
+        <skos:prefLabel xml:lang="en">GC-MS</skos:prefLabel>
+        <skos:altLabel xml:lang="en">Gas chromatography–mass spectrometry</skos:altLabel>
+        <skos:broader rdf:resource="http://localhost:8000/8331ba52-065a-4ab7-8883-f6cfc14e8a08"/>
+      </skos:Concept>
+    </skos:narrower>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b9cb3ead-ae6d-4f04-9551-e390defc35f2">
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/6e3bd268-68bc-4464-aad0-82eabfd5a78f">
+        <dcterms:title>Event Types - Sampling Activity</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/f41ad781-5aa6-46c6-8daf-7598ffcd4aae">
+        <skos:inScheme rdf:resource="http://localhost:8000/6e3bd268-68bc-4464-aad0-82eabfd5a78f"/>
+        <skos:narrower rdf:resource="http://localhost:8000/cd3d2406-1ae5-42f0-98f9-43e965ae5d38"/>
+        <skos:narrower rdf:resource="http://localhost:8000/b9cb3ead-ae6d-4f04-9551-e390defc35f2"/>
+        <skos:prefLabel xml:lang="en">Intentional Sampling</skos:prefLabel>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+        <dcterms:identifier>http://localhost:8000/f41ad781-5aa6-46c6-8daf-7598ffcd4aae</dcterms:identifier>
+      </skos:Concept>
+    </skos:broader>
+    <skos:prefLabel xml:lang="en">Invasive</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/b9cb3ead-ae6d-4f04-9551-e390defc35f2</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b96656eb-094b-48c3-a491-148df2d5fec0">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">black-and-white photography</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300162056</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/30c6d071-88cf-4778-912b-b04bd4b856cd">
+        <skos:narrower rdf:resource="http://localhost:8000/879c7e4e-2bce-490c-bb05-bf9ac6c3fe28"/>
+        <skos:narrower rdf:resource="http://localhost:8000/b2a36d1a-3f90-4b23-a35d-837482891be1"/>
+        <dcterms:identifier>http://localhost:8000/30c6d071-88cf-4778-912b-b04bd4b856cd</dcterms:identifier>
+        <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+        <skos:narrower rdf:resource="http://localhost:8000/b96656eb-094b-48c3-a491-148df2d5fec0"/>
+        <skos:prefLabel xml:lang="en">photography techniques</skos:prefLabel>
+        <skos:narrower rdf:resource="http://localhost:8000/f74ebcee-1474-423a-98e0-eec4a6f70599"/>
+      </skos:Concept>
+    </skos:broader>
+    <skos:scopeNote xml:lang="en">The art or practice of taking and/or processing photographs whose images are composed of gray tones, black, and white, and sometimes one hue, which may result from toning or aging.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/8201eb9f-7936-4220-8403-074ce3e9ea48">
+    <skos:prefLabel xml:lang="en">fiber optics reflectance (FORS) spectrometers</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/8201eb9f-7936-4220-8403-074ce3e9ea48</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:broader rdf:resource="http://localhost:8000/b2af20c9-e820-4db2-ad65-3744a4202d2d"/>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/eedcb6df-656b-4a3b-b808-be00a7a4daf9">
+    <skos:prefLabel xml:lang="de">Grisaillemalerei</skos:prefLabel>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/faeaa555-3942-4a7e-9c22-bcfae7e3076b">
+        <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+        <skos:narrower rdf:resource="http://localhost:8000/afbf17a2-4e83-4de6-963a-b985dc0f7c35"/>
+        <skos:narrower rdf:resource="http://localhost:8000/eedcb6df-656b-4a3b-b808-be00a7a4daf9"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+        <dcterms:identifier>http://localhost:8000/faeaa555-3942-4a7e-9c22-bcfae7e3076b</dcterms:identifier>
+        <skos:narrower rdf:resource="http://localhost:8000/fa11cdad-f45d-41f2-bac0-8b8045cff74b"/>
+        <skos:narrower rdf:resource="http://localhost:8000/a7e9a77a-005b-4253-8abc-7f3b944a4c0c"/>
+        <skos:narrower rdf:resource="http://localhost:8000/1bd9f61f-fbc6-4b0d-9107-0e5b1ed9b277"/>
+        <skos:prefLabel xml:lang="en">painting techniques</skos:prefLabel>
+      </skos:Concept>
+    </skos:broader>
+    <skos:prefLabel xml:lang="en">grisaille</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9">
+        <dcterms:title>Method Types -  Production Technique</dcterms:title>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+    <skos:scopeNote xml:lang="en">Painting of images in monochrome, usually gray tones; employed in paintings, stained glass, enamels, and on pottery and other objects.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053386</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Gemaltes Bild in Schwarz-Weiß, in der Regel mit Grautönen; etabliert in der Malerei, Glasmalerei, Emaillekunst, auf Keramik und anderen Objekten.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cd3d2406-1ae5-42f0-98f9-43e965ae5d38">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/6e3bd268-68bc-4464-aad0-82eabfd5a78f"/>
+    <skos:broader rdf:resource="http://localhost:8000/f41ad781-5aa6-46c6-8daf-7598ffcd4aae"/>
+    <dcterms:identifier>http://localhost:8000/cd3d2406-1ae5-42f0-98f9-43e965ae5d38</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Superficial</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0c682c76-a6a4-48f0-9c5b-1203a6dc33da">
+    <skos:prefLabel xml:lang="en">IIIF Manifest</skos:prefLabel>
+    <skos:narrower>
+      <skos:Concept rdf:about="http://localhost:8000/106feb03-935f-49c4-8e15-c30ee42adc66">
+        <skos:prefLabel xml:lang="en">Preferred Manifest</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971"/>
+        <skos:broader rdf:resource="http://localhost:8000/0c682c76-a6a4-48f0-9c5b-1203a6dc33da"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+        <dcterms:identifier>http://localhost:8000/106feb03-935f-49c4-8e15-c30ee42adc66</dcterms:identifier>
+      </skos:Concept>
+    </skos:narrower>
+    <skos:narrower>
+      <skos:Concept rdf:about="http://localhost:8000/b8a8e087-6e8f-41db-98ff-202785afddbb">
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+        <dcterms:identifier>http://localhost:8000/b8a8e087-6e8f-41db-98ff-202785afddbb</dcterms:identifier>
+        <skos:prefLabel xml:lang="en">Alternate Manifest</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971"/>
+        <skos:broader rdf:resource="http://localhost:8000/0c682c76-a6a4-48f0-9c5b-1203a6dc33da"/>
+      </skos:Concept>
+    </skos:narrower>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/933cf221-2d71-478f-998a-a5e088457971"/>
+    <dcterms:identifier>http://localhost:8000/0c682c76-a6a4-48f0-9c5b-1203a6dc33da</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e80c9f10-5bb5-45b9-b7c5-daa7f81f7211">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/e80c9f10-5bb5-45b9-b7c5-daa7f81f7211</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">Unintentional Sampling</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/6e3bd268-68bc-4464-aad0-82eabfd5a78f"/>
+    <skos:narrower>
+      <skos:Concept rdf:about="http://localhost:8000/07591d48-bad3-4fea-972f-584394cefeb1">
+        <dcterms:identifier>http://localhost:8000/07591d48-bad3-4fea-972f-584394cefeb1</dcterms:identifier>
+        <skos:prefLabel xml:lang="en">volunteers</skos:prefLabel>
+        <skos:broader rdf:resource="http://localhost:8000/e80c9f10-5bb5-45b9-b7c5-daa7f81f7211"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+        <skos:inScheme rdf:resource="http://localhost:8000/6e3bd268-68bc-4464-aad0-82eabfd5a78f"/>
+      </skos:Concept>
+    </skos:narrower>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/e3193f72-3a4c-4d54-8294-6a1af433a886">
+    <skos:broader rdf:resource="http://localhost:8000/b2af20c9-e820-4db2-ad65-3744a4202d2d"/>
+    <dcterms:identifier>http://localhost:8000/e3193f72-3a4c-4d54-8294-6a1af433a886</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:prefLabel xml:lang="en">hyperspectral cameras</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9ef07691-f751-415a-805e-6fc52fbdb5a1">
+    <skos:broader rdf:resource="http://localhost:8000/c6ad85c9-12a5-40f5-8773-9b513ded7585"/>
+    <skos:prefLabel xml:lang="en">FTIR Measurement</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <dcterms:identifier>http://localhost:8000/9ef07691-f751-415a-805e-6fc52fbdb5a1</dcterms:identifier>
+    <skos:altLabel xml:lang="en">Fourier-transform infrared (FTIR) spectroscopy Measurement</skos:altLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/804e24c6-f30b-4675-b4d4-49b0897b589c">
+    <skos:scopeNote xml:lang="en">Refers to the practice of making photographs with a pinhole camera. Light-sensitive film or paper is exposed through a tiny, lensless aperture: the resulting images have very great depth of field, but lack critical sharpness.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300265124</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:prefLabel xml:lang="en">pinhole photography</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/f2bd260c-a4ba-4b27-ba3b-961f37ca8016">
+        <dcterms:identifier>http://localhost:8000/f2bd260c-a4ba-4b27-ba3b-961f37ca8016</dcterms:identifier>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+        <skos:narrower rdf:resource="http://localhost:8000/804e24c6-f30b-4675-b4d4-49b0897b589c"/>
+        <skos:narrower rdf:resource="http://localhost:8000/b96a5716-1e25-4697-b5f9-3afad1627ed4"/>
+        <skos:prefLabel xml:lang="en">photography techniques</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+        <skos:narrower rdf:resource="http://localhost:8000/cb2a1f81-43a9-4c99-be9b-1624501a8c29"/>
+        <skos:narrower rdf:resource="http://localhost:8000/7dfe3f0a-333c-45e6-8751-840841142bb1"/>
+      </skos:Concept>
+    </skos:broader>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1bd9f61f-fbc6-4b0d-9107-0e5b1ed9b277">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">acrylic painting (technique)</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">The art or practice of producing creative works with acrylic paint.</skos:scopeNote>
+    <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+    <skos:broader rdf:resource="http://localhost:8000/faeaa555-3942-4a7e-9c22-bcfae7e3076b"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300182574</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cbc2485e-0e8b-4884-9045-e764078bbbb2">
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+    <skos:scopeNote xml:lang="en">The art or practice of producing creative works in oil paint, which is pigment suspended in vegetal drying oils. It dates from at least the Middle Ages in Europe, and was widely adopted for easel painting by the fifteenth century.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300178684</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">oil painting (technique)</skos:prefLabel>
+    <skos:broader rdf:resource="http://localhost:8000/9d30b6a3-e948-4a87-97a8-f145984694bb"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/0d9d0957-e2eb-4ba1-a848-a6e8231ab70d">
+    <skos:narrower>
+      <skos:Concept rdf:about="http://localhost:8000/7ec8734d-8c9c-446c-a5df-13fa852c4a79">
+        <skos:broader rdf:resource="http://localhost:8000/0d9d0957-e2eb-4ba1-a848-a6e8231ab70d"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+        <dcterms:identifier>http://localhost:8000/7ec8734d-8c9c-446c-a5df-13fa852c4a79</dcterms:identifier>
+        <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+        <skos:prefLabel xml:lang="en">FT-IR microscopes</skos:prefLabel>
+      </skos:Concept>
+    </skos:narrower>
+    <skos:prefLabel xml:lang="de">Mikroskop</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300024594</dcterms:identifier>
+    <skos:narrower>
+      <skos:Concept rdf:about="http://localhost:8000/3044ebe4-8d5f-446a-b618-5f39fbfc2364">
+        <skos:prefLabel xml:lang="en">scanning electron microscopes</skos:prefLabel>
+        <dcterms:identifier>http://localhost:8000/3044ebe4-8d5f-446a-b618-5f39fbfc2364</dcterms:identifier>
+        <skos:altLabel xml:lang="en">SEM</skos:altLabel>
+        <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+        <skos:broader rdf:resource="http://localhost:8000/0d9d0957-e2eb-4ba1-a848-a6e8231ab70d"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+      </skos:Concept>
+    </skos:narrower>
+    <skos:prefLabel xml:lang="en">microscopes</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:prefLabel xml:lang="fr">microscope</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Optisches Gerät, das aus einer Linse oder einer Kombination von Linsen besteht, mit dessen Hilfe sich Objekte betrachten lassen, die zu klein für das bloße Auge sind. Zudem werden auch andere Gerätetypen so bezeichnet, die einen Elektronenstrom (Elektronenmikroskop), elektro-magnetische Strahlung (Röntgenmikroskop) oder andere Hilfsmittel als Licht und Linsen einsetzen, um das Abbild von kleinen Gegenständen zu vergrößern.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">Optical instruments consisting of a lens or combination of lenses that allow the viewing of objects that are too small to be seen with the naked, unaided eye. The term may also be used for various types of instruments that use a stream of electrons (electron microscope), electromagnetic radiation (x-ray microscope), or other means other than light and lenses to magnify images of small objects.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa11cdad-f45d-41f2-bac0-8b8045cff74b">
+    <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300067450</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Painting technique whereby tones and hues are obtained by applying regular small dots or touches of unmixed pigment on the canvas so that they combine optically. The French critic Félix Fénéon coined the term "peinture au point" in 1886 after seeing Seurat's "La Grande Jatte." Paul Signac offered the alternative term of "divisionism" in his book "D'Eugène Delacroix au Néo-Impressionnisme (1899), although in modern usage "pointillism" is reserved for the technique involving dots applied in a controlled manner, while "divisionism" refers to use of marks of unmixed color in Italian painters’ works.</skos:scopeNote>
+    <skos:broader rdf:resource="http://localhost:8000/faeaa555-3942-4a7e-9c22-bcfae7e3076b"/>
+    <skos:prefLabel xml:lang="en">pointillism (painting technique)</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">pointillisme</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cf3ccbc1-5524-4c0b-a706-61dd71554742">
+    <skos:altLabel xml:lang="en">macro-XRF spectrometers</skos:altLabel>
+    <dcterms:identifier>http://localhost:8000/cf3ccbc1-5524-4c0b-a706-61dd71554742</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:broader rdf:resource="http://localhost:8000/3c4df3ee-bf83-4b3e-b2d1-0dc42baf6088"/>
+    <skos:altLabel xml:lang="en">macro X-ray fluorescence spectrometers</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en"> MA-XRF spectrometers</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/07edfe46-dc43-40ab-aeec-3103e2673bab">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053386</dcterms:identifier>
+    <skos:scopeNote xml:lang="de">Gemaltes Bild in Schwarz-Weiß, in der Regel mit Grautönen; etabliert in der Malerei, Glasmalerei, Emaillekunst, auf Keramik und anderen Objekten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">grisaille</skos:prefLabel>
+    <skos:broader rdf:resource="http://localhost:8000/9d30b6a3-e948-4a87-97a8-f145984694bb"/>
+    <skos:scopeNote xml:lang="en">Painting of images in monochrome, usually gray tones; employed in paintings, stained glass, enamels, and on pottery and other objects.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="de">Grisaillemalerei</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/96c6ba52-ac8b-4c26-a020-a8199a851e42">
+    <skos:prefLabel xml:lang="en">acrylic painting (technique)</skos:prefLabel>
+    <skos:broader rdf:resource="http://localhost:8000/9d30b6a3-e948-4a87-97a8-f145984694bb"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300182574</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+    <skos:scopeNote xml:lang="en">The art or practice of producing creative works with acrylic paint.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/9b1c5d1b-7ff9-400a-acde-c9a081eff7e1">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+    <skos:altLabel xml:lang="en">Scanning electron microscopy – energy dispersive (SEM-EDS) spectroscopy Measurement</skos:altLabel>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/9f336e9a-17bd-45bc-a4a2-f816a551d196">
+        <skos:narrower rdf:resource="http://localhost:8000/fa1d6a48-4e82-4d23-8747-c4fa10f3301a"/>
+        <skos:narrower rdf:resource="http://localhost:8000/d5c7a90b-fd87-4d2c-86f8-01909795e73e"/>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+        <skos:narrower rdf:resource="http://localhost:8000/091a244e-6532-4fc7-8b70-63364c4a4569"/>
+        <dcterms:identifier>http://localhost:8000/9f336e9a-17bd-45bc-a4a2-f816a551d196</dcterms:identifier>
+        <skos:prefLabel xml:lang="en">3D Data Measurement</skos:prefLabel>
+        <skos:narrower rdf:resource="http://localhost:8000/9b1c5d1b-7ff9-400a-acde-c9a081eff7e1"/>
+        <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+      </skos:Concept>
+    </skos:broader>
+    <skos:prefLabel xml:lang="en">SEM-EDS Measurement</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/9b1c5d1b-7ff9-400a-acde-c9a081eff7e1</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/091a244e-6532-4fc7-8b70-63364c4a4569">
+    <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+    <skos:broader rdf:resource="http://localhost:8000/9f336e9a-17bd-45bc-a4a2-f816a551d196"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en">3D XRF Measurement</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/091a244e-6532-4fc7-8b70-63364c4a4569</dcterms:identifier>
+    <skos:altLabel xml:lang="en">3D X-ray fluorescence (XRF) spectroscopy Measurement</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/fa1d6a48-4e82-4d23-8747-c4fa10f3301a">
+    <dcterms:identifier>http://localhost:8000/fa1d6a48-4e82-4d23-8747-c4fa10f3301a</dcterms:identifier>
+    <skos:broader rdf:resource="http://localhost:8000/9f336e9a-17bd-45bc-a4a2-f816a551d196"/>
+    <skos:prefLabel xml:lang="en">3D Raman Measurement</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+    <skos:altLabel xml:lang="en">3D Raman spectroscopy Measurement</skos:altLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b0f10e3b-6dc6-41a1-b3ac-204ba3f9b982">
+    <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+    <skos:prefLabel xml:lang="en">Point Raman Measurement</skos:prefLabel>
+    <skos:altLabel xml:lang="en">Point Raman spectroscopy Measurement</skos:altLabel>
+    <skos:broader rdf:resource="http://localhost:8000/c6ad85c9-12a5-40f5-8773-9b513ded7585"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <dcterms:identifier>Point Raman Measurement</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d29562a6-93e2-409e-9bb4-bcc58077113f">
+    <dcterms:identifier>http://localhost:8000/d29562a6-93e2-409e-9bb4-bcc58077113f</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:broader rdf:resource="http://localhost:8000/b2af20c9-e820-4db2-ad65-3744a4202d2d"/>
+    <skos:prefLabel xml:lang="en">Raman spectrometers</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/f74ebcee-1474-423a-98e0-eec4a6f70599">
+    <dcterms:identifier>http://vocab.getty.edu/aat/300134530</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Generally, the art or practice of taking and/or processing photographs that reproduce hues perceptible to the human eye. Extended to include imagery in which colors have been artificially enhanced or altered. </skos:scopeNote>
+    <skos:broader rdf:resource="http://localhost:8000/30c6d071-88cf-4778-912b-b04bd4b856cd"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+    <skos:prefLabel xml:lang="en-US">color photography</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/7dfe3f0a-333c-45e6-8751-840841142bb1">
+    <skos:broader rdf:resource="http://localhost:8000/f2bd260c-a4ba-4b27-ba3b-961f37ca8016"/>
+    <skos:scopeNote xml:lang="en">The art or practice of taking and/or processing photographs whose images are composed of gray tones, black, and white, and sometimes one hue, which may result from toning or aging.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">black-and-white photography</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300162056</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/1364936b-f5bc-4fd3-b0db-6ef7efe3f08a">
+    <skos:altLabel xml:lang="en">Gas chromatography–mass spectrometry</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:prefLabel xml:lang="en">GC-MS</skos:prefLabel>
+    <dcterms:identifier>http://localhost:8000/1364936b-f5bc-4fd3-b0db-6ef7efe3f08a</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+    <skos:broader>
+      <skos:Concept rdf:about="http://localhost:8000/13485eec-f4aa-456a-8250-71526797597d">
+        <skos:scopeNote xml:lang="en">Mass spectroscopes that identify and record the kinds and intensities of particles in a given substance.</skos:scopeNote>
+        <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</arches:sortorder>
+        <skos:prefLabel xml:lang="de">Massenspektrometer</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">mass spectrometers</skos:prefLabel>
+        <skos:scopeNote xml:lang="de">Massenspektroskop, das die Arten und Intensitäten von Partikeln in einer vorhandenen Substanz erkennt und aufzeichnet.</skos:scopeNote>
+        <skos:prefLabel xml:lang="fr">spectromètre de masse</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://localhost:8000/05ad2322-38c4-434f-95ec-4f9f297515eb"/>
+        <skos:narrower rdf:resource="http://localhost:8000/1364936b-f5bc-4fd3-b0db-6ef7efe3f08a"/>
+        <dcterms:identifier>http://vocab.getty.edu/aat/300198980</dcterms:identifier>
+      </skos:Concept>
+    </skos:broader>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b1a3bc7a-441a-48c8-9cfa-d37627b021a5">
+    <skos:broader rdf:resource="http://localhost:8000/9d30b6a3-e948-4a87-97a8-f145984694bb"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053368</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Application of paint in thick, opaque masses, usually with a well-loaded brush or a palette knife.</skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+    <skos:prefLabel xml:lang="de">Pastos (impasto)</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">impasto</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/afbf17a2-4e83-4de6-963a-b985dc0f7c35">
+    <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+    <skos:prefLabel xml:lang="en-US">watercolor painting (technique)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389895</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</arches:sortorder>
+    <skos:broader rdf:resource="http://localhost:8000/faeaa555-3942-4a7e-9c22-bcfae7e3076b"/>
+    <skos:scopeNote xml:lang="en">The technique of painting with pigments in a water-soluble binder and thinned with water, usually on paper. Includes gouache painting, although gouache is not technically watercolor paint.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/d5c7a90b-fd87-4d2c-86f8-01909795e73e">
+    <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:altLabel xml:lang="en">Reflectance imaging spectroscopy (RIS) Measurement</skos:altLabel>
+    <skos:prefLabel xml:lang="en">RIS Measurement</skos:prefLabel>
+    <skos:broader rdf:resource="http://localhost:8000/9f336e9a-17bd-45bc-a4a2-f816a551d196"/>
+    <dcterms:identifier>http://localhost:8000/d5c7a90b-fd87-4d2c-86f8-01909795e73e</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/94bb858b-3d17-41c7-a145-d70fda1822c5">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</arches:sortorder>
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+    <skos:broader rdf:resource="http://localhost:8000/9d30b6a3-e948-4a87-97a8-f145984694bb"/>
+    <skos:prefLabel xml:lang="en-US">watercolor painting (technique)</skos:prefLabel>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300389895</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">The technique of painting with pigments in a water-soluble binder and thinned with water, usually on paper. Includes gouache painting, although gouache is not technically watercolor paint.</skos:scopeNote>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/879c7e4e-2bce-490c-bb05-bf9ac6c3fe28">
+    <skos:scopeNote xml:lang="en">Still photography in which the camera shutter operates at a speed much higher than normal.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">high-speed photography (still photography)</skos:prefLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:broader rdf:resource="http://localhost:8000/30c6d071-88cf-4778-912b-b04bd4b856cd"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053462</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/cb2a1f81-43a9-4c99-be9b-1624501a8c29">
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+    <skos:broader rdf:resource="http://localhost:8000/f2bd260c-a4ba-4b27-ba3b-961f37ca8016"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053462</dcterms:identifier>
+    <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+    <skos:scopeNote xml:lang="en">Still photography in which the camera shutter operates at a speed much higher than normal.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">high-speed photography (still photography)</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b2a36d1a-3f90-4b23-a35d-837482891be1">
+    <skos:inScheme rdf:resource="http://localhost:8000/3e46a547-fa4b-418d-bca7-18b2a5a50536"/>
+    <skos:prefLabel xml:lang="en">pinhole photography</skos:prefLabel>
+    <skos:broader rdf:resource="http://localhost:8000/30c6d071-88cf-4778-912b-b04bd4b856cd"/>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</arches:sortorder>
+    <skos:scopeNote xml:lang="en">Refers to the practice of making photographs with a pinhole camera. Light-sensitive film or paper is exposed through a tiny, lensless aperture: the resulting images have very great depth of field, but lack critical sharpness.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300265124</dcterms:identifier>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/2e3e64b3-c802-4bbc-b284-5dbcd50ee4da">
+    <skos:altLabel xml:lang="en">Fiber Optics Reflectance spectroscopy (FORS) Measurement</skos:altLabel>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</arches:sortorder>
+    <skos:broader rdf:resource="http://localhost:8000/c6ad85c9-12a5-40f5-8773-9b513ded7585"/>
+    <skos:inScheme rdf:resource="http://localhost:8000/0ca18480-f5f2-41b2-b177-857726e5ecd7"/>
+    <dcterms:identifier>FORS Measurement</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">FORS Measurement</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/b96a5716-1e25-4697-b5f9-3afad1627ed4">
+    <skos:prefLabel xml:lang="en-US">color photography</skos:prefLabel>
+    <skos:broader rdf:resource="http://localhost:8000/f2bd260c-a4ba-4b27-ba3b-961f37ca8016"/>
+    <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300134530</dcterms:identifier>
+    <skos:scopeNote xml:lang="en">Generally, the art or practice of taking and/or processing photographs that reproduce hues perceptible to the human eye. Extended to include imagery in which colors have been artificially enhanced or altered. </skos:scopeNote>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</arches:sortorder>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/a7e9a77a-005b-4253-8abc-7f3b944a4c0c">
+    <skos:prefLabel xml:lang="en">impasto</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Pastos (impasto)</skos:prefLabel>
+    <skos:broader rdf:resource="http://localhost:8000/faeaa555-3942-4a7e-9c22-bcfae7e3076b"/>
+    <skos:inScheme rdf:resource="http://localhost:8000/1bb3db74-3dff-4e44-a629-7d6a0c1383e9"/>
+    <skos:scopeNote xml:lang="en">Application of paint in thick, opaque masses, usually with a well-loaded brush or a palette knife.</skos:scopeNote>
+    <dcterms:identifier>http://vocab.getty.edu/aat/300053368</dcterms:identifier>
+    <arches:sortorder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</arches:sortorder>
+  </skos:Concept>
+</rdf:RDF>

--- a/arches_for_science/settings.py
+++ b/arches_for_science/settings.py
@@ -63,6 +63,37 @@ ELASTICSEARCH_CONNECTION_OPTIONS = {"request_timeout": 30, "verify_certs": False
 # ELASTICSEARCH_CONNECTION_OPTIONS = {"request_timeout": 30, "verify_certs": False, "basic_auth": ("elastic", "E1asticSearchforArche5")}
 ELASTICSEARCH_PREFIX = "arches_for_science"
 
+REFERENCES_INDEX_NAME = "references"
+ELASTICSEARCH_CUSTOM_INDEXES = [
+    {
+        "module": "arches_controlled_lists.search_indexes.reference_index.ReferenceIndex",
+        "name": REFERENCES_INDEX_NAME,
+        "should_update_asynchronously": True,
+    }
+]
+TERM_SEARCH_TYPES = [
+    {
+        "type": "term",
+        "label": _("Term Matches"),
+        "key": "terms",
+        "module": "arches.app.search.search_term.TermSearch",
+    },
+    {
+        "type": "concept",
+        "label": _("Concepts"),
+        "key": "concepts",
+        "module": "arches.app.search.concept_search.ConceptSearch",
+    },
+    {
+        "type": "reference",
+        "label": _("References"),
+        "key": REFERENCES_INDEX_NAME,
+        "module": "arches_controlled_lists.search_indexes.reference_index.ReferenceIndex",
+    },
+]
+
+ES_MAPPING_MODIFIER_CLASSES = ["arches_controlled_lists.search.references_es_mapping_modifier.ReferencesEsMappingModifier"]
+
 LOAD_DEFAULT_ONTOLOGY = False
 LOAD_PACKAGE_ONTOLOGIES = True
 
@@ -102,6 +133,7 @@ INSTALLED_APPS = (
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.gis",
+    "arches_controlled_lists",
     "arches",
     "arches.app.models",
     "arches.management",
@@ -111,6 +143,9 @@ INSTALLED_APPS = (
     "corsheaders",
     "oauth2_provider",
     "django_celery_results",
+    "django.contrib.postgres",
+    "arches_querysets",
+    "arches_component_lab",
     "pgtrigger",
     "arches_templating",
     # "silk",

--- a/arches_for_science/urls.py
+++ b/arches_for_science/urls.py
@@ -72,9 +72,13 @@ urlpatterns = [
     re_path(r"^renderer_config/(?P<renderer_config_id>[^\/]+)", RendererConfigView.as_view(), name="renderer_config"),
     re_path(r"^renderer_config/", RendererConfigView.as_view(), name="renderer_config"),
     re_path(r"^manifest_x_canvas/", ManifestXCanvasView.as_view(), name="manifest_x_canvas"),
-    path("reports/", include("arches_templating.urls")),
-    path("", include("arches.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+urlpatterns.append(path("reports/", include("arches_templating.urls")))
+urlpatterns.append(path("", include("arches_component_lab.urls")))
+urlpatterns.append(path("", include("arches_controlled_lists.urls")))
+urlpatterns.append(path("", include("arches_querysets.urls")))
+urlpatterns.append(path("", include("arches.urls")))
 
 # Only handle i18n routing in active project. This will still handle the routes provided by Arches core and Arches applications,
 # but handling i18n routes in multiple places causes application errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
                 "@uppy/dashboard": "3.9.0",
                 "@uppy/drag-drop": "3.1.0",
                 "@uppy/progress-bar": "3.1.1",
-                "arches": "archesproject/arches#stable/7.6.17",
+                "arches": "archesproject/arches#dev/8.1.x",
+                "arches_controlled_lists": "archesproject/arches-controlled-lists#dev/1.1.x",
                 "dom-to-image": "^2.6.0",
                 "eslint": "^9.39.2",
                 "html2canvas": "^1.4.1",
@@ -22,7 +23,7 @@
                 "three": "^0.148.0"
             },
             "devDependencies": {
-                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.6.17"
+                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.1.x"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -61,9 +62,9 @@
             "license": "ISC"
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-            "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -75,9 +76,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-            "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -85,21 +86,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-            "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/generator": "^7.28.6",
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
                 "@babel/helper-compilation-targets": "^7.28.6",
                 "@babel/helper-module-transforms": "^7.28.6",
                 "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.28.6",
+                "@babel/parser": "^7.29.0",
                 "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -135,14 +136,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-            "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
+            "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6",
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -425,12 +426,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-            "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.6"
+                "@babel/types": "^7.29.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -615,15 +616,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.6.tgz",
-            "integrity": "sha512-9knsChgsMzBV5Yh3kkhrZNxH3oCYAfMBkNNaVN4cP2RVlFPe8wYdwwcnOsAbkdDoV9UjFtOXWrWB52M8W4jNeA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+            "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-remap-async-to-generator": "^7.27.1",
-                "@babel/traverse": "^7.28.6"
+                "@babel/traverse": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -805,9 +806,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.28.6.tgz",
-            "integrity": "sha512-5suVoXjC14lUN6ZL9OLKIHCNVWCrqGqlmEp/ixdXjvgnEl/kauLvvMO/Xw9NyMc95Joj1AeLVPVMvibBgSoFlA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+            "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1020,16 +1021,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz",
-            "integrity": "sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+            "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.5"
+                "@babel/traverse": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1056,14 +1057,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-            "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+            "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1258,9 +1259,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.6.tgz",
-            "integrity": "sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+            "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1307,14 +1308,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.5.tgz",
-            "integrity": "sha512-20NUVgOrinudkIBzQ2bNxP08YpKprUkRTiRSd2/Z5GOdPImJGkoN4Z7IQe1T5AdyKI1i5L6RBmluqdSzvaq9/w==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.0.tgz",
+            "integrity": "sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "babel-plugin-polyfill-corejs2": "^0.4.14",
                 "babel-plugin-polyfill-corejs3": "^0.13.0",
                 "babel-plugin-polyfill-regenerator": "^0.6.5",
@@ -1476,13 +1477,13 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
-            "integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
+            "integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
+                "@babel/compat-data": "^7.29.0",
                 "@babel/helper-compilation-targets": "^7.28.6",
                 "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
@@ -1496,7 +1497,7 @@
                 "@babel/plugin-syntax-import-attributes": "^7.28.6",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.27.1",
-                "@babel/plugin-transform-async-generator-functions": "^7.28.6",
+                "@babel/plugin-transform-async-generator-functions": "^7.29.0",
                 "@babel/plugin-transform-async-to-generator": "^7.28.6",
                 "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
                 "@babel/plugin-transform-block-scoping": "^7.28.6",
@@ -1507,7 +1508,7 @@
                 "@babel/plugin-transform-destructuring": "^7.28.5",
                 "@babel/plugin-transform-dotall-regex": "^7.28.6",
                 "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.28.6",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
                 "@babel/plugin-transform-dynamic-import": "^7.27.1",
                 "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
                 "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
@@ -1520,9 +1521,9 @@
                 "@babel/plugin-transform-member-expression-literals": "^7.27.1",
                 "@babel/plugin-transform-modules-amd": "^7.27.1",
                 "@babel/plugin-transform-modules-commonjs": "^7.28.6",
-                "@babel/plugin-transform-modules-systemjs": "^7.28.5",
+                "@babel/plugin-transform-modules-systemjs": "^7.29.0",
                 "@babel/plugin-transform-modules-umd": "^7.27.1",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
                 "@babel/plugin-transform-new-target": "^7.27.1",
                 "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
                 "@babel/plugin-transform-numeric-separator": "^7.28.6",
@@ -1534,7 +1535,7 @@
                 "@babel/plugin-transform-private-methods": "^7.28.6",
                 "@babel/plugin-transform-private-property-in-object": "^7.28.6",
                 "@babel/plugin-transform-property-literals": "^7.27.1",
-                "@babel/plugin-transform-regenerator": "^7.28.6",
+                "@babel/plugin-transform-regenerator": "^7.29.0",
                 "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
                 "@babel/plugin-transform-reserved-words": "^7.27.1",
                 "@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -1547,10 +1548,10 @@
                 "@babel/plugin-transform-unicode-regex": "^7.27.1",
                 "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "babel-plugin-polyfill-corejs2": "^0.4.14",
-                "babel-plugin-polyfill-corejs3": "^0.13.0",
-                "babel-plugin-polyfill-regenerator": "^0.6.5",
-                "core-js-compat": "^3.43.0",
+                "babel-plugin-polyfill-corejs2": "^0.4.15",
+                "babel-plugin-polyfill-corejs3": "^0.14.0",
+                "babel-plugin-polyfill-regenerator": "^0.6.6",
+                "core-js-compat": "^3.48.0",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1558,6 +1559,20 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.0.tgz",
+            "integrity": "sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-define-polyfill-provider": "^0.6.6",
+                "core-js-compat": "^3.48.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/@babel/preset-modules": {
@@ -1600,18 +1615,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-            "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/generator": "^7.28.6",
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
                 "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.6",
+                "@babel/parser": "^7.29.0",
                 "@babel/template": "^7.28.6",
-                "@babel/types": "^7.28.6",
+                "@babel/types": "^7.29.0",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -1619,9 +1634,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-            "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -3631,6 +3646,18 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@primeuix/forms": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@primeuix/forms/-/forms-0.1.0.tgz",
+            "integrity": "sha512-LctcQidb+B5PuvAFWH24YH/SIzmHlOabLHpaTeGY/k51iBv1WyCp+5w9JMYuMB/BplSvV0ZGySxQVkN5Azr/aQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.6.0"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
         "node_modules/@primeuix/styled": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
@@ -3671,9 +3698,9 @@
             }
         },
         "node_modules/@primevue/core": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.7.tgz",
-            "integrity": "sha512-rYmEZTKs/C2Re+xFluY9R02+n4TcyJshooPPOG6zc23v/bmhrfcqCiS5gNiuXF/lYoOh4y8VTcHF6eZCZW724Q==",
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.9.tgz",
+            "integrity": "sha512-P08MhVD8WrldbropVuiG25ku6il+v+cKKrspES6RijDc4NE/CrGMAwOlrdpOkpy7pcfTzqC9eIGBx5ifS28S5g==",
             "license": "MIT",
             "dependencies": {
                 "@primeuix/styled": "^0.7.2",
@@ -3684,6 +3711,20 @@
             },
             "peerDependencies": {
                 "vue": "^3.5.0"
+            }
+        },
+        "node_modules/@primevue/forms": {
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/@primevue/forms/-/forms-4.3.9.tgz",
+            "integrity": "sha512-j/GGxFwpfzP3kdxpfxezmsWohmFjoiNHTZlDxGwrNBGrXfb9GExghgoPPKc0K4OeAX5enufS+g8YGqcglABHAQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/forms": "^0.1.0",
+                "@primeuix/utils": "^0.6.1",
+                "@primevue/core": "4.3.9"
+            },
+            "engines": {
+                "node": ">=12.11.0"
             }
         },
         "node_modules/@primevue/icons": {
@@ -3699,10 +3740,26 @@
                 "node": ">=12.11.0"
             }
         },
+        "node_modules/@primevue/icons/node_modules/@primevue/core": {
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.7.tgz",
+            "integrity": "sha512-rYmEZTKs/C2Re+xFluY9R02+n4TcyJshooPPOG6zc23v/bmhrfcqCiS5gNiuXF/lYoOh4y8VTcHF6eZCZW724Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.7.2",
+                "@primeuix/utils": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.0.tgz",
-            "integrity": "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+            "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
             "cpu": [
                 "arm"
             ],
@@ -3714,9 +3771,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.0.tgz",
-            "integrity": "sha512-sa4LyseLLXr1onr97StkU1Nb7fWcg6niokTwEVNOO7awaKaoRObQ54+V/hrF/BP1noMEaaAW6Fg2d/CfLiq3Mg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+            "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
             "cpu": [
                 "arm64"
             ],
@@ -3728,9 +3785,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.0.tgz",
-            "integrity": "sha512-/NNIj9A7yLjKdmkx5dC2XQ9DmjIECpGpwHoGmA5E1AhU0fuICSqSWScPhN1yLCkEdkCwJIDu2xIeLPs60MNIVg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+            "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
             "cpu": [
                 "arm64"
             ],
@@ -3742,9 +3799,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.0.tgz",
-            "integrity": "sha512-xoh8abqgPrPYPr7pTYipqnUi1V3em56JzE/HgDgitTqZBZ3yKCWI+7KUkceM6tNweyUKYru1UMi7FC060RyKwA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+            "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
             "cpu": [
                 "x64"
             ],
@@ -3756,9 +3813,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.0.tgz",
-            "integrity": "sha512-PCkMh7fNahWSbA0OTUQ2OpYHpjZZr0hPr8lId8twD7a7SeWrvT3xJVyza+dQwXSSq4yEQTMoXgNOfMCsn8584g==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+            "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
             "cpu": [
                 "arm64"
             ],
@@ -3770,9 +3827,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.0.tgz",
-            "integrity": "sha512-1j3stGx+qbhXql4OCDZhnK7b01s6rBKNybfsX+TNrEe9JNq4DLi1yGiR1xW+nL+FNVvI4D02PUnl6gJ/2y6WJA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+            "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
             "cpu": [
                 "x64"
             ],
@@ -3784,9 +3841,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.0.tgz",
-            "integrity": "sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+            "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
             "cpu": [
                 "arm"
             ],
@@ -3798,9 +3855,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.0.tgz",
-            "integrity": "sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+            "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
             "cpu": [
                 "arm"
             ],
@@ -3812,9 +3869,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.0.tgz",
-            "integrity": "sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+            "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
             "cpu": [
                 "arm64"
             ],
@@ -3826,9 +3883,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.0.tgz",
-            "integrity": "sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+            "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3840,9 +3897,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.0.tgz",
-            "integrity": "sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+            "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
             "cpu": [
                 "loong64"
             ],
@@ -3854,9 +3911,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.0.tgz",
-            "integrity": "sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+            "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
             "cpu": [
                 "loong64"
             ],
@@ -3868,9 +3925,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.0.tgz",
-            "integrity": "sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+            "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
             "cpu": [
                 "ppc64"
             ],
@@ -3882,9 +3939,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.0.tgz",
-            "integrity": "sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+            "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
             "cpu": [
                 "ppc64"
             ],
@@ -3896,9 +3953,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.0.tgz",
-            "integrity": "sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+            "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
             "cpu": [
                 "riscv64"
             ],
@@ -3910,9 +3967,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.0.tgz",
-            "integrity": "sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+            "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
             "cpu": [
                 "riscv64"
             ],
@@ -3924,9 +3981,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.0.tgz",
-            "integrity": "sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+            "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
             "cpu": [
                 "s390x"
             ],
@@ -3938,9 +3995,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.0.tgz",
-            "integrity": "sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+            "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
             "cpu": [
                 "x64"
             ],
@@ -3952,9 +4009,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.0.tgz",
-            "integrity": "sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+            "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
             "cpu": [
                 "x64"
             ],
@@ -3966,9 +4023,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.0.tgz",
-            "integrity": "sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+            "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
             "cpu": [
                 "x64"
             ],
@@ -3980,9 +4037,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.0.tgz",
-            "integrity": "sha512-v5xwKDWcu7qhAEcsUubiav7r+48Uk/ENWdr82MBZZRIm7zThSxCIVDfb3ZeRRq9yqk+oIzMdDo6fCcA5DHfMyA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+            "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3994,9 +4051,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.0.tgz",
-            "integrity": "sha512-XnaaaSMGSI6Wk8F4KK3QP7GfuuhjGchElsVerCplUuxRIzdvZ7hRBpLR0omCmw+kI2RFJB80nenhOoGXlJ5TfQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+            "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4008,9 +4065,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.0.tgz",
-            "integrity": "sha512-3K1lP+3BXY4t4VihLw5MEg6IZD3ojSYzqzBG571W3kNQe4G4CcFpSUQVgurYgib5d+YaCjeFow8QivWp8vuSvA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+            "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
             "cpu": [
                 "ia32"
             ],
@@ -4022,9 +4079,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.0.tgz",
-            "integrity": "sha512-MDk610P/vJGc5L5ImE4k5s+GZT3en0KoK1MKPXCRgzmksAMk79j4h3k1IerxTNqwDLxsGxStEZVBqG0gIqZqoA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+            "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
             "cpu": [
                 "x64"
             ],
@@ -4036,9 +4093,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.0.tgz",
-            "integrity": "sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+            "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
             "cpu": [
                 "x64"
             ],
@@ -4050,11 +4107,14 @@
             ]
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+            "version": "0.27.9",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.9.tgz",
+            "integrity": "sha512-rmO/7eydTehgUT8AtCdMFIWfyMVsH/k/Evo7o/ZCqcz+a3CZTzkKC3+FZgT/EGUdl6si5M0qFrh9xn52ubqjFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "@typescript/native-preview": "^7.0.0-dev.20260203.1"
+            }
         },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
@@ -5999,9 +6059,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-            "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+            "version": "25.2.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
+            "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
@@ -6100,6 +6160,13 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@types/unist": {
             "version": "2.0.11",
@@ -6389,6 +6456,123 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/@typescript/native-preview": {
+            "version": "7.0.0-dev.20260203.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260203.1.tgz",
+            "integrity": "sha512-8XwI9TS/idoFXAM8fVjBS4QmRzBr/AE3dQiMdhgwW+49tcGJeiU6MOwTHYyp8MhlFFx/1kiNwwdPoUnp3cS5vQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsgo": "bin/tsgo.js"
+            },
+            "optionalDependencies": {
+                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260203.1",
+                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260203.1",
+                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260203.1",
+                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260203.1",
+                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260203.1",
+                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260203.1",
+                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260203.1"
+            }
+        },
+        "node_modules/@typescript/native-preview-darwin-arm64": {
+            "version": "7.0.0-dev.20260203.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260203.1.tgz",
+            "integrity": "sha512-0se1eibJ4rJ3JXD1WlNF3JL3GWjUeZ9fmDJyUkpP0974cFApblKhqsYubT+kDWrWExh4IXctzjRpkWfJi2srow==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@typescript/native-preview-darwin-x64": {
+            "version": "7.0.0-dev.20260203.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260203.1.tgz",
+            "integrity": "sha512-mMO5QBKSeVFWKvCu5+G9mbh5EmYqnCZb0g7s9HAUGAtOdjeGBVrvJTXLnahMbVB2KLU3ApUQCZQOoumZQ5z0Qw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@typescript/native-preview-linux-arm": {
+            "version": "7.0.0-dev.20260203.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260203.1.tgz",
+            "integrity": "sha512-74Q4nr9zOWlWqNJ726BrujFpeqNVuNo09GUaIHtV3TatVf6qGcQtWJLD4xdsZXt1n1YwneTiBHqfXwU7h6Z26g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@typescript/native-preview-linux-arm64": {
+            "version": "7.0.0-dev.20260203.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260203.1.tgz",
+            "integrity": "sha512-Vl3f5LKFAXrgb7TTag8sG7Np9imyt1QsiRN5O9yl/aoqZpopdmMSBTUFuOzQFLD9ive/0cTsRIKt32gWT4zvew==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@typescript/native-preview-linux-x64": {
+            "version": "7.0.0-dev.20260203.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260203.1.tgz",
+            "integrity": "sha512-HGNXkZ10rs88It98rfGhvCwG9RKLm2TVjfYOnKzYq0xKrfvG9exvpojio5n5OxXaSvTumTjRbWbRYY+qwpSCag==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@typescript/native-preview-win32-arm64": {
+            "version": "7.0.0-dev.20260203.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260203.1.tgz",
+            "integrity": "sha512-GkuRbW13iq2lRijkHnTWzrM/LThrr6KG0IXewdXd//E0DXcVvlg7ommgxPC29cf18X6T3vul1owjNmjVwp8siA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@typescript/native-preview-win32-x64": {
+            "version": "7.0.0-dev.20260203.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260203.1.tgz",
+            "integrity": "sha512-O+OsC8DOEnoKWWlWrPOnULh0kSvQ8DiWWfFMVIDmoWfCIi2cDLZKKE1WfCXSLi6L76H9f1zXJEvNqW58tEG/vQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@uppy/aws-s3": {
             "version": "3.6.2",
@@ -6867,6 +7051,12 @@
                 "de-indent": "^1.0.2",
                 "he": "^1.2.0"
             }
+        },
+        "node_modules/@vue/devtools-api": {
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+            "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+            "license": "MIT"
         },
         "node_modules/@vue/language-core": {
             "version": "2.2.12",
@@ -7406,8 +7596,8 @@
             }
         },
         "node_modules/arches": {
-            "version": "7.6.17",
-            "resolved": "git+ssh://git@github.com/archesproject/arches.git#d89ebe75da7cb95709f808838ec79a1d9513bf5b",
+            "version": "8.1.0",
+            "resolved": "git+ssh://git@github.com/archesproject/arches.git#2f87c96be90c3b455c61f2039d5250728fc18289",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
@@ -7446,7 +7636,7 @@
                 "jquery-migrate": "~3.4.1",
                 "jquery-validation": "1.19.5",
                 "jqueryui": "1.11.1",
-                "js-cookie": "2.1.1",
+                "js-cookie": "3.0.5",
                 "knockout": "3.5.0",
                 "knockout-mapping": "~2.6.0",
                 "knockstrap": "1.3.2",
@@ -7465,22 +7655,39 @@
                 "primeicons": "^7.0.0",
                 "primevue": "4.3.7",
                 "proj4": "^2.3.15",
-                "regenerator-runtime": "^0.14.1",
-                "requirejs": "~2.3.2",
-                "requirejs-plugins": "1.0.2",
-                "requirejs-text": "~2.0.16",
                 "select-woo": "jadu/selectWoo",
                 "shpjs": "~6.1.0",
                 "underscore": "^1.13.6",
                 "uuidjs": "^3.3.0",
-                "vue": "^3.5.8",
+                "vue": "^3.5.20",
                 "vue3-gettext": "^3.0.0-beta.6",
                 "webpack-bundle-tracker": "^3.1.0"
             }
         },
+        "node_modules/arches_controlled_lists": {
+            "resolved": "git+ssh://git@github.com/archesproject/arches-controlled-lists.git#e40f36de589e7df27be05cd144d1122186ec4231",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "arches": "archesproject/arches#dev/8.1.x",
+                "arches-component-lab": "archesproject/arches-component-lab#main",
+                "vue-router": "4.4.3"
+            }
+        },
+        "node_modules/arches-component-lab": {
+            "name": "arches_component_lab",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-component-lab.git#5ead6f8839cf5596bb1e6084c599e494728fef4b",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "@primevue/forms": "4.3.9",
+                "arches": "archesproject/arches#dev/8.0.x",
+                "dayjs": "^1.11.13",
+                "dompurify": "^3.2.6",
+                "quill": "2.0.3"
+            }
+        },
         "node_modules/arches-dev-dependencies": {
-            "version": "7.6.17",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#0e0bc561f3c4949a655b56efe35dda57cc7cadcd",
+            "version": "8.1.0",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#4fbb5dd30c2736691f8f0966acd89d7984b0105a",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.24.4",
@@ -7525,7 +7732,6 @@
                 "typescript-eslint": "^8.0.0-alpha.11",
                 "vitest": "^1.5.0",
                 "vue-loader": "^17.4.2",
-                "vue-template-compiler": "^2.7.16",
                 "vue-tsc": "^2.1.6",
                 "webpack": "^5.91.0",
                 "webpack-cli": "^5.1.4",
@@ -8189,9 +8395,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001766",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-            "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+            "version": "1.0.30001767",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
+            "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
             "dev": true,
             "funding": [
                 {
@@ -9591,6 +9797,12 @@
                 "jquery": "1.8 - 4"
             }
         },
+        "node_modules/dayjs": {
+            "version": "1.11.19",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+            "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+            "license": "MIT"
+        },
         "node_modules/de-indent": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -9723,9 +9935,9 @@
             "license": "MIT"
         },
         "node_modules/default-browser": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-            "integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9842,7 +10054,7 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -10073,6 +10285,15 @@
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
         },
+        "node_modules/dompurify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+            "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
+        },
         "node_modules/domutils": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -10197,9 +10418,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.282",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.282.tgz",
-            "integrity": "sha512-FCPkJtpst28UmFzd903iU7PdeVTfY0KAeJy+Lk0GLZRwgwYHn/irRcaCbQQOmr5Vytc/7rcavsYLvTM8RiHYhQ==",
+            "version": "1.5.286",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+            "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
             "dev": true,
             "license": "ISC"
         },
@@ -10239,14 +10460,14 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.4",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-            "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+            "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.0"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -11006,6 +11227,12 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "license": "MIT"
         },
+        "node_modules/fast-diff": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+            "license": "Apache-2.0"
+        },
         "node_modules/fast-glob": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -11610,7 +11837,7 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -11660,6 +11887,7 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
@@ -12021,9 +12249,9 @@
             }
         },
         "node_modules/hookified": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.0.tgz",
-            "integrity": "sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+            "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
             "dev": true,
             "license": "MIT"
         },
@@ -13499,21 +13727,14 @@
                 "node": ">=14"
             }
         },
-        "node_modules/js-beautify/node_modules/js-cookie": {
+        "node_modules/js-cookie": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
             "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
-        },
-        "node_modules/js-cookie": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.1.1.tgz",
-            "integrity": "sha512-BYjLHmXr/YFnH1x+wmK5qSSsag7bKRF7JDp6BRBsSjIXOnZoI6Y+JrmlCqN99/9MQq/Dim/cc949wwkEJCuPnQ==",
-            "license": "MIT"
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -13858,10 +14079,22 @@
             "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "license": "MIT"
         },
+        "node_modules/lodash-es": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "license": "MIT"
+        },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
             "license": "MIT"
         },
         "node_modules/lodash.debounce": {
@@ -15108,6 +15341,12 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/parchment": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+            "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15799,9 +16038,9 @@
             "license": "ISC"
         },
         "node_modules/preact": {
-            "version": "10.28.2",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
-            "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
+            "version": "10.28.3",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
+            "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -15892,6 +16131,22 @@
             },
             "engines": {
                 "node": ">=12.11.0"
+            }
+        },
+        "node_modules/primevue/node_modules/@primevue/core": {
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.7.tgz",
+            "integrity": "sha512-rYmEZTKs/C2Re+xFluY9R02+n4TcyJshooPPOG6zc23v/bmhrfcqCiS5gNiuXF/lYoOh4y8VTcHF6eZCZW724Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.7.2",
+                "@primeuix/utils": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
             }
         },
         "node_modules/process-nextick-args": {
@@ -16083,6 +16338,41 @@
             "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
             "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
             "license": "ISC"
+        },
+        "node_modules/quill": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+            "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "eventemitter3": "^5.0.1",
+                "lodash-es": "^4.17.21",
+                "parchment": "^3.0.0",
+                "quill-delta": "^5.1.0"
+            },
+            "engines": {
+                "npm": ">=8.2.3"
+            }
+        },
+        "node_modules/quill-delta": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+            "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-diff": "^1.3.0",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.isequal": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/quill/node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -16427,12 +16717,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "license": "MIT"
-        },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -16556,31 +16840,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/requirejs": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
-            "integrity": "sha512-7/cTSLOdYkNBNJcDMWf+luFvMriVm7eYxp4BcFCsAX0wF421Vyce5SXP17c+Jd5otXKGNehIonFlyQXSowL6Mw==",
-            "license": "MIT",
-            "bin": {
-                "r_js": "bin/r.js",
-                "r.js": "bin/r.js"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/requirejs-plugins": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/requirejs-plugins/-/requirejs-plugins-1.0.2.tgz",
-            "integrity": "sha512-bX1vGnjDd1iIod3hst47oM/Nv9JiYw4qodWNKgyeQw5ahzSvPI3j1K6hMcK0HtiGRKxebCf+QUrtWzbrZtzQog==",
-            "license": "ISC"
-        },
-        "node_modules/requirejs-text": {
-            "version": "2.0.16",
-            "resolved": "https://registry.npmjs.org/requirejs-text/-/requirejs-text-2.0.16.tgz",
-            "integrity": "sha512-XrzjeTb1pwzIWmkz8qnUiM20gENgiwB+66IciNuziwlaPAJsYQsQPSYyQ1kD4tGKGZxTisIfDbOHk02DpI/76Q==",
-            "license": "MIT"
         },
         "node_modules/requires-port": {
             "version": "1.0.0",
@@ -16717,7 +16976,7 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -16755,9 +17014,9 @@
             "license": "Unlicense"
         },
         "node_modules/rollup": {
-            "version": "4.57.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
-            "integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+            "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16771,31 +17030,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.57.0",
-                "@rollup/rollup-android-arm64": "4.57.0",
-                "@rollup/rollup-darwin-arm64": "4.57.0",
-                "@rollup/rollup-darwin-x64": "4.57.0",
-                "@rollup/rollup-freebsd-arm64": "4.57.0",
-                "@rollup/rollup-freebsd-x64": "4.57.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.57.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.57.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.57.0",
-                "@rollup/rollup-linux-arm64-musl": "4.57.0",
-                "@rollup/rollup-linux-loong64-gnu": "4.57.0",
-                "@rollup/rollup-linux-loong64-musl": "4.57.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.57.0",
-                "@rollup/rollup-linux-ppc64-musl": "4.57.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.57.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.57.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.57.0",
-                "@rollup/rollup-linux-x64-gnu": "4.57.0",
-                "@rollup/rollup-linux-x64-musl": "4.57.0",
-                "@rollup/rollup-openbsd-x64": "4.57.0",
-                "@rollup/rollup-openharmony-arm64": "4.57.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.57.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.57.0",
-                "@rollup/rollup-win32-x64-gnu": "4.57.0",
-                "@rollup/rollup-win32-x64-msvc": "4.57.0",
+                "@rollup/rollup-android-arm-eabi": "4.57.1",
+                "@rollup/rollup-android-arm64": "4.57.1",
+                "@rollup/rollup-darwin-arm64": "4.57.1",
+                "@rollup/rollup-darwin-x64": "4.57.1",
+                "@rollup/rollup-freebsd-arm64": "4.57.1",
+                "@rollup/rollup-freebsd-x64": "4.57.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+                "@rollup/rollup-linux-arm64-musl": "4.57.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+                "@rollup/rollup-linux-loong64-musl": "4.57.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+                "@rollup/rollup-linux-x64-gnu": "4.57.1",
+                "@rollup/rollup-linux-x64-musl": "4.57.1",
+                "@rollup/rollup-openbsd-x64": "4.57.1",
+                "@rollup/rollup-openharmony-arm64": "4.57.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+                "@rollup/rollup-win32-x64-gnu": "4.57.1",
+                "@rollup/rollup-win32-x64-msvc": "4.57.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -18581,7 +18840,7 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -20897,15 +21156,19 @@
                 }
             }
         },
-        "node_modules/vue-template-compiler": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-            "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
-            "dev": true,
+        "node_modules/vue-router": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.4.3.tgz",
+            "integrity": "sha512-sv6wmNKx2j3aqJQDMxLFzs/u/mjA9Z5LCgy6BE0f7yFWMjrPLnS/sPNn8ARY/FXw6byV18EFutn5lTO6+UsV5A==",
             "license": "MIT",
             "dependencies": {
-                "de-indent": "^1.0.2",
-                "he": "^1.2.0"
+                "@vue/devtools-api": "^6.6.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "vue": "^3.2.0"
             }
         },
         "node_modules/vue-tsc": {
@@ -21087,9 +21350,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.104.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-            "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+            "version": "5.105.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+            "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -21103,7 +21366,7 @@
                 "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.4",
+                "enhanced-resolve": "^5.19.0",
                 "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -21116,7 +21379,7 @@
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
                 "terser-webpack-plugin": "^5.3.16",
-                "watchpack": "^2.4.4",
+                "watchpack": "^2.5.1",
                 "webpack-sources": "^3.3.3"
             },
             "bin": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@uppy/drag-drop": "3.1.0",
         "@uppy/progress-bar": "3.1.1",
         "arches": "archesproject/arches#dev/8.1.x",
+        "arches_controlled_lists": "archesproject/arches-controlled-lists#dev/1.1.x",
         "dom-to-image": "^2.6.0",
         "eslint": "^9.39.2",
         "html2canvas": "^1.4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "django-storages==1.13.2",
   "boto3==1.42.38",
   "arches-templating>=0.1.2",
+  "arches_controlled_lists @ git+https://github.com/archesproject/arches-controlled-lists@dev/1.1.x",
 ]
 version = "3.0.0a0"
 


### PR DESCRIPTION
**The following nodes does not have  the rdmCollection configured**
So, generic "00000000-0000-0000-0000-000000000005"  is assigned if the collection is missing except for `digital_reference_type` which '933cf221-2d71-478f-998a-a5e088457971' was assigned 

- "instrument" - production_type
- "collection_or_set" - digital_reference_type
- "period" - type_n4 , digital_reference_type
- "physical_thing" - material_data_assignment_statement_type_metatype, material_data_assignment_classification, removal_from_object_type
- "person" - birth_type, digital_reference_type, identifier_attribute_assignment__classification, death_type
- "textual_work" - publication_type
- "group" - digital_reference_type, dissolution_type
- "provenance_activity" - type_n11

**The default value were not migrated because the values are not available in the system or the the specific controlled list that the nodes are configured with.**
- "activity" - timespan_name_type, statement_name_type, timespan_duration_name_type
- "observation" - timespan_name_type, timespan_statement_name_type, timespan_duration_name_type, statement_name_type
- "visual_work" - type_n9, type_n1, statement_name_type
- "place" - type_n2
- "sampling_activity" - timespan_duration_name_type, timespan_name_type, statement_name_type
- "modification" - type_n1, type_n5, type_n10, type_n2
- "digital_resource" - creation_statement_name_type, creation_time_duration_name_type, service_name_type, service_statement_name_type, file_creation_procedure_dimension_name_type, file_creation_procedure_dimension_statement_name_type, file_statement_name_type, dimension_name_type, statement_name_type, creation_time_name_type
